### PR TITLE
Add more banks to the ROM map

### DIFF
--- a/src/ROM map.md
+++ b/src/ROM map.md
@@ -14,27 +14,48 @@
 09 Data and text
 0A n/a
 0B n/a
-0C Graphics
-0D Graphics
+0C Graphics: items, Link, minimap
+0D Graphics: dungeons
 0E Graphics
-0F Graphics
-10 Graphics
-11 Graphics
-12 Graphics
-13 Graphics
-14 Code
-15 n/a
-16 stuff, then text from 1700
+0F Graphics: title screen, font, overworld (DMG variant)
+10 Graphics: intro, various pictures (DMG variant)
+11 Graphics: NPCs (DMG variant)
+12 Graphics: NPCs, dungeons (DMG variant)
+13 Graphics: ending (DMG variant)
+14 Code and text
+15 Code
+16 Code and text
 17 Code and credits text
 18 Code and data
-19 n/a
+19 Code
 1A n/a
 1B Music
 1C Map data?
 1D Text
 1E Music
 1F Music
-…
-2F Graphics
-30 Graphics
-…
+20 n/a
+21 Code and data
+22 Data
+23 Data
+24 Data
+25 Data
+26 n/a
+27 Data
+28 n/a
+29 Graphics: photo pictures
+2F Graphics: title screen, font, overworld (CGB variant)
+30 Graphics: intro, various pictures (CGB variant)
+31 Graphics: NPCs (CGB variant)
+32 Graphics: NPCs, dungeons (CGB variant)
+33 Graphics: ending (CGB variant)
+34 Graphics: printer UI
+35 Graphics: Color dungeon
+36 Code
+37 Code
+38 Graphics: large font, misc
+39 Graphics: photo elements
+3A Graphics: photo elements
+3B Graphics: photo elements, photo pictures
+3C Graphics
+3D n/a


### PR DESCRIPTION
Now all banks are more-or-less labeled. This should make it easier to find graphics in the banks.