### PR TITLE
Bank-related labelling

### DIFF
--- a/src/CopyData.asm
+++ b/src/CopyData.asm
@@ -1,8 +1,21 @@
+; Copy data from specified bank
+; Inputs:
+;   a  : source bank
+;   bc : number of bytes to copy
+;   de : destination address
+;   hl : source address
+CopyDataFromBank::
+    ld   [SelectRomBank_2100], a
+    call CopyData
+    ld   a, $01
+    ld   [SelectRomBank_2100], a
+    ret
+
 ; Copy data
 ; Inputs:
 ;   bc : number of bytes to copy
-;   de: destination address
-;   hl: source address
+;   de : destination address
+;   hl : source address
 CopyData::
     ld   a, [hli]
     ld   [de], a
@@ -12,4 +25,3 @@ CopyData::
     or   c
     jr   nz, CopyData
     ret
-

--- a/src/CopyData.asm
+++ b/src/CopyData.asm
@@ -1,4 +1,8 @@
-
+; Copy data
+; Inputs:
+;   bc : number of bytes to copy
+;   de: destination address
+;   hl: source address
 CopyData::
     ld   a, [hli]
     ld   [de], a

--- a/src/bank1.asm
+++ b/src/bank1.asm
@@ -5131,10 +5131,10 @@ label_61AA::
     ld   a, [hli]
     ld   h, [hl]
     ld   l, a
-    ld   de, $96D0
-    ld   bc, $0010
-    ld   a, $0F
-    call label_2908
+    ld   de, $96D0  ; destination
+    ld   bc, $0010  ; count
+    ld   a, $0F     ; bank
+    call CopyDataFromBank
     ld   a, [$C109]
     swap a
     and  $0F
@@ -5146,10 +5146,10 @@ label_61AA::
     ld   a, [hli]
     ld   h, [hl]
     ld   l, a
-    ld   de, $96C0
-    ld   bc, $0010
-    ld   a, $0F
-    call label_2908
+    ld   de, $96C0 ; destination
+    ld   bc, $0010 ; count
+    ld   a, $0F    ; bank
+    call CopyDataFromBank
     ld   a, $6C
     ld   [$9909], a
 

--- a/src/main.asm
+++ b/src/main.asm
@@ -636,7 +636,7 @@ WaitForNextFrame::
     call SwitchBank
     call label_7F80
     ld   a, $0C
-    call label_B0B
+    call AdjustBankNumberForGBC
     call SwitchBank
     xor  a
     ld   [hWaitingForNextFrame], a ; Waiting for next frame
@@ -799,7 +799,7 @@ label_43A::
     ld   [SelectRomBank_2100], a
     call label_292D
     ld   a, $0C
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
 
 label_45D::
@@ -1028,7 +1028,7 @@ label_5BC::
     cp   $02
     jp   z, label_826
     ld   a, $0D
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   a, [$FF92]
     ld   c, a
@@ -1091,7 +1091,7 @@ label_655::
 
 label_656::
     ld   a, $0F
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   a, [$FF92]
     ld   c, a
@@ -1179,7 +1179,7 @@ label_6CB::
     ld   a, [hl]
     and  a
     jr   z, label_6F7
-    call label_B0B
+    call AdjustBankNumberForGBC
 
 label_6F7::
     ld   [SelectRomBank_2100], a
@@ -1249,7 +1249,7 @@ label_73E::
     ld   a, [hl]
     and  a
     jr   z, label_764
-    call label_B0B
+    call AdjustBankNumberForGBC
 
 label_764::
     ld   [SelectRomBank_2100], a
@@ -1324,7 +1324,7 @@ label_7D3::
     ld   h, [hl]
     ld   l, a
     ld   a, $0C
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   bc, $0040
     call CopyData
@@ -1355,8 +1355,9 @@ SwitchBank::
     ld   [SelectRomBank_2100], a
     ret
 
-label_813::
-    call label_B0B
+; Switch to the bank defined in a, depending on GB or GBC mode
+SwitchAdjustedBank::
+    call AdjustBankNumberForGBC
 
 SwitchBank_duplicate::
     ld   [WR1_CurrentBank], a
@@ -1372,7 +1373,7 @@ ReloadSavedBank::
 
 label_826::
     ld   a, $12
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   a, [$FF92]
     cp   $08
@@ -1829,21 +1830,25 @@ label_B02::
     call label_4029
     ret
 
-label_B0B::
+; Toogle an extra byte to the bank number on GBC (on GB, does nothing)
+; Input:  a: the bank number to adjust
+; Output: a: the adjusted bank number
+AdjustBankNumberForGBC::
     push bc
     ld   b, a
-    ld   a, [$FFFE]
-    and  a
-    jr   z, label_B17
-    ld   a, b
-    or   $20
+    ld   a, [hIsGBC]
+    and  a           ; if !isGBC
+    jr   z, .notGBC  ;   handle standard GB
+    ld   a, b        ; else
+    or   $20         ;   set 6-th bit of `a` to 1
+    pop  bc          ;   restore registers
+    ret              ;   return a
+.notGBC
+    ld   a, b        ; return the original value of a
     pop  bc
     ret
 
-label_B17::
-    ld   a, b
-    pop  bc
-    ret
+label_0B1A::
     ld   a, [$FFD7]
     ld   [SelectRomBank_2100], a
     ld   a, $02
@@ -4274,7 +4279,7 @@ label_1ACC::
     and  a
     ret  nz
     ld   a, $10
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   hl, $6500
     ld   de, $9500
@@ -4320,7 +4325,7 @@ label_1B0D::
     cp   $04
     jr   c, label_1B45
     ld   a, $10
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   a, [$D006]
     ld   l, a
@@ -4452,7 +4457,7 @@ label_1BD2::
     ld   [SelectRomBank_2100], a
     call label_61AA
     ld   a, $0C
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     jp   label_1D2E
 
@@ -4590,7 +4595,7 @@ label_1CE8::
     call label_7830
     jp   label_1D2E
     ld   a, $0C
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
 
 label_1D12::
@@ -4608,7 +4613,7 @@ label_1D1E::
     ld   [SelectRomBank_2100], a
     call label_54F5
     ld   a, $0C
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
 
 label_1D2E::
@@ -4773,7 +4778,7 @@ label_1E01::
     ld   de, $89A0
     ld   bc, $0040
     ld   a, $0C
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     jp   label_1F3B
 
@@ -4784,7 +4789,7 @@ label_1E2B::
 
 label_1E33::
     ld   a, $11
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   a, [$D000]
     swap a
@@ -4808,13 +4813,13 @@ label_1E55::
     xor  a
     ld   [$FFA5], a
     ld   a, $0C
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ret
 
 label_1E69::
     ld   a, $13
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   a, [$D000]
     swap a
@@ -4835,7 +4840,7 @@ label_1E8D::
     ld   hl, $48E0
     ld   de, $88E0
     ld   a, $0C
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   bc, $0020
     jp   label_1F3B
@@ -4846,7 +4851,7 @@ label_1EA1::
 
 label_1EA7::
     ld   a, $0C
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   bc, $0020
     jp   label_1F3B
@@ -4861,7 +4866,7 @@ label_1EBC::
     ld   a, $0D
 
 label_1EC1::
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   de, $9140
     jp   label_1F38
@@ -4878,7 +4883,7 @@ data_1ED3::
 label_1ED7::
     push af
     ld   a, $0C
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     pop  af
     ld   hl, $FFA1
@@ -6792,7 +6797,7 @@ label_2A2C::
 
 label_2A37::
     ld   a, $13
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   hl, $6800
     ld   de, $9000
@@ -6812,21 +6817,21 @@ label_2A57::
 
 label_2A66::
     ld   a, $13
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   hl, $4000
     ld   de, $8000
     ld   bc, $1800
     call CopyData
     ld   a, $0C
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   hl, $57E0
     ld   de, $97F0
     ld   bc, $0010
     call CopyData
     ld   a, $12
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   hl, $7500
     ld   de, $8000
@@ -6837,21 +6842,21 @@ label_2A66::
     ld   bc, $0200
     jp   CopyData
     ld   a, $0C
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   hl, $5000
     ld   de, $9000
     ld   bc, $0800
     call CopyData
     ld   a, $12
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   hl, $6000
     ld   de, $8000
     ld   bc, $0800
     call CopyData
     ld   a, $0F
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   hl, $6000
     ld   de, $8800
@@ -6870,7 +6875,7 @@ label_2A66::
 
 label_2B01::
     ld   a, $13
-    call label_B0B
+    call AdjustBankNumberForGBC
 
 label_2B06::
     ld   [SelectRomBank_2100], a
@@ -6878,7 +6883,7 @@ label_2B06::
     ld   bc, $0800
     call CopyData
     ld   a, $13
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   hl, $5800
     ld   de, $8800
@@ -6890,7 +6895,7 @@ label_2B06::
     call label_2B92
     call label_8A4
     ld   a, $12
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   hl, $6600
     ld   de, $8000
@@ -6933,7 +6938,7 @@ label_2B90::
     ld   a, $13
 
 label_2B92::
-    call label_B0B
+    call AdjustBankNumberForGBC
 
 label_2B95::
     ld   [SelectRomBank_2100], a
@@ -6941,7 +6946,7 @@ label_2B95::
     ld   bc, $0800
     call CopyData
     ld   a, $13
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   hl, $7000
     ld   de, $8800
@@ -6963,13 +6968,13 @@ label_2BC1::
 
 label_2BCF::
     ld   a, $0C
-    call SwitchBank_with_B0B_call
+    call SwitchAdjustedBank
     ld   hl, data_bank_c_0000
     ld   de, $8000
     ld   bc, data_bank_c_0400-data_bank_c_0000
     call CopyData
     ld   a, $0C
-    call SwitchBank_with_B0B_call
+    call SwitchAdjustedBank
     ld   hl, data_bank_c_0800
     ld   de, $8800
     ld   bc, data_bank_c_1800-data_bank_c_0800
@@ -6984,13 +6989,13 @@ label_2BCF::
 
     call label_2BCF
     ld   a, $0F
-    call label_813
+    call SwitchAdjustedBank
     ld   hl, $4000
     ld   de, $8800
     ld   bc, $0400
     call CopyData
     ld   a, $0F
-    call label_813
+    call SwitchAdjustedBank
     ld   hl, $5000
     ld   de, $9000
     ld   bc, $0800
@@ -7021,14 +7026,14 @@ label_2C53::
     ld   h, [hl]
     ld   l, $00
     ld   a, $0D
-    call label_813
+    call SwitchAdjustedBank
 
 label_2C5D::
     ld   de, $9100
     ld   bc, $0100
     call CopyData
     ld   a, $0D
-    call label_813
+    call SwitchAdjustedBank
     ld   hl, $4000
     ld   de, $9200
     ld   bc, $0600
@@ -7052,7 +7057,7 @@ label_2C8A::
     ld   bc, $0200
     call CopyData
     ld   a, $0C
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   hl, $47C0
     ld   de, $DCC0
@@ -7067,7 +7072,7 @@ label_2C8A::
     ld   h, [hl]
     ld   l, $00
     ld   a, $12
-    call label_813
+    call SwitchAdjustedBank
     ld   a, [$FFF7]
     cp   $FF
     jr   nz, label_2CD1
@@ -7088,7 +7093,7 @@ label_2CD1::
     cp   $0A
     jr   c, label_2CF5
     ld   a, $0C
-    call label_813
+    call SwitchAdjustedBank
     ld   hl, $4C00
 
 label_2CF5::
@@ -7128,7 +7133,7 @@ label_2D21::
 label_2D2C::
     ret
     ld   a, $0C
-    call label_813
+    call SwitchAdjustedBank
     ld   hl, $5200
     ld   de, $9200
     ld   bc, $0600
@@ -7146,7 +7151,7 @@ label_2D50::
     ld   [$FFA7], a
     call label_1BD2
     ld   a, $0C
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   hl, $4800
     ld   de, $8800
@@ -7164,7 +7169,7 @@ label_2D50::
     ld   bc, $0080
     call CopyData
     ld   a, $10
-    call label_813
+    call SwitchAdjustedBank
     ld   hl, $5400
     ld   de, $8000
     ld   bc, $0600
@@ -7174,7 +7179,7 @@ label_2D50::
     ld   bc, $1000
     jp   CopyData
     ld   a, $0F
-    call label_813
+    call SwitchAdjustedBank
     ld   hl, $4900
     ld   de, $8800
     ld   bc, $0700
@@ -7208,7 +7213,7 @@ label_2DE0::
     ld   bc, $0100
     jp   CopyData
     ld   a, $0C
-    call label_813
+    call SwitchAdjustedBank
     ld   hl, $7800
     ld   de, $8F00
     ld   bc, $0800
@@ -7225,12 +7230,12 @@ label_2DE0::
 
 label_2E13::
     ld   a, $10
-    call label_813
+    call SwitchAdjustedBank
     ld   de, $9000
     ld   bc, $0800
     jp   CopyData
     ld   a, $13
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   hl, $7C00
     ld   de, $8C00
@@ -7241,7 +7246,7 @@ label_2E13::
     ld   bc, $0400
     jp   CopyData
     ld   a, $10
-    call SwitchBank_with_B0B_call
+    call SwitchAdjustedBank
     ld   hl, $6700
     ld   de, $8400
     ld   bc, $0400
@@ -7341,7 +7346,7 @@ label_2ED4::
     ld   a, [hl]
     and  a
     jr   z, label_2EF2
-    call label_B0B
+    call AdjustBankNumberForGBC
 
 label_2EF2::
     ld   [SelectRomBank_2100], a
@@ -7369,7 +7374,7 @@ label_2F12::
     and  a
     jp   z, label_2FAD
     ld   a, $0D
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   a, [$FFF9]
     and  a
@@ -7450,7 +7455,7 @@ label_2F87::
 
 label_2FAD::
     ld   a, $0F
-    call label_B0B
+    call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
     ld   a, [$FF94]
     cp   $0F

--- a/src/main.asm
+++ b/src/main.asm
@@ -532,7 +532,7 @@ label_2A0::
     push af
     cp   $60
     jr   c, label_2B7
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_2B4
     ld   a, $20
@@ -617,7 +617,7 @@ label_33B::
 
 label_343::
     call label_E34
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_353
     ld   a, $21
@@ -927,14 +927,13 @@ label_521::
     call label_1B0D
 
 label_52B::
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
-    jr   z, label_538
+    jr   z, .notGBC
     ld   a, $24
     ld   [SelectRomBank_2100], a
     call label_5C1A ; Change BG column palette. Triggered by an interrupt?
-
-label_538::
+.notGBC
     ld   de, $D601
     call label_2927 ; Load BD column tiles
     xor  a
@@ -946,7 +945,7 @@ label_538::
     ld   [SelectRomBank_2100], a
     call label_72BA
     call label_FFC0
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, WaitForVBlank
     ld   a, $21
@@ -977,7 +976,7 @@ label_577::
     and  a
     jr   nz, label_5AB
     call label_FFC0
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_598
     ld   a, $21
@@ -1132,7 +1131,7 @@ label_69D::
     ret
 
 label_69E::
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_6CB
     ld   a, [$FFF7]
@@ -1684,7 +1683,7 @@ label_A01::
 
 label_A13::
     ld   [SelectRomBank_2100], a
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_A01
     ld   a, b
@@ -1862,7 +1861,7 @@ label_0B1A::
 
 label_B2F::
     ld   [$FFD9], a
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     ret  z
     ld   a, [$DBA5]
@@ -1898,7 +1897,7 @@ label_B54::
     ret
     push hl
     ld   [SelectRomBank_2100], a
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_B80
     ld   de, data_0168
@@ -4620,7 +4619,7 @@ label_1D2E::
     ld   a, [$FF9D]
     inc  a
     ret  z
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_1D42
     ld   a, [$DBC7]
@@ -4658,7 +4657,7 @@ label_1D49::
     ld   a, [$C11D]
     or   d
     ld   [hl], a
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_1DA1
     ld   a, [$DBC7]
@@ -4707,7 +4706,7 @@ label_1DA1::
     ld   a, [$C11E]
     or   d
     ld   [hl], a
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_1DE7
     ld   a, [$DBC7]
@@ -5431,7 +5430,7 @@ label_2241::
     add  hl, bc
     ld   b, $00
     ld   c, [hl]
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_2262
     ld   a, [$DBA5]
@@ -5452,7 +5451,7 @@ label_2262::
     and  a
     jr   z, label_2286
     ld   hl, $4000
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_2299
     ld   hl, $43B0
@@ -5464,7 +5463,7 @@ label_2262::
 
 label_2286::
     ld   hl, $6749
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_2299
     ld   hl, $6B1D
@@ -5483,7 +5482,7 @@ label_2299::
     and  $02
     jr   z, label_22D3
     call label_2214
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_22D1
     push bc
@@ -5511,7 +5510,7 @@ label_22D1::
 
 label_22D3::
     call label_2224
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_22FE
     push bc
@@ -5695,7 +5694,7 @@ label_23EF::
     xor  a
     ld   e, a
     ld   d, a
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   nz, label_2444
 
@@ -6728,7 +6727,7 @@ label_29DC::
     ld   hl, $C000
 
 ZeroMemory::
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     push af
 
 .ZeroMemory_loop
@@ -6739,7 +6738,7 @@ ZeroMemory::
     or   c
     jr   nz, .ZeroMemory_loop
     pop  af
-    ld   [$FFFE], a
+    ld   [hIsGBC], a
     ret
 
 label_29ED::
@@ -6856,7 +6855,7 @@ label_2A66::
     ld   bc, $0800
     jp   CopyData
     ld   hl, $4000
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_2B01
     ld   hl, $6800
@@ -6895,7 +6894,7 @@ label_2B06::
     ld   bc, $0080
     call CopyData
     call label_8A4
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   nz, label_2B61
     ld   a, $10
@@ -6913,14 +6912,14 @@ label_2B61::
     ld   bc, $0800
     jp   CopyData
     ld   hl, $7800
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_2B90
     ld   hl, $7800
     ld   a, $35
     jr   label_2B95
     ld   hl, $4800
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_2B90
     ld   hl, $7000
@@ -7179,7 +7178,7 @@ label_2D50::
     call CopyData
     ld   a, $38
     call SwitchBank
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   nz, label_2DC7
     ld   hl, $5C00
@@ -7192,7 +7191,7 @@ label_2DCA::
     ld   de, $8400
     ld   bc, $0400
     call CopyData
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   nz, label_2DDD
     ld   hl, $6600
@@ -7428,7 +7427,7 @@ label_2F69::
     ret
 
 label_2F87::
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     ret  z
     ld   a, [$FFF7]
@@ -7614,7 +7613,7 @@ label_30A9::
     push de
     push hl
     push bc
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   nz, label_30B6
     call label_2FCD
@@ -7674,7 +7673,7 @@ label_30F4::
     ld   a, $20
     ld   [SelectRomBank_2100], a
     call label_4CA3
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_3119
     ld   a, $21
@@ -8153,7 +8152,7 @@ label_33DC::
     ld   a, [$C3CD]
     add  a, $04
     ld   [$C3CD], a
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   nz, label_3406
     ld   a, $04
@@ -9369,7 +9368,7 @@ label_3C08::
     ld   hl, $FFED
     xor  [hl]
     ld   [de], a
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_3C21
     ld   a, [$FFED]
@@ -9417,7 +9416,7 @@ label_3C4B::
     ld   hl, $FFED
     xor  [hl]
     ld   [de], a
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_3C63
     ld   a, [$FFED]
@@ -9483,7 +9482,7 @@ label_3C9C::
     ld   a, [hli]
     ld   [de], a
     inc  de
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_3CD0
     ld   a, [$DB95]
@@ -9577,7 +9576,7 @@ label_3D28::
     xor  [hl]
     ld   [de], a
     inc  hl
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_3D3F
     ld   a, [$FFED]
@@ -9997,7 +9996,7 @@ label_3FBD::
     ld   [SelectRomBank_2100], a
     jp   label_1D2E
     ld   b, $34
-    ld   a, [$FFFE]
+    ld   a, [hIsGBC]
     and  a
     jr   z, label_3FD9
     inc  b

--- a/src/main.asm
+++ b/src/main.asm
@@ -1358,7 +1358,7 @@ SwitchBank::
 label_813::
     call label_B0B
 
-label_816::
+SwitchBank_duplicate::
     ld   [WR1_CurrentBank], a
     ld   [SelectRomBank_2100], a
     ret
@@ -3458,7 +3458,7 @@ label_158F::
     ld   [label_1608], sp
     ld   d, $08
     ld   a, [$FAFA]
-    ld   [label_816], sp
+    ld   [SwitchBank_duplicate], sp
     ld   [label_16FA], sp
     ld   [label_1616], sp
     ld   d, $08

--- a/src/main.asm
+++ b/src/main.asm
@@ -1363,8 +1363,7 @@ SwitchBank_duplicate::
     ld   [SelectRomBank_2100], a
     ret
 
-; Probably something like `ReloadCurrentBank`
-label_81D::
+ReloadSavedBank::
     push af
     ld   a, [WR1_CurrentBank]
     ld   [SelectRomBank_2100], a
@@ -1981,7 +1980,7 @@ label_BE7::
     ld   a, $02
     ld   [SelectRomBank_2100], a
     call label_1A50
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_BFB::
     ld   hl, $C450
@@ -2374,7 +2373,7 @@ label_E29::
     jr   nz, label_E03
 
 label_E31::
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_E34::
     ld   a, [$DB95]
@@ -2559,7 +2558,7 @@ label_F48::
     ld   a, $01
     ld   [SelectRomBank_2100], a
     call label_61EE
-    call label_81D
+    call ReloadSavedBank
 
 label_F75::
     ld   a, [$C19F]
@@ -5267,7 +5266,7 @@ label_2153::
     ld   a, $14
     ld   [SelectRomBank_2100], a
     call label_50C3
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_2161::
     ld   a, $01
@@ -5290,7 +5289,7 @@ label_2178::
     ld   a, $14
     ld   [SelectRomBank_2100], a
     call label_5526
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_2183::
     ld   a, $05
@@ -5934,7 +5933,7 @@ label_2529::
     ld   e, a
     ld   a, [hl]
     ld   [$C3C3], a
-    call label_81D
+    call ReloadSavedBank
     ld   a, e
     ld   [$FFD7], a
     cp   $FE
@@ -6040,7 +6039,7 @@ label_2608::
     rl   d
     sla  e
     rl   d
-    call label_81D
+    call ReloadSavedBank
     ld   hl, $5000
     add  hl, de
     ld   c, l
@@ -6330,7 +6329,7 @@ label_27DD::
     push bc
     call label_4146
     pop  bc
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_27EA::
     ld   a, $38
@@ -6348,13 +6347,13 @@ label_27F2::
     call label_4003
 
 label_27FF::
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_2802::
     ld   a, $01
     ld   [SelectRomBank_2100], a
     call label_5E67
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_280D::
     push hl
@@ -6749,7 +6748,7 @@ label_29ED::
     ld   a, $14
     ld   [SelectRomBank_2100], a
     call label_5884
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_29F8::
     ld   a, $20
@@ -6763,7 +6762,7 @@ label_2A07::
     ld   a, $01
     ld   [SelectRomBank_2100], a
     call label_5A59
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_2A12::
     ld   a, $08
@@ -6781,7 +6780,7 @@ label_2A23::
 
 label_2A26::
     call label_2A12
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_2A2C::
     call label_2A12
@@ -6958,19 +6957,19 @@ label_2BC1::
     ld   a, $14
     ld   [SelectRomBank_2100], a
     call label_5838
-    call label_81D
+    call ReloadSavedBank
     pop  bc
     ret
 
 label_2BCF::
     ld   a, $0C
-    call label_813
+    call SwitchBank_with_B0B_call
     ld   hl, data_bank_c_0000
     ld   de, $8000
     ld   bc, data_bank_c_0400-data_bank_c_0000
     call CopyData
     ld   a, $0C
-    call label_813
+    call SwitchBank_with_B0B_call
     ld   hl, data_bank_c_0800
     ld   de, $8800
     ld   bc, data_bank_c_1800-data_bank_c_0800
@@ -7048,7 +7047,7 @@ label_2C8A::
     add  hl, de
     ld   h, [hl]
     ld   l, $00
-    call label_81D
+    call ReloadSavedBank
     ld   de, $9200
     ld   bc, $0200
     call CopyData
@@ -7242,7 +7241,7 @@ label_2E13::
     ld   bc, $0400
     jp   CopyData
     ld   a, $10
-    call label_813
+    call SwitchBank_with_B0B_call
     ld   hl, $6700
     ld   de, $8400
     ld   bc, $0400
@@ -7928,7 +7927,7 @@ endOfRoom::
     ld   a, $21
     ld   [SelectRomBank_2100], a
     call label_53F3 ; stuff that returns early when DBA5 is 0
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_32A9::
     xor  a
@@ -8828,7 +8827,7 @@ label_386D::
     jr   label_386D
 
 label_3877::
-    call label_81D
+    call ReloadSavedBank
     ret
 
 data_387B::
@@ -8967,13 +8966,13 @@ label_3942::
     ld   a, $03
     ld   [SelectRomBank_2100], a
     call label_53E4
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_394D::
     ld   a, $14
     ld   [SelectRomBank_2100], a
     call label_54AC
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3958::
     ld   a, $01
@@ -8986,13 +8985,13 @@ label_3965::
     ld   a, $03
     ld   [SelectRomBank_2100], a
     call label_485B
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3970::
     ld   a, $03
     ld   [SelectRomBank_2100], a
     call label_7EFE
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_397B::
     ld   a, $14
@@ -9226,61 +9225,61 @@ label_3B18::
     ld   a, $02
     ld   [SelectRomBank_2100], a
     call label_75F5
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3B23::
     ld   a, $03
     ld   [SelectRomBank_2100], a
     call label_7893
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3B2E::
     ld   a, $03
     ld   [SelectRomBank_2100], a
     call label_7CAB
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3B39::
     ld   a, $03
     ld   [SelectRomBank_2100], a
     call label_6E28
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3B44::
     ld   a, $03
     ld   [SelectRomBank_2100], a
     call label_6C6B
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3B4F::
     ld   a, $03
     ld   [SelectRomBank_2100], a
     call label_6BDE
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3B5A::
     ld   a, $03
     ld   [SelectRomBank_2100], a
     call label_6C77
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3B65::
     ld   a, $03
     ld   [SelectRomBank_2100], a
     call label_73EB
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3B70::
     ld   a, $03
     ld   [SelectRomBank_2100], a
     call label_6E2B
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3B7B::
     ld   a, $03
     ld   [SelectRomBank_2100], a
     call label_75A2
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3B86::
     push af
@@ -9289,7 +9288,7 @@ label_3B86::
     pop  af
     call label_64CA
     rr   l
-    call label_81D
+    call ReloadSavedBank
     rl   l
     ret
 
@@ -9300,7 +9299,7 @@ label_3B98::
     pop  af
     call label_64CC
     rr   l
-    call label_81D
+    call ReloadSavedBank
     rl   l
     ret
 
@@ -9308,13 +9307,13 @@ label_3BAA::
     ld   hl, SelectRomBank_2100
     ld   [hl], $03
     call label_7EC7
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3BB5::
     ld   hl, SelectRomBank_2100
     ld   [hl], $03
     call label_7E45
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3BC0::
     ld   a, [$FFF1]
@@ -9441,7 +9440,7 @@ label_3C63::
 
 label_3C71::
     call label_7995
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3C77::
     ld   a, [$FFF1]
@@ -9600,7 +9599,7 @@ label_3D3F::
     ld   a, $15
     ld   [SelectRomBank_2100], a
     call label_795D
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3D52::
     ld   a, [$C123]
@@ -9666,67 +9665,67 @@ label_3DA0::
     ld   hl, SelectRomBank_2100
     ld   [hl], $15
     call label_7964
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3DAB::
     ld   hl, SelectRomBank_2100
     ld   [hl], $04
     call label_5A1A
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3DB6::
     ld   hl, SelectRomBank_2100
     ld   [hl], $04
     call label_5690
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3DC1::
     ld   hl, SelectRomBank_2100
     ld   [hl], $04
     call label_504B
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3DCC::
     ld   hl, SelectRomBank_2100
     ld   [hl], $04
     call label_49BD
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3DD7::
     ld   hl, SelectRomBank_2100
     ld   [hl], $36
     call label_72AB
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3DE2::
     ld   hl, SelectRomBank_2100
     ld   [hl], $05
     call label_6CC6
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3DED::
     ld   hl, SelectRomBank_2100
     ld   [hl], $05
     call label_6818
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3DF8::
     ld   hl, SelectRomBank_2100
     ld   [hl], $05
     call label_6302
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3E03::
     ld   hl, SelectRomBank_2100
     ld   [hl], $05
     call label_5A1E
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3E0E::
     ld   hl, SelectRomBank_2100
     ld   [hl], $05
     call label_556B
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3E19::
     ld   a, [WR1_CurrentBank]
@@ -9741,20 +9740,20 @@ label_3E29::
     ld   hl, SelectRomBank_2100
     ld   [hl], $04
     call label_5C63
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3E34::
     ld   hl, SelectRomBank_2100
     ld   [hl], $03
     call label_5407
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3E3F::
     ld   hl, SelectRomBank_2100
     ld   [hl], $02
     call label_62CE
     call label_6414
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3E4D::
     ld   a, $02
@@ -9770,13 +9769,13 @@ label_3E5A::
     ld   b, $00
     ld   e, $FF
     call label_5C9C
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3E6B::
     ld   hl, SelectRomBank_2100
     ld   [hl], $03
     call label_6472
-    jp   label_81D
+    jp   ReloadSavedBank
 
 label_3E76::
     ld   a, $06
@@ -9931,7 +9930,7 @@ label_3F50::
     ld   [$C113], a
     ld   [SelectRomBank_2100], a
     call label_55CF
-    call label_81D
+    call ReloadSavedBank
     ld   hl, $C460
     add  hl, bc
     ld   a, [hl]

--- a/src/main.asm
+++ b/src/main.asm
@@ -6545,13 +6545,6 @@ ClearMap::
     jr   nz, .clearMap_loop
     ret
 
-label_2908::
-    ld   [SelectRomBank_2100], a
-    call CopyData
-    ld   a, $01
-    ld   [SelectRomBank_2100], a
-    ret
-
 include "CopyData.asm"
 
 label_291D::


### PR DESCRIPTION
This PR adds label for bank-switching functions:

* `SwitchBank`
* `ReloadSavedBank`
* `AdjustBankNumberForGBC`
* `CopyDataFromBank`

As all these functions are using conditionals for GBC, it also labels usages of the `hIsGBC` variable.