### PR TITLE
Improve dump banks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 *.1bpp
 *.2bpp
 
+# bin
+DumpBanks
+
 # rgbasm extras
 *.sym
 *.map

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ clean: ;
 	@rm -f $(obj)
 	@rm -f game.{gbc,sym,map}
 
+DumpBanks: src/tools/DumpBanks.c
+	gcc -o DumpBanks src/tools/DumpBanks.c
+	chmod +x DumpBanks
+
 # Objects are assembled from source.
 # src/main.o is built from src/main.asm.
 obj = src/main.o

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,17 @@ DumpBanks: src/tools/DumpBanks.c
 	gcc -o DumpBanks src/tools/DumpBanks.c
 	chmod +x DumpBanks
 
+src/bank-bins:
+	mkdir -p src/bank-bins
+
+src/bank-bins/bank_00_0.bin: src/bank-bins DumpBanks
+	cd src/bank-bins && ../DumpBanks ../Zelda.gbc
+
 # Objects are assembled from source.
 # src/main.o is built from src/main.asm.
 obj = src/main.o
 
-.asm.o:
+.asm.o: src/bank-bins/bank_00_0.bin
 	rgbasm -i src/ -o $@ $<
 
 # Then we link them to create a playable image.

--- a/src/tools/DumpBanks.c
+++ b/src/tools/DumpBanks.c
@@ -17,28 +17,36 @@ WriteBankFile(char *FileName, uint8_t *Data) {
 
 int
 main(int argc, char **argv) {
-    if (argc > 2) {
-        FILE *f = fopen(argv[1], "rb");
-
-        if (f) {
-            uint8_t Header[0x150];
-            fread(Header, 1, 0x150, f);
-
-            if (memcmp(Header + 0x134, "ZELDA", 5) == 0) {
-                for (int32_t BankNum = 0; BankNum <= 0x3C; ++BankNum) {
-                    uint8_t BankData[BANK_SIZE];
-                    char FileName[512];
-
-                    fseek(f, BankNum * BANK_SIZE, SEEK_SET);
-                    fread(BankData, 1, BANK_SIZE, f);
-
-                    sprintf(FileName, "bank_%02X_%X.bin", BankNum, BankNum * BANK_SIZE);
-                    WriteBankFile(FileName, BankData);
-                }
-            }
-        }
+    if (argc != 2) {
+        printf("Usage: DumpBanks <filename.gbc>");
+        return 1;
     }
 
+    FILE *f = fopen(argv[1], "rb");
+
+    if (!f) {
+        printf("Error: file not found (%s)", argv[1]);
+        return 1;
+    }
+
+    uint8_t Header[0x150];
+    fread(Header, 1, 0x150, f);
+
+    if (memcmp(Header + 0x134, "ZELDA", 5) != 0) {
+        printf("Error: ROM header is not 'ZELDA'");
+        return 1;
+    }
+
+    for (int32_t BankNum = 0; BankNum <= 0x3C; ++BankNum) {
+        uint8_t BankData[BANK_SIZE];
+        char FileName[512];
+
+        fseek(f, BankNum * BANK_SIZE, SEEK_SET);
+        fread(BankData, 1, BANK_SIZE, f);
+
+        sprintf(FileName, "bank_%02X_%X.bin", BankNum, BankNum * BANK_SIZE);
+        WriteBankFile(FileName, BankData);
+    }
+    
     return 0;
 }
-


### PR DESCRIPTION
This PR:

* Adds error messages to `DumpBanks` (in case of invalid input),
* Adds a Makefile for compiling the `DumpBank` binary from `DumpBank.c`,
* Adds a dependency of the main build to the dumped banks (so they can be dumped automatically).

I didn't get the ROM to compile yet (I get a lot of `rgblink: Unknown symbol 'label_D942'` errors), but that's a start :)

What do you think of this?