### PR TITLE
Turn WRAM constants into labels

### DIFF
--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -57,7 +57,7 @@ Init::
     ld   a, $4F
     ld   [rLYC], a
     ld   a, $01
-    ld   [WR1_CurrentBank], a
+    ld   [wCurrentBank], a
     ld   a, $01
     ld   [rIE], a
     call label_46AA
@@ -83,7 +83,7 @@ RenderLoop::
     and  a
     jr   z, .applyRegularScrollYOffset
     ; and GameplayType == OVERWORLD...
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_OVERWORLD
     jr   nz, .applyRegularScrollYOffset
     ; set scroll Y to $00 or $80 alternatively every other frame.
@@ -94,7 +94,7 @@ RenderLoop::
 
 .applyRegularScrollYOffset
     ; Compose the base offset and the screen shake offset
-    ld   hl, WR0_ScreenShakeVertical
+    ld   hl, wScreenShakeVertical
     ld   a, [hBaseScrollY]
     add  a, [hl]
 
@@ -103,7 +103,7 @@ RenderLoop::
 
     ; Set ScrollX
     ld   a, [hBaseScrollX]
-    ld   hl, WR0_ScreenShakeHorizontal
+    ld   hl, wScreenShakeHorizontal
     add  a, [hl]
     ld   hl, $C1BF
     add  a, [hl]
@@ -119,7 +119,7 @@ RenderLoop::
 
 RenderLoopLoadNewMap::
     ; Control audio during the transition
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_MARIN_BEACH
     jr   z, .playAudioStep
     cp   GAMEPLAY_FILE_SAVE
@@ -127,7 +127,7 @@ RenderLoopLoadNewMap::
     cp   GAMEPLAY_OVERWORLD
     jr   nz, .skipAudio
     ; GameplayType == OVERWORLD
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
     cp   $07
     jr   nc, .skipAudio
 
@@ -145,7 +145,7 @@ RenderLoopLoadNewMap::
 
 RenderFrame::
     ; Update LCD status flags
-    ld   a, [WR1_LCDControl]
+    ld   a, [wLCDControl]
     and  $7F
     ld   e, a
     ld   a, [rLCDC]
@@ -158,11 +158,11 @@ RenderFrame::
     inc  [hl]
 
     ; Special case for the intro screen sprites
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_INTRO
     jr   nz, RenderWarpTransition
     ; GameplayType == INTRO
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
     cp   $08
     jr   c, RenderWarpTransition
     ; GameplaySubtype > GAMEPLAY_INTRO_BEACH
@@ -171,7 +171,7 @@ RenderFrame::
     call label_5257 ; position sprites for the title screen?
 
 RenderWarpTransition::
-    ld   a, [WR0_WarpTransition]
+    ld   a, [wWarpTransition]
     and  a
     jp   z, RenderInteractiveFrame
     inc  a
@@ -193,14 +193,14 @@ label_279::
     ld   [$C180], a
     cp   $C0
     jr   nz, label_2A0
-    ld   a, [WR0_WarpTransition]
+    ld   a, [wWarpTransition]
     cp   $02
     jr   nz, label_296
     call label_4E51
 
 label_296::
     xor  a
-    ld   [WR0_WarpTransition], a
+    ld   [wWarpTransition], a
     ld   [$C3CA], a
     jp   RenderInteractiveFrame
 
@@ -225,23 +225,23 @@ label_2B7::
     pop  af
     call label_5038
     call PlayAudioStep
-    ld   a, [WR1_BGPalette]
+    ld   a, [wBGPalette]
     ld   [rBGP], a
-    ld   a, [WR1_OBJ0Palette]
+    ld   a, [wOBJ0Palette]
     ld   [rOBP0], a
-    ld   a, [WR1_OBJ1Palette]
+    ld   a, [wOBJ1Palette]
     ld   [rOBP1], a
     jp   WaitForNextFrame
 
 RenderInteractiveFrame::
     ; Update graphics registers from game values
-    ld   a, [WR1_WindowY]
+    ld   a, [wWindowY]
     ld   [rWY], a
-    ld   a, [WR1_BGPalette]
+    ld   a, [wBGPalette]
     ld   [rBGP], a
-    ld   a, [WR1_OBJ0Palette]
+    ld   a, [wOBJ0Palette]
     ld   [rOBP0], a
-    ld   a, [WR1_OBJ1Palette]
+    ld   a, [wOBJ1Palette]
     ld   [rOBP1], a
 
     call PlayAudioStep
@@ -251,7 +251,7 @@ RenderInteractiveFrame::
     ld   a, [hNeedsUpdatingBGTiles]
     ld   hl, hNeedsUpdatingEnnemiesTiles
     or   [hl]
-    ld   hl, WR0_needsUpdatingNPCTiles
+    ld   hl, wneedsUpdatingNPCTiles
     or   [hl]
     ; skip further rendering: the vblank interrupt will load the required data
     jr   nz, WaitForNextFrame
@@ -261,7 +261,7 @@ RenderInteractiveFrame::
     and  a  ; Is debug mode disabled?
     jr   z, RenderUpdateSprites
 
-    ld   a, [WR1_EnginePaused]
+    ld   a, [wEnginePaused]
     and  a  ; Is engine already paused?
     jr   nz, .engineIsPaused
 
@@ -276,34 +276,34 @@ RenderInteractiveFrame::
 
     ; If Select button was just pressed,
     ; toogle engine paused status.
-    ld   a, [WR1_EnginePaused]
+    ld   a, [wEnginePaused]
     xor  $01
-    ld   [WR1_EnginePaused], a
+    ld   [wEnginePaused], a
 
     ; If the engine was just paused, skip the rest of the render loop
     jr   nz, WaitForNextFrame
 
     ; If the engine was just unpaused,
     ; toggle Free-movement mode.
-    ld   a, [WR0_FreeMovementMode]
+    ld   a, [wFreeMovementMode]
     xor  $10
-    ld   [WR0_FreeMovementMode], a
+    ld   [wFreeMovementMode], a
     jr   WaitForNextFrame
 
 .saveEngineStatus
     ; If the engine is paused, skip the rest of the render loop
-    ld   a, [WR1_EnginePaused]
+    ld   a, [wEnginePaused]
     and  a
     jr   nz, WaitForNextFrame
 
 RenderUpdateSprites::
     ; If not in Inventory, update sprites
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_INVENTORY
     jr   nz, .updateSprites
 
     ; If Inventory is actually visible, skip sprites update
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
     cp   GAMEPLAY_INVENTORY_DELAY1
     jr   c, RenderGameplay
 
@@ -382,11 +382,11 @@ InterruptLCDStatus::
     ld   c, a        ;
     xor  a           ; Load WRAM Bank 1 (as "0" fallbacks to loading bank 1)
     ld   [rSVBK], a  ;
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_CREDITS ; if GameplayType != GAMEPLAY_CREDITS
     jr   nz, skipScrollY
     ; GameplayType == CREDITS
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
     cp   $05 ; if GameplaySubtype != 5
     jr   nz, setStandardScrollY
     ; GameplaySubtype == 5
@@ -407,16 +407,16 @@ skipScrollY::
     ; GameplayType == INTRO
     ; Apply differential scrolling to each section:
     ; load and apply the scrollX offset for the current screen section being drawn
-    ld   a, [WR0_LCDSectionIndex]
+    ld   a, [wLCDSectionIndex]
     ld   e, a             ; hl = ScrollXOffsetForSection + LCDSectionIndex
     ld   d, $00           ;
-    ld   hl, WR0_ScrollXOffsetForSection
+    ld   hl, wScrollXOffsetForSection
     add  hl, de           ;
     ld   a, [hl]
     ld   hl, hBaseScrollX ; a = hBaseScrollX + [hl]
     add  a, [hl]
     ld   [rSCX], a        ; set scrollX
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
     cp   $06  ; if GameplaySubtype < 6 (intro sea)
     jr   c, setupNextInterruptForIntroSea
     ; If TransitionCounter >= 6 (intro beach)
@@ -428,7 +428,7 @@ setupNextInterruptForIntroBeach::
     ld   a, e          ; a = SectionIndex + 1
     inc  a             ;
     and  $03           ; a = a % 4
-    ld   [WR0_LCDSectionIndex], a ; save SectionIndex
+    ld   [wLCDSectionIndex], a ; save SectionIndex
     jr   restoreSavedWRAMBankAndReturn
 
 setupNextInterruptForIntroSea::
@@ -444,12 +444,12 @@ setupNextInterruptForIntroSea::
     xor  a             ; a = 0
 
 skipResetSectionIndex::
-    ld   [WR0_LCDSectionIndex], a ; save SectionIndex
+    ld   [wLCDSectionIndex], a ; save SectionIndex
     nop
     cp   $04           ; if SectionIndex != 4
     jr   nz, restoreSavedWRAMBankAndReturn ; skip
     ; If we are drawing the last section (4)
-    ld   a, [WR0_IntroBGYOffset] ; Apply the Y offset to compensate for sea vertical movement
+    ld   a, [wIntroBGYOffset] ; Apply the Y offset to compensate for sea vertical movement
     ld   [rSCY], a               ; (so that the horizon position stays constant).
     cpl                ; a = $FF - a + $61
     inc  a             ;
@@ -476,7 +476,7 @@ InterruptSerial::
     ld   a, $28
     ld   [SelectRomBank_2100], a
     call label_4601
-    ld   a, [WR1_CurrentBank]
+    ld   a, [wCurrentBank]
     ld   [SelectRomBank_2100], a
     pop  af
     reti
@@ -545,7 +545,7 @@ LoadMapData::
     xor  a
     ld   [$D6FF], a
     ld   [$D6FE], a
-    ld   a, [WR1_LCDControl]
+    ld   a, [wLCDControl]
     ld   [rLCDC], a
     ret
 
@@ -571,11 +571,11 @@ InterruptVBlank::
     ;
     ; Photo Album handling
     ;
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_PHOTO_ALBUM
     jr   nz, .continue
     ; GameplayType == PHOTO_ALBUM
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
     cp   $09
     jr   c, .continue
     cp   $12
@@ -589,7 +589,7 @@ InterruptVBlank::
     ;
     ; Dialog handling
     ;
-    ld   a, [WR0_DialogState]
+    ld   a, [wDialogState]
     and  $7F  ; If dialog is closed
     jr   z, vBlankContinue
     cp   DIALOG_OPENING_1  ; If DialogState == 1
@@ -599,7 +599,7 @@ InterruptVBlank::
     ; DialogState < 5
     ; Open dialog
     call label_23E4
-    ld   hl, WR0_DialogState
+    ld   hl, wDialogState
     inc  [hl]  ; Increment DialogState
     jp   WaitForVBlankAndReturn
 
@@ -613,12 +613,12 @@ InterruptVBlank::
 .renderDialogTextContinue
     cp   DIALOG_SCROLLING_2  ; if DialogState != Scrolling2
     jr   nz, vBlankContinue
-    ld   a, [WR0_DialogScrollDelay]
+    ld   a, [wDialogScrollDelay]
     and  a  ; if DialogScrollDelay == 0
     jr   z, .DialogFinishScrolling
     ; DialogScrollDelay > 0
     dec  a  ; decrement the delay
-    ld   [WR0_DialogScrollDelay], a
+    ld   [wDialogScrollDelay], a
     jr   vBlankContinue
 
 .DialogFinishScrolling
@@ -629,11 +629,11 @@ InterruptVBlank::
     ; Photo Picture handling
     ;
 vBlankContinue::
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_PHOTO_DIZZY_LINK  ; If GameplayType < Photo Picture
     jr   c, .continue3
     ; GameplayType is one of the Pictures
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
     cp   $06
     jr   c, label_52B
     ld   a, $38
@@ -649,7 +649,7 @@ vBlankContinue::
     ld   [$FFE8], a
     ld   hl, hNeedsUpdatingEnnemiesTiles
     or   [hl]
-    ld   hl, WR0_needsUpdatingNPCTiles
+    ld   hl, wneedsUpdatingNPCTiles
     or   [hl]
     jr   z, label_509
     call label_5BC ; Copy tiles?
@@ -680,7 +680,7 @@ label_509::
     jr   label_501
 
 label_521::
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_PHOTO_ALBUM
     jr   z, label_52B
     call AnimateTiles
@@ -710,7 +710,7 @@ label_52B::
     ld   a, $21
     ld   [SelectRomBank_2100], a
     call label_4000
-    ld   a, [WR1_CurrentBank]
+    ld   a, [wCurrentBank]
     ld   [SelectRomBank_2100], a
 
 WaitForVBlankAndReturn::
@@ -729,7 +729,7 @@ WaitForVBlankAndReturn_direct::
     reti
 
 PhotoAlbumVBlankHandler::
-    ld   a, [WR1_CurrentBank]
+    ld   a, [wCurrentBank]
     push af
     ld   a, [hDidRenderFrame]
     and  a
@@ -759,7 +759,7 @@ label_5AB::
     call SwitchBank
     call label_4616
     pop  af
-    ld   [WR1_CurrentBank], a
+    ld   [wCurrentBank], a
     ld   [SelectRomBank_2100], a
     jr   WaitForVBlankAndReturn_direct
 
@@ -901,7 +901,7 @@ label_69E::
     ld   [SelectRomBank_2100], a
     call label_475A
     xor  a
-    ld   [WR0_needsUpdatingNPCTiles], a
+    ld   [wneedsUpdatingNPCTiles], a
     ld   [$C10F], a
     ld   hl, $9000
     ld   bc, $0000
@@ -1047,7 +1047,7 @@ label_764::
     cp   $04
     jr   nz, label_7AF
     xor  a
-    ld   [WR0_needsUpdatingNPCTiles], a
+    ld   [wneedsUpdatingNPCTiles], a
     ld   [$C10F], a
 
 label_7AF::
@@ -1110,7 +1110,7 @@ label_808::
 
 ; Switch to the bank defined in a, and save the active bank
 SwitchBank::
-    ld   [WR1_CurrentBank], a
+    ld   [wCurrentBank], a
     ld   [SelectRomBank_2100], a
     ret
 
@@ -1119,13 +1119,13 @@ SwitchAdjustedBank::
     call AdjustBankNumberForGBC
 
 SwitchBank_duplicate::
-    ld   [WR1_CurrentBank], a
+    ld   [wCurrentBank], a
     ld   [SelectRomBank_2100], a
     ret
 
 ReloadSavedBank::
     push af
-    ld   a, [WR1_CurrentBank]
+    ld   a, [wCurrentBank]
     ld   [SelectRomBank_2100], a
     pop  af
     ret
@@ -1241,7 +1241,7 @@ label_8D7::
     call label_6A30
 
 restoreBankAndReturn::
-    ld   a, [WR1_CurrentBank]
+    ld   a, [wCurrentBank]
     ld   [SelectRomBank_2100], a
     ret
 
@@ -1675,7 +1675,7 @@ label_B80::
     push hl
     call label_B96
     pop  hl
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_PHOTO_ALBUM
     jr   nz, label_B90
     call label_BB5
@@ -1869,7 +1869,7 @@ label_C9E::
     ld   a, $03
     ld   [$C11C], a
     xor  a
-    ld   [WR0_TransitionSequenceCounter], a
+    ld   [wTransitionSequenceCounter], a
     ld   [$C16C], a
     ld   [$D478], a
     and  a
@@ -1877,7 +1877,7 @@ label_C9E::
 
 label_CAF::
     xor  a
-    ld   [WR0_IsUsingSpinAttack], a
+    ld   [wIsUsingSpinAttack], a
     ld   [$C122], a
 
 label_CB6::
@@ -2119,7 +2119,7 @@ label_E03::
     ld   a, d
     ld   [$C10D], a
     ld   a, $01
-    ld   [WR0_needsUpdatingNPCTiles], a
+    ld   [wneedsUpdatingNPCTiles], a
     jr   label_E29
 
 label_E1E::
@@ -2142,32 +2142,32 @@ label_E31::
     jp   ReloadSavedBank
 
 ExecuteGameplayHandler::
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_MINI_MAP ; If GameplayType < MINI_MAP
     jr   c, jumpToGameplayHandler
     cp   GAMEPLAY_OVERWORLD ; If GameplayType != Overworld
     jr   nz, presentSaveScreenIfNeeded
     ; If GameplayType == OVERWORLD
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
     cp   $07 ; If GameplaySubtype != 7 (standard overworld gameplay)
     jr   nz, jumpToGameplayHandler
 
 presentSaveScreenIfNeeded::
     ; If a indoor/outdoor transition is running
-    ld   a, [WR0_TransitionSequenceCounter]
+    ld   a, [wTransitionSequenceCounter]
     cp   $04
     jr   nz, jumpToGameplayHandler
 
     ; If a dialog is visible, or the screen is animating from one map to another
-    ld   a, [WR0_DialogState]
+    ld   a, [wDialogState]
     ld   hl, $C167
     or   [hl]
-    ld   hl, WR0_MapSlideTransitionState
+    ld   hl, wMapSlideTransitionState
     or   [hl]
     jr   nz, jumpToGameplayHandler
 
     ; If GameplayType > INVENTORY (i.e. photo album and pictures)
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_INVENTORY
     jr   nc, jumpToGameplayHandler
 
@@ -2188,15 +2188,15 @@ presentSaveScreenIfNeeded::
 
     ; Present save screen
     xor  a ; Clear variables
-    ld   [WR0_TransitionSequenceCounter], a
+    ld   [wTransitionSequenceCounter], a
     ld   [$C16C], a
-    ld   [WR0_DialogState], a
-    ld   [WR1_GameplaySubtype], a
+    ld   [wDialogState], a
+    ld   [wGameplaySubtype], a
     ld   a, GAMEPLAY_FILE_SAVE ; Set GameplayType to FILE_SAVE
-    ld   [WR1_GameplayType], a
+    ld   [wGameplayType], a
 
 jumpToGameplayHandler::
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     JP_TABLE
 ._00 dw IntroHandler
 ._01 dw EndCreditsHandler
@@ -2319,7 +2319,7 @@ PhotoPictureHandler::
 label_F48::
     ld   a, $02
     call SwitchBank
-    ld   a, [WR0_DialogState]
+    ld   a, [wDialogState]
     and  a
     jr   nz, label_F8F
     ; Dialog is closed
@@ -2327,10 +2327,10 @@ label_F48::
     ld   a, [hl]
     and  a
     jr   z, label_F75
-    ld   a, [WR1_WindowY]
+    ld   a, [wWindowY]
     cp   $80
     jr   nz, label_F75
-    ld   a, [WR0_InventoryAppearing]
+    ld   a, [wInventoryAppearing]
     and  a
     jr   nz, label_F75
     dec  [hl]
@@ -2341,7 +2341,7 @@ label_F48::
     call ReloadSavedBank
 
 label_F75::
-    ld   a, [WR0_DialogState]
+    ld   a, [wDialogState]
     and  a
     jr   nz, label_F8F
     ld   a, [$C1BC]
@@ -2451,7 +2451,7 @@ label_1033::
     ld   a, [$C1A9]
     and  a
     jr   z, label_107F
-    ld   a, [WR0_DialogState]
+    ld   a, [wDialogState]
     and  a
     jr   nz, label_106D
     ld   hl, $C1AA
@@ -2514,21 +2514,21 @@ label_107F::
     ld   a, [$C11C]
     cp   $02
     jr   nc, label_10DB
-    ld   a, [WR0_DialogState]
+    ld   a, [wDialogState]
     ld   hl, $C167
     or   [hl]
-    ld   hl, WR0_MapSlideTransitionState
+    ld   hl, wMapSlideTransitionState
     or   [hl]
     jr   nz, label_10DB
     ld   a, [$D464]
     and  a
     jr   nz, label_10DB
     xor  a
-    ld   [WR0_TransitionSequenceCounter], a
+    ld   [wTransitionSequenceCounter], a
     ld   [$C16C], a
-    ld   [WR1_GameplaySubtype], a
+    ld   [wGameplaySubtype], a
     ld   a, $07
-    ld   [WR1_GameplayType], a
+    ld   [wGameplayType], a
     ld   a, GAMEPLAY_FILE_SELECT
     ld   [SelectRomBank_2100], a
     call label_755B
@@ -2556,10 +2556,10 @@ label_10E7::
     ld   [$FFB6], a
 
 label_10EF::
-    ld   a, [WR0_DialogState]
+    ld   a, [wDialogState]
     and  a
     jp   nz, label_1794
-    ld   a, [WR0_MapSlideTransitionState]
+    ld   a, [wMapSlideTransitionState]
     and  a
     jp   nz, label_114F
     ld   a, [$C11C]
@@ -2568,7 +2568,7 @@ label_10EF::
     ld   a, [$DB5A]
     ld   hl, $C50A
     or   [hl]
-    ld   hl, WR0_InventoryAppearing
+    ld   hl, wInventoryAppearing
     or   [hl]
     jr   nz, label_1135
     ld   a, $07
@@ -2635,16 +2635,16 @@ label_114F::
     ld   a, [$C14A]
     and  a
     jr   z, label_11BC
-    ld   a, [WR1_BButtonSlot]
+    ld   a, [wBButtonSlot]
     cp   $01
     jr   z, label_11AA
-    ld   a, [WR1_AButtonSlot]
+    ld   a, [wAButtonSlot]
     cp   $01
     jr   z, label_11AA
-    ld   a, [WR1_BButtonSlot]
+    ld   a, [wBButtonSlot]
     cp   $04
     jr   z, label_11A5
-    ld   a, [WR1_AButtonSlot]
+    ld   a, [wAButtonSlot]
     cp   $04
     jr   nz, label_11BA
 
@@ -2666,8 +2666,8 @@ label_11BA::
 
 label_11BC::
     xor  a
-    ld   [WR0_IsUsingShield], a
-    ld   [WR0_HasMirrorShield], a
+    ld   [wIsUsingShield], a
+    ld   [wHasMirrorShield], a
 
 label_11C3::
     ld   a, [$C117]
@@ -2691,7 +2691,7 @@ label_11E2::
     jp   nz, label_12ED
 
 label_11E8::
-    ld   a, [WR1_AButtonSlot]
+    ld   a, [wAButtonSlot]
     cp   $08
     jr   nz, label_11FE
     ld   a, [hPressedButtonsMask]
@@ -2705,7 +2705,7 @@ label_11FA::
     ld   [$C14B], a
 
 label_11FE::
-    ld   a, [WR1_BButtonSlot]
+    ld   a, [wBButtonSlot]
     cp   $08
     jr   nz, label_1214
     ld   a, [hPressedButtonsMask]
@@ -2721,11 +2721,11 @@ label_1210::
     ld   [$C14B], a
 
 label_1214::
-    ld   a, [WR1_BButtonSlot]
+    ld   a, [wBButtonSlot]
     cp   $04
     jr   nz, label_1235
-    ld   a, [WR1_ShieldLevel]
-    ld   [WR0_HasMirrorShield], a
+    ld   a, [wShieldLevel]
+    ld   [wHasMirrorShield], a
     ld   a, [hPressedButtonsMask]
     and  $10
     jr   z, label_1235
@@ -2737,11 +2737,11 @@ label_1214::
     call label_1340
 
 label_1235::
-    ld   a, [WR1_AButtonSlot]
+    ld   a, [wAButtonSlot]
     cp   $04
     jr   nz, label_124B
-    ld   a, [WR1_ShieldLevel]
-    ld   [WR0_HasMirrorShield], a
+    ld   a, [wShieldLevel]
+    ld   [wHasMirrorShield], a
     ld   a, [hPressedButtonsMask]
     and  $20
     jr   z, label_124B
@@ -2754,7 +2754,7 @@ label_124B::
     ld   a, [$C1AD]
     cp   $02
     jr   z, label_125E
-    ld   a, [WR1_AButtonSlot]
+    ld   a, [wAButtonSlot]
     call ItemFunction
 
 label_125E::
@@ -2766,28 +2766,28 @@ label_125E::
     jr   z, label_1275
     cp   $02
     jr   z, label_1275
-    ld   a, [WR1_BButtonSlot]
+    ld   a, [wBButtonSlot]
     call ItemFunction
 
 label_1275::
     ld   a, [hPressedButtonsMask]
     and  $20
     jr   z, label_1281
-    ld   a, [WR1_AButtonSlot]
+    ld   a, [wAButtonSlot]
     call label_1321
 
 label_1281::
     ld   a, [hPressedButtonsMask]
     and  $10
     jr   z, label_128D
-    ld   a, [WR1_BButtonSlot]
+    ld   a, [wBButtonSlot]
     call label_1321
 
 label_128D::
     ld   a, $20
     ld   [SelectRomBank_2100], a
     call label_48CA
-    ld   a, [WR1_CurrentBank]
+    ld   a, [wCurrentBank]
     ld   [SelectRomBank_2100], a
     ret
 
@@ -2821,7 +2821,7 @@ ItemFunction::
     ld   a, [$C19B]
     or   [hl]
     jr   nz, label_12ED
-    ld   a, [WR0_ProjectileCount]
+    ld   a, [wProjectileCount]
     cp   $02
     jr   nc, label_12ED
     ld   a, $8E
@@ -2888,33 +2888,33 @@ label_1321::
 
 label_1340::
     ld   a, $01
-    ld   [WR0_IsUsingShield], a
-    ld   a, [WR1_ShieldLevel]
-    ld   [WR0_HasMirrorShield], a
+    ld   [wIsUsingShield], a
+    ld   a, [wShieldLevel]
+    ld   [wHasMirrorShield], a
     ld   a, $20
     ld   [SelectRomBank_2100], a
     call label_4B4A
-    ld   a, [WR1_CurrentBank]
+    ld   a, [wCurrentBank]
     ld   [SelectRomBank_2100], a
     ret
 
 PlaceBomb::
-    ld   a, [WR0_HasPlacedBomb]
+    ld   a, [wHasPlacedBomb]
     cp   $01
     ret  nc
-    ld   a, [WR1_BombCount]
+    ld   a, [wBombCount]
     and  a
     jp   z, label_C20
     sub  a, $01
     daa
-    ld   [WR1_BombCount], a
+    ld   [wBombCount], a
     ld   a, $02
     call label_142F
     ret  c
     ld   a, $20
     ld   [SelectRomBank_2100], a
     call label_4B81
-    ld   a, [WR1_CurrentBank]
+    ld   a, [wCurrentBank]
     ld   [SelectRomBank_2100], a
     ret
 
@@ -2922,7 +2922,7 @@ UsePowerBracelet::
     ret
 
 UseBoomerang::
-    ld   a, [WR0_ProjectileCount]
+    ld   a, [wProjectileCount]
     and  a
 
 label_1387::
@@ -2933,7 +2933,7 @@ label_1387::
     ld   a, $20
     ld   [SelectRomBank_2100], a
     call label_4BFF
-    ld   a, [WR1_CurrentBank]
+    ld   a, [wCurrentBank]
     ld   [SelectRomBank_2100], a
     ret
 
@@ -2956,20 +2956,20 @@ data_13B5::
     db   0, 0, $D0, $30, 0, 0, $C0, $40
 
 ShootArrow::
-    ld   a, [WR0_IsShootingArrow]
+    ld   a, [wIsShootingArrow]
     and  a
     ret  nz
-    ld   a, [WR0_ProjectileCount]
+    ld   a, [wProjectileCount]
     cp   $02
     jr   nc, label_142E
     ld   a, $10
-    ld   [WR0_IsShootingArrow], a
-    ld   a, [WR1_ArrowCount]
+    ld   [wIsShootingArrow], a
+    ld   a, [wArrowCount]
     and  a
     jp   z, label_C20
     sub  a, $01
     daa
-    ld   [WR1_ArrowCount], a
+    ld   [wArrowCount], a
     call label_157C
     ld   a, $00
     call label_142F
@@ -2982,7 +2982,7 @@ ShootArrow::
     ld   a, [$C1C1]
     ld   c, a
     ld   b, d
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
     add  hl, bc
     ld   [hl], b
     ld   hl, $C290
@@ -3111,7 +3111,7 @@ label_14A7::
     ld   a, $20
     ld   [SelectRomBank_2100], a
     call label_4C47
-    ld   a, [WR1_CurrentBank]
+    ld   a, [wCurrentBank]
     ld   [SelectRomBank_2100], a
     ret
 
@@ -3180,7 +3180,7 @@ data_1524::
 
 UseSword::
     ld   a, [$C16D]
-    ld   hl, WR0_IsUsingSpinAttack
+    ld   hl, wIsUsingSpinAttack
     or   [hl]
     ret  nz
     ld   a, $03
@@ -3209,7 +3209,7 @@ label_1535::
     call label_178E
 
 label_1562::
-    ld   a, [WR0_ProjectileCount]
+    ld   a, [wProjectileCount]
     and  a
     ret  nz
     ld   a, [$C5A9]
@@ -3265,7 +3265,7 @@ label_15AF::
     ret  z
 
 label_15C0::
-    ld   a, [WR0_IsUsingSpinAttack]
+    ld   a, [wIsUsingSpinAttack]
     and  a
     jr   z, label_15CD
     ld   a, [$C136]
@@ -3296,7 +3296,7 @@ label_15CF::
     ld   [$FFCD], a
     or   c
     ld   e, a
-    ld   hl, WR1_TileMap
+    ld   hl, wTileMap
     add  hl, de
     ld   a, h
     cp   $D7
@@ -3507,7 +3507,7 @@ label_1713::
     ret  nz
     ld   [$C14A], a
     xor  a
-    ld   [WR0_IsUsingSpinAttack], a
+    ld   [wIsUsingSpinAttack], a
     ld   [$C122], a
     ld   a, [$FF9E]
     ld   e, a
@@ -3611,8 +3611,8 @@ label_17DB::
     and  $7F
     cp   $0C
     jr   nz, label_1814
-    ld   hl, WR0_DialogState
-    ld   a, [WR0_MapSlideTransitionState]
+    ld   hl, wDialogState
+    ld   a, [wMapSlideTransitionState]
     or   [hl]
     jr   nz, label_1814
     call label_157C
@@ -3634,13 +3634,13 @@ label_1819::
     ld   a, $20
     ld   [SelectRomBank_2100], a
     call label_4AB3
-    ld   a, [WR1_CurrentBank]
+    ld   a, [wCurrentBank]
     ld   [SelectRomBank_2100], a
     ret
     ld   a, $20
     ld   [SelectRomBank_2100], a
     call label_49BA
-    ld   a, [WR1_CurrentBank]
+    ld   a, [wCurrentBank]
     ld   [SelectRomBank_2100], a
     ret
     call label_754F
@@ -3657,7 +3657,7 @@ label_1847::
     ld   [$C157], a
     inc  a
     ld   [$C1A8], a
-    ld   a, [WR0_TransitionSequenceCounter]
+    ld   a, [wTransitionSequenceCounter]
     cp   $04
     jp   nz, label_19D9
     xor  a
@@ -3667,7 +3667,7 @@ label_1847::
     ld   [$DDD6], a
     ld   [$DDD7], a
     ld   e, $10
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
 
 label_186C::
     ldi  [hl], a
@@ -3689,7 +3689,7 @@ label_186C::
     or   $40
     ld   [$DC0C], a
     ld   a, $01
-    ld   [WR1_DidStealItem], a
+    ld   [wDidStealItem], a
     xor  a
     ld   [hLinkAnimationState], a
 
@@ -3697,9 +3697,9 @@ label_1898::
     ld   a, [$FFF9]
     ld   [$FFE4], a
     ld   a, GAMEPLAY_OVERWORLD
-    ld   [WR1_GameplayType], a
+    ld   [wGameplayType], a
     xor  a
-    ld   [WR1_GameplaySubtype], a
+    ld   [wGameplaySubtype], a
     ld   [$C3CB], a
     ld   [$FFF9], a
     ld   hl, $D401
@@ -3919,14 +3919,14 @@ label_19DA::
     ld   a, $30
     ld   [$C180], a
     ld   a, $03
-    ld   [WR0_WarpTransition], a
+    ld   [wWarpTransition], a
     ld   a, $04
-    ld   [WR0_TransitionSequenceCounter], a
+    ld   [wTransitionSequenceCounter], a
     jr   label_1A06
 
 label_19FC::
     call label_1A39
-    ld   a, [WR0_TransitionSequenceCounter]
+    ld   a, [wTransitionSequenceCounter]
     cp   $04
     jr   nz, label_1A21
 
@@ -3938,11 +3938,11 @@ label_1A06::
 
 label_1A0F::
     ld   [$C11C], a
-    ld   a, [WR1_DidStealItem]
+    ld   a, [wDidStealItem]
     and  a
     jr   z, label_1A21
     xor  a
-    ld   [WR1_DidStealItem], a
+    ld   [wDidStealItem], a
     ld   a, $36
     jp   label_2385
 
@@ -3956,7 +3956,7 @@ label_1A22::
     ld   a, $20
     ld   [SelectRomBank_2100], a
     call label_55CA
-    ld   a, [WR1_CurrentBank]
+    ld   a, [wCurrentBank]
     ld   [SelectRomBank_2100], a
     ret
 
@@ -3967,7 +3967,7 @@ label_1A39::
     ld   a, $20
     ld   [SelectRomBank_2100], a
     call label_563B
-    ld   a, [WR1_CurrentBank]
+    ld   a, [wCurrentBank]
     ld   [SelectRomBank_2100], a
     ret
 
@@ -4017,7 +4017,7 @@ label_1A88::
     jr   nz, label_1ABF
 
 label_1A9A::
-    ld   a, [WR0_HasMirrorShield]
+    ld   a, [wHasMirrorShield]
     and  a
     jr   nz, label_1AA5
     ld   hl, $4910
@@ -4030,7 +4030,7 @@ label_1AA5::
     ld   hl, $4928
 
 label_1AAF::
-    ld   a, [WR0_IsUsingShield]
+    ld   a, [wIsUsingShield]
     and  a
     jr   z, label_1ABD
     ld   a, l
@@ -4099,7 +4099,7 @@ AnimateTiles::
     ;
 
     ; If GameplayType == MARIN_BEACH, handle special case
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_MARIN_BEACH
     jr   z, AnimateMarinBeachTiles
 
@@ -4142,7 +4142,7 @@ AnimateTilesStep2::
     ;
 
     ; If GameplayType != CREDITS, skip
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_CREDITS
     jr   nz, AnimateTilesStep3
 
@@ -4162,17 +4162,17 @@ AnimateTilesStep3::
     jp   c, AnimateTilesReturn ; return immediately
 
     ; If the Inventory window is overlapping the screen
-    ld   a, [WR1_WindowY]
+    ld   a, [wWindowY]
     cp   $80
     jp   nz, AnimateTilesReturn ; return immediately
 
     ; If the Inventory apparition animation is running
-    ld   a, [WR0_InventoryAppearing]
+    ld   a, [wInventoryAppearing]
     and  a
     jp   nz, DrawLinkSpriteAndReturn
 
 AnimateTilesStep4::
-    ld   hl, WR0_MapSlideTransitionState
+    ld   hl, wMapSlideTransitionState
     ld   a, [$D601]
     or   [hl]
     jp   nz, DrawLinkSpriteAndReturn
@@ -4491,7 +4491,7 @@ label_1D49::
     jr   label_1DA1
 
 label_1D8C::
-    ld   a, [WR1_TunicType]
+    ld   a, [wTunicType]
     and  a
     jr   z, label_1D95
     inc  a
@@ -4540,7 +4540,7 @@ label_1DA1::
     jr   label_1DE7
 
 label_1DD2::
-    ld   a, [WR1_TunicType]
+    ld   a, [wTunicType]
     and  a
     jr   z, label_1DDB
     inc  a
@@ -4579,7 +4579,7 @@ label_1DF5::
     jp   label_1F3B
 
 label_1E01::
-    ld   a, [WR1_TradeSequenceItem]
+    ld   a, [wTradeSequenceItem]
     cp   $02
     jp  c, label_1F3E
     sub  a, $02
@@ -4829,7 +4829,7 @@ label_1F69::
     or   c
     ld   e, a
     ld   [$FFD8], a
-    ld   hl, WR1_TileMap
+    ld   hl, wTileMap
     add  hl, de
     ld   a, h
     cp   $D7
@@ -4897,7 +4897,7 @@ label_1FFE::
     jr   z, label_2049
     cp   $D4
     jr   z, label_2049
-    ld   a, [WR1_IsMarinFollowingLink]
+    ld   a, [wIsMarinFollowingLink]
     and  a
     jr   z, label_2030
     ld   a, $78
@@ -5003,7 +5003,7 @@ label_20BF::
     call label_41D0
 
 label_20CF::
-    ld   a, [WR1_AButtonSlot]
+    ld   a, [wAButtonSlot]
     cp   $03
     jr   nz, label_20DD
     ld   a, [hPressedButtonsMask]
@@ -5012,7 +5012,7 @@ label_20CF::
     ret
 
 label_20DD::
-    ld   a, [WR1_BButtonSlot]
+    ld   a, [wBButtonSlot]
     cp   $03
     jp   nz, label_2177
     ld   a, [hPressedButtonsMask]
@@ -5118,7 +5118,7 @@ label_2183::
     jr   c, label_21A7
     ld   a, $02
     ld   [$FFF3], a
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
     add  hl, de
     ld   [hl], $07
     ld   hl, $C3B0
@@ -5136,7 +5136,7 @@ label_21A7::
     ret
 
 label_21A8::
-    ld   a, [WR0_InventoryAppearing]
+    ld   a, [wInventoryAppearing]
     and  a
     ret  nz
     ld   c, $01
@@ -5243,7 +5243,7 @@ label_2241::
     ld   a, [$FFD9]
     ld   c, a
     ld   b, $00
-    ld   hl, WR1_TileMap
+    ld   hl, wTileMap
     add  hl, bc
     ld   b, $00
     ld   c, [hl]
@@ -5370,11 +5370,11 @@ label_22FE::
     jp   $5570
 
 label_2321::
-    ld   a, [WR0_DialogState]
+    ld   a, [wDialogState]
     and  a
     ret  z
     ld   e, a
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_CREDITS
     ld   a, $7E
     jr   nz, label_2332
@@ -5462,7 +5462,7 @@ label_2385::
     rra
     and  $80
     or   $01
-    ld   [WR0_DialogState], a
+    ld   [wDialogState], a
     ret
 
 data_23B0::
@@ -5481,7 +5481,7 @@ data_23DC::
 ; Open dialog animation
 ; Saves tiles under the dialog box?
 label_23E4::
-    ld   a, [WR0_DialogState]
+    ld   a, [wDialogState]
     bit  7, a
     jr   z, label_23EF
     and  $7F
@@ -5601,7 +5601,7 @@ label_2475::
     jp   $4A2C
 
 label_2485::
-    ld   hl, WR0_DialogState
+    ld   hl, wDialogState
     inc  [hl]
     ret
     ld   a, [$C1AB]
@@ -5614,19 +5614,19 @@ label_2485::
 label_2496::
     xor  a
     ld   [$C16F], a
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_PHOTO_ALBUM
     jr   nz, label_24A4
     xor  a
     jr   label_24AB
 
 label_24A4::
-    ld   a, [WR0_DialogState]
+    ld   a, [wDialogState]
     and  $F0
     or   $0E
 
 label_24AB::
-    ld   [WR0_DialogState], a
+    ld   [wDialogState], a
 
 label_24AE::
     ret
@@ -5635,11 +5635,11 @@ label_24AE::
     jp   $4AA8
     ld   a, $1C
     ld   [SelectRomBank_2100], a
-    ld   a, [WR0_DialogScrollDelay]
+    ld   a, [wDialogScrollDelay]
     and  a
     jr   z, label_24C7
     dec  a
-    ld   [WR0_DialogScrollDelay], a
+    ld   [wDialogScrollDelay], a
     ret
 
 label_24C7::
@@ -5647,7 +5647,7 @@ label_24C7::
     jp   label_2485
     ld   a, $1C
     ld   [SelectRomBank_2100], a
-    ld   a, [WR0_DialogState]
+    ld   a, [wDialogState]
     ld   c, a
     ld   a, [$C171]
     bit  7, c
@@ -5767,10 +5767,10 @@ label_2529::
     ld   [$D601], a
 
 label_2595::
-    ld   a, [WR0_DialogState]
+    ld   a, [wDialogState]
     and  $F0
     or   $0D
-    ld   [WR0_DialogState], a
+    ld   [wDialogState], a
 
 label_259F::
     ld   a, $15
@@ -5785,10 +5785,10 @@ label_25A4::
     ld   [$D601], a
 
 label_25AD::
-    ld   a, [WR0_DialogState]
+    ld   a, [wDialogState]
     and  $F0
     or   $0C
-    ld   [WR0_DialogState], a
+    ld   [wDialogState], a
     ret
 
 data_25B8::
@@ -5919,12 +5919,12 @@ label_2663::
     jr   z, label_268E
 
 label_267E::
-    ld   a, [WR0_DialogState]
+    ld   a, [wDialogState]
     and  $F0
     or   $06
-    ld   [WR0_DialogState], a
+    ld   [wDialogState], a
     ld   a, $00
-    ld   [WR0_DialogScrollDelay], a
+    ld   [wDialogScrollDelay], a
     ret
 
 label_268E::
@@ -5961,7 +5961,7 @@ label_26B6::
     jr   z, label_2714
     ld   a, $1C
     ld   [SelectRomBank_2100], a
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_MINI_MAP
     jp   z, label_278B
     ld   a, [$C173]
@@ -5976,7 +5976,7 @@ label_26B6::
 
 label_26E1::
     ld   e, $00
-    ld   a, [WR0_DialogState]
+    ld   a, [wDialogState]
     and  $80
     jr   z, label_26EB
     inc  e
@@ -6013,7 +6013,7 @@ data_2717::
 ; Scroll dialog line?
 DialogBeginScrolling::
     ld   e, $00
-    ld   a, [WR0_DialogState]
+    ld   a, [wDialogState]
     and  $80
     jr   z, label_2723
     inc  e
@@ -6068,7 +6068,7 @@ label_275D::
     dec  e
     jr   nz, label_2739
     ld   a, $08  ; Pause the scrolling for 8 frames
-    ld   [WR0_DialogScrollDelay], a
+    ld   [wDialogScrollDelay], a
     jp   label_2485
     ret
 
@@ -6132,7 +6132,7 @@ label_27BB::
 
 ; Set overworld music track?
 label_27C3::
-    ld   [WR1_OverworldMusic], a
+    ld   [wOverworldMusic], a
     ld   [$FFBF], a
     ld   a, $38
     ld   [$FFAB], a
@@ -6184,23 +6184,23 @@ label_2802::
 GetRandomByte::
     push hl
     ld   a, [hFrameCounter]
-    ld   hl, WR0_RandomSeed
+    ld   hl, wRandomSeed
     add  a, [hl]
     ld   hl, rLY
     add  a, [hl]
     rrca
-    ld   [WR0_RandomSeed], a ; WR0_RandomSeed += FrameCounter + rrca(rLY)
+    ld   [wRandomSeed], a ; wRandomSeed += FrameCounter + rrca(rLY)
     pop  hl
     ret
 
 ReadJoypadState::
-    ld   a, [WR0_MapSlideTransitionState]
+    ld   a, [wMapSlideTransitionState]
     and  a
     jr   nz, label_2886 ; return
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_OVERWORLD
     jr   nz, label_2852
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
     cp   $07
     jr   nz, label_284C
     ld   a, [$C11C]
@@ -6211,7 +6211,7 @@ ReadJoypadState::
     jr   z, label_2852
 
 label_283F::
-    ld   a, [WR0_TransitionSequenceCounter]
+    ld   a, [wTransitionSequenceCounter]
     cp   $04
     jr   nz, label_284C
     ld   a, [$DDD5]
@@ -6384,7 +6384,7 @@ label_2924::
     call label_2941
 
 label_2927::
-    ld   a, [WR0_MapSlideTransitionState]
+    ld   a, [wMapSlideTransitionState]
     and  a
     jr   nz, label_293C
 
@@ -6576,7 +6576,7 @@ label_29F8::
     ld   a, $20
     ld   [SelectRomBank_2100], a
     call label_4C98
-    ld   a, [WR1_CurrentBank]
+    ld   a, [wCurrentBank]
     ld   [SelectRomBank_2100], a
     ret
 
@@ -6903,7 +6903,7 @@ label_2CD1::
     ld   de, $8F00
     ld   bc, $0100
     call CopyData
-    ld   a, [WR1_CurrentBank]
+    ld   a, [wCurrentBank]
     ld   [SelectRomBank_2100], a
     ld   hl, $7D00
     ld   a, [$FFF7]
@@ -6943,7 +6943,7 @@ label_2D17::
     call label_1EA1
 
 label_2D21::
-    ld   a, [WR1_TradeSequenceItem]
+    ld   a, [wTradeSequenceItem]
     cp   $02
     jr   c, label_2D2C
     ld   a, $0D
@@ -7125,19 +7125,19 @@ label_2E85::
     jr   z, label_2ED3
 
 label_2EB0::
-    ld   a, [WR1_IsBowWowFollowingLink]
+    ld   a, [wIsBowWowFollowingLink]
     cp   $01
     ld   a, $A4
     jr   z, label_2ED1
-    ld   a, [WR1_IsGhostFollowingLink]
+    ld   a, [wIsGhostFollowingLink]
     and  a
     ld   a, $D8
     jr   nz, label_2ED1
-    ld   a, [WR1_IsRoosterFollowingLink]
+    ld   a, [wIsRoosterFollowingLink]
     and  a
     ld   a, $DD
     jr   nz, label_2ED1
-    ld   a, [WR1_IsMarinFollowingLink]
+    ld   a, [wIsMarinFollowingLink]
     and  a
     jr   z, label_2ED3
     ld   a, $8F
@@ -7437,7 +7437,7 @@ label_309B::
     call label_3905
     call SwitchBank
     ld   de, vBGMap0
-    ld   hl, WR1_TileMap
+    ld   hl, wTileMap
     ld   c, $80
 
 label_30A9::
@@ -7525,7 +7525,7 @@ label_3119::
     ld   [$FFE8], a
     call label_5897
     ld   e, a
-    ld   hl, WR1_KillCount2
+    ld   hl, wKillCount2
 
 label_3132::
     xor  a
@@ -7539,7 +7539,7 @@ label_313A::
     ld   a, [$FFF6]
     ld   e, a
     ld   d, $00
-    ld   hl, WR1_MinimapTiles
+    ld   hl, wMinimapTiles
     ld   a, [$DBA5]
     and  a
     jr   z, label_3161
@@ -7591,7 +7591,7 @@ label_318F::
     ld   a, [$FFF6]
     cp   $F5
     jr   nz, label_31A6
-    ld   a, [WR1_TradeSequenceItem]
+    ld   a, [wTradeSequenceItem]
     cp   $0E
     jr   nz, label_31A6
     ld   bc, $7855
@@ -7988,7 +7988,7 @@ label_33DC::
     and  a
     jr   nz, label_3406
     ld   a, $04
-    ld   [WR0_TransitionSequenceCounter], a
+    ld   [wTransitionSequenceCounter], a
 
 label_3406::
     pop  af
@@ -8167,7 +8167,7 @@ MoveToNextLine_tileTypeNotA0::
     dec  bc ; decrement tile address
     ld   a, [bc] ; load new tile type
     ld   e, a
-    ld   hl, WR1_TileMap ; prepare tile map
+    ld   hl, wTileMap ; prepare tile map
     add  hl, de ; add current tile offset
     ld   a, [$FFD7]
     and  $0F
@@ -8231,7 +8231,7 @@ label_352D::
     dec  bc
     ld   a, [bc]
     ld   e, a
-    ld   hl, WR1_TileMap
+    ld   hl, wTileMap
     add  hl, de
     pop  af
     ld   [hl], a
@@ -8384,7 +8384,7 @@ label_35EE::
     ld   a, [bc]
     ld   e, a
     ld   d, $00
-    ld   hl, WR1_TileMap
+    ld   hl, wTileMap
     add  hl, de
     ret
 
@@ -8567,7 +8567,7 @@ data_37E4::
 FillTileMapWith::
     ld   [$FFE9], a
     ld   d, TILES_PER_MAP
-    ld   hl, WR1_TileMap
+    ld   hl, wTileMap
     ld   e, a
 
 FillTileMapWith_loop::
@@ -8683,7 +8683,7 @@ label_389B::
     ld   d, e
 
 label_389E::
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
     add  hl, de
     ld   a, [hl]
     cp   $00
@@ -8844,7 +8844,7 @@ label_398D::
     ld   [$FFF3], a
 
 label_399B::
-    ld   a, [WR0_DialogState]
+    ld   a, [wDialogState]
     and  a
     jr   nz, label_39AE
     ld   a, [$C111]
@@ -8879,14 +8879,14 @@ label_39C1::
     call label_4303
     xor  a
     ld   [SelectRomBank_2100], a
-    ld   a, [WR0_DialogState]
+    ld   a, [wDialogState]
     and  a
     jr   nz, label_39E3
     ld   [$C1AD], a
 
 label_39E3::
     ld   a, $20
-    ld   [WR1_CurrentBank], a
+    ld   [wCurrentBank], a
     ld   [SelectRomBank_2100], a
     call label_6352
     ld   b, $00
@@ -8895,7 +8895,7 @@ label_39E3::
 label_39F2::
     ld   a, c
     ld   [$C123], a
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
     add  hl, bc
     ld   a, [hl]
     and  a
@@ -8932,7 +8932,7 @@ label_3A18::
     ld   a, [hl]
     ld   [$FFF1], a
     ld   a, $19
-    ld   [WR1_CurrentBank], a
+    ld   [wCurrentBank], a
     ld   [SelectRomBank_2100], a
     ld   a, [$FFEB]
     cp   $6A
@@ -8957,11 +8957,11 @@ label_3A4E::
 
 label_3A54::
     ld   a, $14
-    ld   [WR1_CurrentBank], a
+    ld   [wCurrentBank], a
     ld   [SelectRomBank_2100], a
     call label_4D73
     ld   a, $03
-    ld   [WR1_CurrentBank], a
+    ld   [wCurrentBank], a
     ld   [SelectRomBank_2100], a
     ld   a, [$FFEA]
     cp   $05
@@ -8973,7 +8973,7 @@ label_3A54::
 label_3A81::
     call label_3A8D
     ld   a, $03
-    ld   [WR1_CurrentBank], a
+    ld   [wCurrentBank], a
     ld   [SelectRomBank_2100], a
     ret
 
@@ -8994,7 +8994,7 @@ label_3A8D::
     ld   a, [hl]
     ld   l, e
     ld   h, d
-    ld   [WR1_CurrentBank], a
+    ld   [wCurrentBank], a
     ld   [SelectRomBank_2100], a
     jp   [hl]
 
@@ -9158,7 +9158,7 @@ label_3BC0::
     ld   a, [$FFEC]
     ld   [de], a
     inc  de
-    ld   a, [WR0_ScreenShakeHorizontal]
+    ld   a, [wScreenShakeHorizontal]
     ld   c, a
     ld   a, [$FFED]
     and  $20
@@ -9214,7 +9214,7 @@ label_3C21::
     ld   a, [$FFEC]
     ld   [de], a
     inc  de
-    ld   a, [WR0_ScreenShakeHorizontal]
+    ld   a, [wScreenShakeHorizontal]
     ld   c, a
     ld   a, [$FFED]
     and  $20
@@ -9295,7 +9295,7 @@ label_3C77::
 label_3C9C::
     ld   [de], a
     inc  de
-    ld   a, [WR0_ScreenShakeHorizontal]
+    ld   a, [wScreenShakeHorizontal]
     ld   h, a
     ld   a, [$FFEE]
     add  a, $04
@@ -9315,7 +9315,7 @@ label_3C9C::
     ld   a, [hIsGBC]
     and  a
     jr   z, label_3CD0
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_CREDITS
     jr   z, label_3CD0
     ld   a, [$FFED]
@@ -9377,7 +9377,7 @@ label_3D06::
     inc  hl
     inc  de
     push bc
-    ld   a, [WR0_ScreenShakeHorizontal]
+    ld   a, [wScreenShakeHorizontal]
     ld   c, a
     ld   a, [$FFEE]
     add  a, [hl]
@@ -9435,7 +9435,7 @@ label_3D52::
 
 label_3D57::
     push hl
-    ld   a, [WR0_MapSlideTransitionState]
+    ld   a, [wMapSlideTransitionState]
     and  a
     jr   z, label_3D7D
     ld   a, [$FFEE]
@@ -9555,7 +9555,7 @@ label_3E0E::
     jp   ReloadSavedBank
 
 label_3E19::
-    ld   a, [WR1_CurrentBank]
+    ld   a, [wCurrentBank]
     push af
     ld   a, $02
     call SwitchBank
@@ -9613,7 +9613,7 @@ label_3E76::
 
 label_3E83::
     ld   e, $10
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
 
 label_3E88::
     xor  a
@@ -9686,8 +9686,8 @@ data_3EDF::
     db $B0, $B4, $B1, $B2, $B3, $B6, $BA, $BC, $B8
 
 label_3EE8::
-    ld   hl, WR0_InventoryAppearing
-    ld   a, [WR0_MapSlideTransitionState]
+    ld   hl, wInventoryAppearing
+    ld   a, [wMapSlideTransitionState]
     or   [hl]
     ret  nz
     ld   a, [$C165]
@@ -9714,7 +9714,7 @@ label_3EFB::
 label_3F11::
     ld   [$D368], a
     ld   [$FFBD], a
-    ld   a, [WR0_TransitionSequenceCounter]
+    ld   a, [wTransitionSequenceCounter]
     cp   $04
     ret  nz
     ld   a, [$FFEB]
@@ -9764,11 +9764,11 @@ label_3F50::
     cp   $FF
     jr   z, label_3F8D
     push af
-    ld   a, [WR1_KillCount2]
+    ld   a, [wKillCount2]
     ld   e, a
     ld   d, b
     inc  a
-    ld   [WR1_KillCount2], a
+    ld   [wKillCount2], a
     ld   a, [hl]
     ld   hl, $DBB6
     add  hl, de
@@ -9792,7 +9792,7 @@ label_3F78::
     ld   [hl], a
 
 label_3F8D::
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
     add  hl, bc
     ld   [hl], b
     ret

--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -2667,7 +2667,7 @@ label_11BA::
 label_11BC::
     xor  a
     ld   [WR0_IsUsingShield], a
-    ld   [WR0_ShieldLevel], a
+    ld   [WR0_HasMirrorShield], a
 
 label_11C3::
     ld   a, [$C117]
@@ -2725,7 +2725,7 @@ label_1214::
     cp   $04
     jr   nz, label_1235
     ld   a, [WR1_ShieldLevel]
-    ld   [WR0_ShieldLevel], a
+    ld   [WR0_HasMirrorShield], a
     ld   a, [hPressedButtonsMask]
     and  $10
     jr   z, label_1235
@@ -2741,7 +2741,7 @@ label_1235::
     cp   $04
     jr   nz, label_124B
     ld   a, [WR1_ShieldLevel]
-    ld   [WR0_ShieldLevel], a
+    ld   [WR0_HasMirrorShield], a
     ld   a, [hPressedButtonsMask]
     and  $20
     jr   z, label_124B
@@ -2890,7 +2890,7 @@ label_1340::
     ld   a, $01
     ld   [WR0_IsUsingShield], a
     ld   a, [WR1_ShieldLevel]
-    ld   [WR0_ShieldLevel], a
+    ld   [WR0_HasMirrorShield], a
     ld   a, $20
     ld   [SelectRomBank_2100], a
     call label_4B4A
@@ -4017,7 +4017,7 @@ label_1A88::
     jr   nz, label_1ABF
 
 label_1A9A::
-    ld   a, [WR0_ShieldLevel]
+    ld   a, [WR0_HasMirrorShield]
     and  a
     jr   nz, label_1AA5
     ld   hl, $4910

--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -4925,7 +4925,7 @@ label_6014::
     ld   a, [$DB68]
     and  $02
     jr   z, label_607F
-    ld   a, [$DB43]
+    ld   a, [WR1_PowerBraceletLevel]
     cp   $02
     jr   c, label_603C
     xor  a

--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -7080,8 +7080,6 @@ IntroShipOnSeaHandler::
 label_7013::
     ret
 
-WR0_IntroShipPosX equ (WR0_EntitiesPosXTable + $02)
-
 label_7014::
     ld   a, [WR0_IntroShipPosX]
     cp   $50

--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -4,7 +4,7 @@
 data_380   equ $0380
 
 label_4000::
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
     JP_TABLE
     ld   [de], a
     ld   b, b
@@ -67,7 +67,7 @@ label_4042::
     call IncrementGameplaySubtype
     xor  a
     ld   [$C1BF], a
-    ld   [WR0_InventoryAppearing], a
+    ld   [wInventoryAppearing], a
     ld   [$C1B8], a
     ld   [$C1B9], a
     ld   [$C1B5], a
@@ -84,7 +84,7 @@ label_4072::
     ld   a, $0D
     ld   [$D6FF], a
     ld   a, $FF
-    ld   [WR1_WindowY], a
+    ld   [wWindowY], a
     xor  a
     ld   [hBaseScrollX], a
     ld   [$FF97], a
@@ -124,11 +124,11 @@ label_40A9::
 label_40D5::
     ret
     xor  a
-    ld   [WR1_OBJ0Palette], a
+    ld   [wOBJ0Palette], a
     ld   [$DB99], a
     ld   [rOBP0], a
     ld   [rOBP1], a
-    ld   [WR1_BGPalette], a
+    ld   [wBGPalette], a
     ld   [rBGP], a
     ld   a, [$FF98]
     ld   [$DB9D], a
@@ -150,11 +150,11 @@ label_40F9::
     call label_6162
     ld   a, $C7
     ld   [rLCDC], a
-    ld   [WR1_LCDControl], a
+    ld   [wLCDControl], a
     ld   a, $07
     ld   [rWX], a
     ld   a, $80
-    ld   [WR1_WindowY], a
+    ld   [wWindowY], a
     ld   [rWY], a
     ld   a, $07
     ld   [$FFA9], a
@@ -289,7 +289,7 @@ label_41B4::
 
 label_41BB::
     xor  a
-    ld   [WR1_BGPalette], a
+    ld   [wBGPalette], a
     ld   [rBGP], a
     ret
 
@@ -325,8 +325,8 @@ label_41E7::
     db   $10 ; Undefined instruction
     db   $10 ; Undefined instruction
     db   $af ; Undefined instruction
-    ld   [WR0_ScreenShakeHorizontal], a
-    ld   [WR0_ScreenShakeVertical], a
+    ld   [wScreenShakeHorizontal], a
+    ld   [wScreenShakeVertical], a
     ld   a, [$FFB7]
     and  a
 
@@ -391,8 +391,8 @@ label_4259::
     ld   a, $01
     ld   [$C3CB], a
     ld   a, $1C
-    ld   [WR1_OBJ0Palette], a
-    ld   a, [WR1_BGPalette]
+    ld   [wOBJ0Palette], a
+    ld   a, [wBGPalette]
     ld   [$DB99], a
     ld   e, $08
     call label_8D7
@@ -404,11 +404,11 @@ label_4259::
     inc  [hl]
     ret
     ld   a, $E4
-    ld   [WR1_BGPalette], a
+    ld   [wBGPalette], a
     ld   a, $0A
     ld   [$D6FF], a
     ld   a, $FF
-    ld   [WR1_WindowY], a
+    ld   [wWindowY], a
     xor  a
     ld   [hBaseScrollX], a
     ld   [$FF97], a
@@ -455,18 +455,18 @@ label_42F2::
 
 label_42F5::
     xor  a
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
     ld   e, $10
 
 label_42FB::
     ldi  [hl], a
     dec  e
     jr   nz, label_42FB
-    ld   [WR1_OBJ0Palette], a
+    ld   [wOBJ0Palette], a
     ld   [$DB99], a
     ld   [rOBP0], a
     ld   [rOBP1], a
-    ld   [WR1_BGPalette], a
+    ld   [wBGPalette], a
     ld   [rBGP], a
     ld   [$D6FB], a
     ld   [$D475], a
@@ -539,7 +539,7 @@ label_435C::
     ret
 
 OverworldHandlerEntryPoint::
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
     JP_TABLE
 ._0 dw label_4395
 ._1 dw label_442B
@@ -771,7 +771,7 @@ label_44C9::
 
 IncrementGameplaySubtype::
 IncrementGameplaySubtypeAndReturn::
-    ld   hl, WR1_GameplaySubtype
+    ld   hl, wGameplaySubtype
     inc  [hl]
     ret
 
@@ -807,7 +807,7 @@ label_4507::
     call label_5895
     ld   a, [$FF40]
     or   $20
-    ld   [WR1_LCDControl], a
+    ld   [wLCDControl], a
     ld   [rLCDC], a
     call IncrementGameplaySubtype
     ld   a, [$C11C]
@@ -821,9 +821,9 @@ label_4507::
     and  a
     jr   z, label_4548
     ld   a, [$C5AD]
-    ld   [WR1_BGPalette], a
+    ld   [wBGPalette], a
     ld   a, $1C
-    ld   [WR1_OBJ0Palette], a
+    ld   [wOBJ0Palette], a
     ld   a, $E4
     ld   [$DB99], a
     ld   a, [hIsGBC]
@@ -924,15 +924,15 @@ label_4555::
     ld   a, [$ABB7]
     ld   [$DC05], a
     ld   a, GAMEPLAY_FILE_SELECT
-    ld   [WR1_GameplayType], a
+    ld   [wGameplayType], a
     xor  a
-    ld   [WR1_GameplaySubtype], a
+    ld   [wGameplaySubtype], a
     xor  a
     ld   [$FF97], a
     ld   [hBaseScrollX], a
     ld   a, $00
-    ld   [WR1_BGPalette], a
-    ld   [WR1_OBJ0Palette], a
+    ld   [wBGPalette], a
+    ld   [wOBJ0Palette], a
     ld   [$DB99], a
     ld   a, $01
     call label_8FA
@@ -1008,7 +1008,7 @@ label_46ED::
     ld   [$A45F], a
     ld   a, $0A
     ld   [$A460], a
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_FILE_NEW
     jr   z, label_474E
     ld   a, $5B
@@ -1104,7 +1104,7 @@ label_47C3::
 label_47CD::
     ret
     call label_5DC0
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
     JP_TABLE
     ; Code below is actually data for the jump table
     jp   [hl]
@@ -1273,9 +1273,9 @@ label_48C2::
 label_48CC::
     ld   [$D6FF], a
     ld   a, $E4
-    ld   [WR1_BGPalette], a
+    ld   [wBGPalette], a
     ld   a, $1C
-    ld   [WR1_OBJ0Palette], a
+    ld   [wOBJ0Palette], a
     ld   a, $E4
     ld   [$DB99], a
     call label_905
@@ -1424,9 +1424,9 @@ label_49AE::
     dec  c
     jr   nz, label_49AE
     xor  a
-    ld   [WR1_GameplaySubtype], a
+    ld   [wGameplaySubtype], a
     ld   a, GAMEPLAY_FILE_NEW
-    ld   [WR1_GameplayType], a
+    ld   [wGameplayType], a
 
 label_49BE::
     ld   a, $13
@@ -1436,8 +1436,8 @@ label_49BE::
 label_49C3::
     call label_49BE
     ld   a, $00
-    ld   [WR1_BGPalette], a
-    ld   [WR1_OBJ0Palette], a
+    ld   [wBGPalette], a
+    ld   [wOBJ0Palette], a
     ld   [$DB99], a
     ld   a, $01
     call label_8FA
@@ -1447,7 +1447,7 @@ label_49C3::
 
 label_49DE::
     xor  a
-    ld   [WR1_GameplaySubtype], a
+    ld   [wGameplaySubtype], a
     ld   a, [$D000]
     and  a
     ld   a, $04
@@ -1455,7 +1455,7 @@ label_49DE::
     ld   a, GAMEPLAY_FILE_COPY
 
 label_49EC::
-    ld   [WR1_GameplayType], a
+    ld   [wGameplayType], a
     jp   label_49BE
 
 label_49F2::
@@ -1478,7 +1478,7 @@ label_49FE::
     db 0, $A1, $AD, $A4, $5A, $A8, $C3, $A4, $52
 
 label_4A07::
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
     JP_TABLE
     ; Code below is actually data for the jump table
     ld   de, label_244A
@@ -1979,7 +1979,7 @@ label_4CDA::
     ld   [hl], e
     ret
     call label_5DC0
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
     JP_TABLE
     ; Code below is actually data for the jump table
     ld   a, [de]
@@ -2229,7 +2229,7 @@ label_4E91::
 label_4E9E::
     call label_4EE5
     call label_4EBB
-    ld   hl, WR1_GameplaySubtype
+    ld   hl, wGameplaySubtype
     dec  [hl]
     ret
 
@@ -2628,7 +2628,7 @@ label_5104::
     ld   a, [$FFCC]
     bit  5, a
     jr   z, label_5114
-    ld   hl, WR1_GameplaySubtype
+    ld   hl, wGameplaySubtype
     dec  [hl]
     jp   label_514F
 
@@ -2815,7 +2815,7 @@ label_5235::
     ld   a, [$FFCC]
     bit  5, a
     jr   z, label_5249
-    ld   hl, WR1_GameplaySubtype
+    ld   hl, wGameplaySubtype
     dec  [hl]
     xor  a
     ld   [$D000], a
@@ -2957,9 +2957,9 @@ label_52FB::
 
 label_531D::
     ld   a, GAMEPLAY_OVERWORLD
-    ld   [WR1_GameplayType], a
+    ld   [wGameplayType], a
     xor  a
-    ld   [WR1_GameplaySubtype], a
+    ld   [wGameplaySubtype], a
     xor  a
     ld   [$C11C], a
     ld   [$FF9C], a
@@ -3522,13 +3522,13 @@ label_5619::
     ret
     xor  a
     ld   [$C3C0], a
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
     cp   $05
     jr   z, label_5639
     xor  a
     ld   [$FFCB], a
     ld   [$FFCC], a
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
 
 label_5639::
     JP_TABLE
@@ -3598,7 +3598,7 @@ label_5678::
     ld   [hBaseScrollX], a
     ld   [$C1BF], a
     ld   [$FF97], a
-    ld   [WR0_InventoryAppearing], a
+    ld   [wInventoryAppearing], a
     ld   [$C1B2], a
     ld   [$C1B3], a
     ld   a, [$DB54]
@@ -3633,7 +3633,7 @@ label_56D9::
     ld   [$C1B4], a
     ld   a, [$FF40]
     and  $DF
-    ld   [WR1_LCDControl], a
+    ld   [wLCDControl], a
     ld   [rLCDC], a
     call label_5888
     ld   a, $08
@@ -3667,9 +3667,9 @@ label_571B::
     bit  7, a
     jr   z, label_5731
     xor  a
-    ld   [WR1_GameplaySubtype], a
+    ld   [wGameplaySubtype], a
     inc  a
-    ld   [WR1_GameplayType], a
+    ld   [wGameplayType], a
     ret
 
 label_5731::
@@ -3768,7 +3768,7 @@ label_57B7::
     cp   $60
     jr   nz, label_57FA
     ld   a, GAMEPLAY_OVERWORLD
-    ld   [WR1_GameplayType], a
+    ld   [wGameplayType], a
     call label_C7D
     ld   a, $00
     ld   [$D401], a
@@ -3789,7 +3789,7 @@ label_57B7::
     or   e
     ld   [$D416], a
     ld   a, $07
-    ld   [WR1_GameplaySubtype], a
+    ld   [wGameplaySubtype], a
     ret
 
 label_57FA::
@@ -3862,10 +3862,10 @@ label_5854::
     ld   a, $70
     ld   [$FFAA], a
     ld   a, GAMEPLAY_OVERWORLD
-    ld   [WR1_GameplayType], a
+    ld   [wGameplayType], a
     ld   [$FFBC], a
     ld   a, $02
-    ld   [WR1_GameplaySubtype], a
+    ld   [wGameplaySubtype], a
     ld   a, [$DBA5]
     and  a
     ld   a, $06
@@ -3876,7 +3876,7 @@ label_5885::
     ld   [$D6FE], a
 
 label_5888::
-    ld   hl, WR0_MapSlideTransitionState
+    ld   hl, wMapSlideTransitionState
     ld   e, $00
 
 label_588D::
@@ -3889,13 +3889,13 @@ label_588D::
 
 label_5895::
     ld   a, $80
-    ld   [WR1_WindowY], a
+    ld   [wWindowY], a
     ld   a, $07
     ld   [rWX], a
     ld   a, $08
     ld   [$C150], a
     xor  a
-    ld   [WR0_InventoryAppearing], a
+    ld   [wInventoryAppearing], a
 
 label_58A7::
     ret
@@ -4049,7 +4049,7 @@ label_5AA0::
     ld   a, [hl]
     and  $FF
     jr   nz, label_5AF5
-    ld   a, [WR0_FreeMovementMode]
+    ld   a, [wFreeMovementMode]
     and  a
     jr   nz, label_5AF5
     ld   a, $09
@@ -4768,11 +4768,11 @@ label_5F43::
     ret
 
 UpdateWindowPosition::
-    ld   a, [WR0_InventoryAppearing]
+    ld   a, [wInventoryAppearing]
     and  a
     jr   z, label_5F6A
     ld   hl, $C000
-    ld   a, [WR1_WindowY]
+    ld   a, [wWindowY]
     add  a, $08
     ld   d, a
     ld   e, $28
@@ -4793,7 +4793,7 @@ label_5F62::
     ret
 
 label_5F6A::
-    ld   a, [WR1_WindowY]
+    ld   a, [wWindowY]
     and  a
     ret  z
     ld   a, [$C19F]
@@ -4881,7 +4881,7 @@ label_5FDE::
     ld   a, [hl]
     cp   $D5
     jr   nz, label_5FF0
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
     add  hl, de
     ld   a, [hl]
     and  a
@@ -4925,7 +4925,7 @@ label_6014::
     ld   a, [$DB68]
     and  $02
     jr   z, label_607F
-    ld   a, [WR1_PowerBraceletLevel]
+    ld   a, [wPowerBraceletLevel]
     cp   $02
     jr   c, label_603C
     xor  a
@@ -4948,7 +4948,7 @@ label_6047::
     ld   a, [hl]
     cp   $D4
     jr   nz, label_6059
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
     add  hl, de
     ld   a, [hl]
     and  a
@@ -4991,7 +4991,7 @@ label_608A::
     ld   a, [hl]
     cp   $C1
     jr   nz, label_609C
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
     add  hl, de
     ld   a, [hl]
     and  a
@@ -5090,7 +5090,7 @@ label_612F::
     ld   a, [hl]
     cp   $6D
     jr   nz, label_6141
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
     add  hl, de
     ld   a, [hl]
     and  a
@@ -5124,11 +5124,11 @@ label_6161::
 label_6162::
     call label_27F2
     xor  a
-    ld   [WR1_GameplayType], a
-    ld   [WR1_GameplaySubtype], a
-    ld   [WR1_OBJ0Palette], a
+    ld   [wGameplayType], a
+    ld   [wGameplaySubtype], a
+    ld   [wOBJ0Palette], a
     ld   [$DB99], a
-    ld   [WR1_BGPalette], a
+    ld   [wBGPalette], a
     ld   [rBGP], a
     ld   [rOBP0], a
     ld   [rOBP1], a
@@ -5184,7 +5184,7 @@ label_61E9::
     ld   a, [$C11C]
     cp   $00
     jr   nz, label_6202
-    ld   a, [WR0_FreeMovementMode]
+    ld   a, [wFreeMovementMode]
     and  a
     jr   nz, label_6202
     ld   a, [$FFF7]
@@ -5255,7 +5255,7 @@ label_6281::
     ld   a, $13
     ld   [$D6FF], a
     ld   a, $FF
-    ld   [WR1_WindowY], a
+    ld   [wWindowY], a
     xor  a
     ld   [hBaseScrollX], a
     ld   [$C16B], a
@@ -5409,12 +5409,12 @@ label_63F8::
     ld   hl, label_63AA
     add  hl, de
     ld   a, [hl]
-    ld   [WR1_BGPalette], a
+    ld   [wBGPalette], a
     ld   [$DB99], a
     ld   hl, label_63BA
     add  hl, de
     ld   a, [hl]
-    ld   [WR1_OBJ0Palette], a
+    ld   [wOBJ0Palette], a
 
 label_6417::
     ld   a, [hFrameCounter]
@@ -5510,7 +5510,7 @@ label_64BA::
     ld   a, $DE
     call label_67DE
     ld   a, $06
-    ld   [WR1_GameplaySubtype], a
+    ld   [wGameplaySubtype], a
     ld   a, $05
     ld   [$C3C7], a
     ret
@@ -5792,7 +5792,7 @@ label_66D7::
 label_66D8::
     db $E0, $66, $E4, $66, $E8, $66, $EC, $66, $4C, 0, $4C, $20, $4E, 0, $4E, $20
     db $5C, 0, $5C, $20, $5E, 0, $5E, $20
-    
+
 label_66F0::
     db 1, $FF
 
@@ -6061,7 +6061,7 @@ label_6885::
     ld   a, e
     ld   [$D6FF], a
     ld   a, $FF
-    ld   [WR1_WindowY], a
+    ld   [wWindowY], a
     xor  a
     ld   [hBaseScrollX], a
     ld   [$FF97], a
@@ -6093,7 +6093,7 @@ label_68BF::
     jr   nz, label_68CF
     call label_6A7C
     ld   a, $07
-    ld   [WR1_GameplaySubtype], a
+    ld   [wGameplaySubtype], a
     ret
 
 label_68CF::
@@ -6116,7 +6116,7 @@ label_68E3::
     dec  a
     ld   [$D210], a
     jr   nz, label_68FB
-    ld   [WR0_ScreenShakeVertical], a
+    ld   [wScreenShakeVertical], a
     ld   a, $20
     ld   [$D210], a
     jp   IncrementGameplaySubtypeAndReturn
@@ -6129,7 +6129,7 @@ label_68FB::
 
 label_6903::
     ld   a, e
-    ld   [WR0_ScreenShakeVertical], a
+    ld   [wScreenShakeVertical], a
     ret
     call label_6A7C
     call label_695B
@@ -6171,7 +6171,7 @@ label_6944::
 
 label_695B::
     xor  a
-    ld   [WR0_ScreenShakeVertical], a
+    ld   [wScreenShakeVertical], a
     ld   a, [$D215]
     and  a
     jr   z, label_6975
@@ -6184,7 +6184,7 @@ label_695B::
 
 label_6971::
     ld   a, e
-    ld   [WR0_ScreenShakeVertical], a
+    ld   [wScreenShakeVertical], a
 
 label_6975::
     ret
@@ -6217,7 +6217,7 @@ label_69C0::
 
 label_69C3::
     db 0, $DE, $10, $40, 8, $E0, $10, $40, $10, $E0, $30, $40, $18, $DE, $30
-    
+
 label_69D2::
     db 0
 
@@ -6296,7 +6296,7 @@ label_6A7C::
     ld   [$FFF5], a
     ld   a, $38
     ld   [$FFEE], a
-    ld   a, [WR0_ScreenShakeVertical]
+    ld   a, [wScreenShakeVertical]
     ld   e, a
     ld   a, $20
     sub  a, e
@@ -6332,7 +6332,7 @@ label_6AAE::
 label_6AC2::
     ld   a, $48
     ld   [$FFEE], a
-    ld   a, [WR0_ScreenShakeVertical]
+    ld   a, [wScreenShakeVertical]
     ld   e, a
     ld   a, [$D211]
     add  a, $20
@@ -6363,7 +6363,7 @@ label_6AF4::
     ret
 
 label_6AF8::
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
     JP_TABLE
 ._0 dw label_6B0A
 ._1 dw label_6B2B
@@ -6423,7 +6423,7 @@ label_6B52::
     ld   a, $15
     ld   [$D6FF], a
     ld   a, $FF
-    ld   [WR1_WindowY], a
+    ld   [wWindowY], a
     xor  a
     ld   [hBaseScrollX], a
     ld   [$FF97], a
@@ -6698,7 +6698,7 @@ label_6D10::
 
 label_6D11::
     ld   d, $05
-    ld   a, [WR1_GameplayType]
+    ld   a, [wGameplayType]
     cp   GAMEPLAY_OVERWORLD
     jr   z, label_6D1C
     ld   d, $06
@@ -6818,11 +6818,11 @@ IntroCheckJoypad::
     jp   z, RenderIntroFrame
     ; Start button pressed
     call label_27F2
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
     cp   GAMEPLAY_INTRO_TITLE  ; if on Title Screen
     jr   z, .transitionToFileMenu
     ; Transition to Title screen
-    ld   a, 40  ; Ignore joypad for the next 40 frames 
+    ld   a, 40  ; Ignore joypad for the next 40 frames
     ld   [hButtonsInactiveDelay], a
     ld   a, $11
     ld   [$D6FF], a
@@ -6831,7 +6831,7 @@ IntroCheckJoypad::
     jr   nz, .isGBC
     ; Not GBC
     ld   a, [label_789B]
-    ld   [WR1_OBJ0Palette], a
+    ld   [wOBJ0Palette], a
     ld   a, [label_789F]
     ld   [$DB99], a
     ld   a, $04
@@ -6847,15 +6847,15 @@ IntroCheckJoypad::
 .transitionToTitleScreen
     ld   [$D013], a
     ld   a, $0D
-    ld   [WR1_GameplaySubtype], a
+    ld   [wGameplaySubtype], a
     xor  a
-    ld   [WR0_EntitiesTypeTable], a
+    ld   [wEntitiesTypeTable], a
     ld   [$C281], a
     ld   [$C282], a
     ld   [$C283], a
     ld   [$C284], a
     ld   [rBGP], a
-    ld   [WR1_BGPalette], a
+    ld   [wBGPalette], a
     ld   a, $10
     ld   [$C17E], a
     call ResetIntroTimers
@@ -6869,12 +6869,12 @@ IntroCheckJoypad::
     jp   TransitionToFileMenu
     ; Jump to End Sequence (dead code, never reached)
     xor  a
-    ld   [WR1_GameplaySubtype], a
+    ld   [wGameplaySubtype], a
     ld   [hBaseScrollX], a
     ld   [$FF97], a
     ld   [rBGP], a
-    ld   [WR1_BGPalette], a
-    ld   hl, WR1_GameplayType
+    ld   [wBGPalette], a
+    ld   hl, wGameplayType
     inc  [hl]
 
 .enableVBlankInterruptAndReturn
@@ -6885,7 +6885,7 @@ IntroCheckJoypad::
     ret
 
 RenderIntroFrame::
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
     cp   GAMEPLAY_INTRO_SEA
     jr   c, IntroSceneJumpTable
     cp   $05
@@ -6906,13 +6906,13 @@ label_6EC6::
     ld   hl, IntroSeaPaletteTable
     add  hl, de
     ld   a, [hl]
-    ld   [WR1_BGPalette], a
+    ld   [wBGPalette], a
     call label_8F0 ; Load BG palette
 
 IntroSceneJumpTable::
-    ld   a, [WR1_GameplaySubtype]
+    ld   a, [wGameplaySubtype]
     JP_TABLE
-._0 dw label_6EF8 
+._0 dw label_6EF8
 ._1 dw label_6F2A
 ._2 dw label_6F36
 ._3 dw IntroShipOnSeaHandler
@@ -6942,7 +6942,7 @@ label_6EF8::
     ld   [$C13D], a
     ld   a, [$FF40]
     and  $DF
-    ld   [WR1_LCDControl], a
+    ld   [wLCDControl], a
     ld   [rLCDC], a
     ld   a, $B4
     ld   [$D016], a
@@ -6971,7 +6971,7 @@ label_6F42::
 label_6F44::
     ld   [$D6FF], a
     ld   a, $1C
-    ld   [WR1_OBJ0Palette], a
+    ld   [wOBJ0Palette], a
     ld   a, $E0
     ld   [$DB99], a
     ld   a, $03
@@ -6986,7 +6986,7 @@ label_6F5F::
     ldi  [hl], a
     dec  e
     jr   nz, label_6F5F
-    ld   [WR0_EntitiesTypeTable], a
+    ld   [wEntitiesTypeTable], a
     ld   [$C281], a
     ld   [$C3B0], a
     ld   [$C3B1], a
@@ -7028,11 +7028,11 @@ label_6F9C::
 IntroShipOnSeaHandler::
     call RenderRain
     call RenderIntroEntities
-    ld   a, [WR0_IntroSubTimer]
+    ld   a, [wIntroSubTimer]
     and  a
     jr   z, label_7014
     inc  a
-    ld   [WR0_IntroSubTimer], a ; Increment subtimer
+    ld   [wIntroSubTimer], a ; Increment subtimer
     cp   $18
     jr   c, label_7013
     sub  a, $18
@@ -7045,31 +7045,31 @@ IntroShipOnSeaHandler::
     ld   hl, label_6F93
     add  hl, de
     ld   a, [hl]
-    ld   [WR1_BGPalette], a
+    ld   [wBGPalette], a
     ld   hl, label_6F9C
     add  hl, de
     ld   a, [hl]
-    ld   [WR1_OBJ0Palette], a
+    ld   [wOBJ0Palette], a
     call label_8D7
     ld   a, e
     cp   $08
     jp   nz, label_7013
     xor  a
-    ld   [WR0_EntitiesTypeTable], a
+    ld   [wEntitiesTypeTable], a
     ld   [$C281], a
     ld   [$C282], a
     ld   [$C290], a
     ld   a, $05
-    ld   [WR1_GameplaySubtype], a
+    ld   [wGameplaySubtype], a
     ld   [$D00F], a
     call label_7D4E
     ld   a, $11
     ld   [$D6FE], a
     ld   a, $FF
-    ld   [WR0_IntroTimer], a
+    ld   [wIntroTimer], a
     xor  a
     ld   [hBaseScrollX], a
-    ld   [WR0_ScrollXOffsetForSection], a
+    ld   [wScrollXOffsetForSection], a
     ld   [$C102], a
     ld   [$C103], a
     ld   a, $92
@@ -7081,7 +7081,7 @@ label_7013::
     ret
 
 label_7014::
-    ld   a, [WR0_IntroShipPosX]
+    ld   a, [wIntroShipPosX]
     cp   $50
     jr   nz, label_7031
     ; If IntroShipPosX == $50
@@ -7089,7 +7089,7 @@ label_7014::
     ld   a, $FF
     ld   [rBGP], a
     ld   a, GAMEPLAY_INTRO_LINK_FACE
-    ld   [WR1_GameplaySubtype], a
+    ld   [wGameplaySubtype], a
     ld   a, $0F
     ld   [$D6FF], a
     ld   a, $01
@@ -7136,7 +7136,7 @@ label_7068::
     ld   d, $00
 
 label_706C::
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
     add  hl, de
     ld   a, [hl]
     and  a
@@ -7159,7 +7159,7 @@ label_7087::
     ld   hl, label_7081
     add  hl, bc
     ld   a, [hl]
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
     add  hl, de
     ld   [hl], a
     ld   hl, label_707B
@@ -7185,9 +7185,9 @@ label_70B1::
 
 IntroLinkFaceHandler::
     call RenderRain
-    ld   a, [WR0_IntroTimer]
+    ld   a, [wIntroTimer]
     inc  a
-    ld   [WR0_IntroTimer], a
+    ld   [wIntroTimer], a
     cp   128
     jr   nz, .continue
     ; If IntroTimer == 128 frames
@@ -7208,7 +7208,7 @@ IntroLinkFaceHandler::
     ; If FrameCounter == 160 frames
     ; Move back to sea sequence
     ld   a, GAMEPLAY_INTRO_SEA
-    ld   [WR1_GameplaySubtype], a 
+    ld   [wGameplaySubtype], a
     ld   a, [hIsGBC]
     and  a
     jr   z, .notGBC
@@ -7224,10 +7224,10 @@ IntroLinkFaceHandler::
     ld   a, $03
     ld   [rIE], a ; Enable interrupts on VBlank and LCDStat
     xor  a
-    ld   [WR0_EntitiesTypeTable], a
+    ld   [wEntitiesTypeTable], a
     ld   [$C281], a
     ld   a, $01
-    ld   [WR0_IntroSubTimer], a
+    ld   [wIntroSubTimer], a
     ret
 
 .continue4
@@ -7291,9 +7291,9 @@ label_7168::
     ld   [$D001], a
     jr   nz, label_7188
     ld   a, $07
-    ld   [WR1_GameplaySubtype], a
+    ld   [wGameplaySubtype], a
     ld   a, $06
-    ld   [WR0_EntitiesTypeTable], a
+    ld   [wEntitiesTypeTable], a
     ld   a, $B0
     ld   [$C200], a
     ld   a, $68
@@ -7324,11 +7324,11 @@ label_719B::
     ld   hl, label_7128
     add  hl, de
     ld   a, [hl]
-    ld   [WR1_BGPalette], a
+    ld   [wBGPalette], a
     ld   hl, label_7138
     add  hl, de
     ld   a, [hl]
-    ld   [WR1_OBJ0Palette], a
+    ld   [wOBJ0Palette], a
     ld   hl, label_7148
     add  hl, de
     ld   a, [hl]
@@ -7641,9 +7641,9 @@ label_7395::
 
 ResetIntroTimers::
     ld   a, $A0
-    ld   [WR0_IntroTimer], a
+    ld   [wIntroTimer], a
     xor  a
-    ld   [WR0_IntroSubTimer], a
+    ld   [wIntroSubTimer], a
     ld   a, $FF
     ld   [$D003], a
     ret
@@ -7684,7 +7684,7 @@ TitleScreenHandler::
     ld   d, $00
 
 label_73E0::
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
     add  hl, de
     ld   a, [hl]
     and  a
@@ -7754,11 +7754,11 @@ label_7447::
     ld   a, $11
     ld   [$D6FE], a
     ld   a, $0B
-    ld   [WR1_GameplaySubtype], a
+    ld   [wGameplaySubtype], a
     ld   a, $C9
-    ld   [WR1_BGPalette], a
+    ld   [wBGPalette], a
     ld   a, $1C
-    ld   [WR1_OBJ0Palette], a
+    ld   [wOBJ0Palette], a
     xor  a
     ld   [hBaseScrollX], a
     ld   [$FF97], a
@@ -7777,8 +7777,8 @@ RenderRain::
     ld   [$FFD7], a
     ld   hl, $C04C
     ; On the sea, limit the rain to the top section of the screen ($10)
-    ld   c, $10  
-    ld   a, [WR1_GameplaySubtype]
+    ld   c, $10
+    ld   a, [wGameplaySubtype]
     cp   GAMEPLAY_INTRO_LINK_FACE ; if GameplaySubtype != LINK_FACE
     jr   nz, .loop
     ; On Link's face, the rain covers all the $15 rows of the screen
@@ -7792,7 +7792,7 @@ RenderRain::
     call GetRandomByte
     and  $01       ; if random(0,1) == 0
     ld   a, $28
-    jr   z, .next  ;   jump to next   
+    jr   z, .next  ;   jump to next
     call GetRandomByte
     and  $06
     add  a, $70
@@ -7841,16 +7841,16 @@ RenderIntroEntities::
 .loop
     ld   a, c
     ld   [$C123], a
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
     add  hl, bc
     ld   a, [hl]
     and  a
     jr   z, .continue ; If no entity at this table index, continue
-    ld   hl, WR0_EntitiesPosXTable
+    ld   hl, wEntitiesPosXTable
     add  hl, bc
     ld   a, [hl]
     ld   [$FFEE], a ; EntityOffsetX?
-    ld   hl, WR0_EntitiesPosYTable
+    ld   hl, wEntitiesPosYTable
     add  hl, bc
     ld   a, [hl]
     ld   [$FFEC], a ; EntityOffsetY?
@@ -7873,7 +7873,7 @@ RenderIntroEntities::
 ; Inputs:
 ;   bc: index of entity in entities table
 RenderIntroEntity::
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
     add  hl, bc
     ld   a, [hl]
     cp   ENTITY_INTRO_SHIP
@@ -7886,7 +7886,7 @@ RenderIntroEntity::
     jp   z, RenderIntroSparkle
     call label_C05
     jr   nz, label_7533
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
     add  hl, bc
     ld   [hl], b
     ret
@@ -7912,7 +7912,7 @@ ShipHeaveTable::
     db 2, 1, 0, 0, 0, 1, 2, 2
 
 RenderIntroShip::
-    ld   a, [WR0_IntroSubTimer]
+    ld   a, [wIntroSubTimer]
     and  a
     ld   a, $00
     jr   nz, .skip
@@ -7957,7 +7957,7 @@ RenderIntroShip::
     dec  c
     jr   nz, .loop
 
-    ld   a, [WR0_IntroSubTimer]
+    ld   a, [wIntroSubTimer]
     cp   $10
     jr   c, .return
     ld   hl, data_7550
@@ -8013,7 +8013,7 @@ label_7629::
     ld   l, $01
 
 label_762B::
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
     add  hl, bc
     ld   a, [hl]
     dec  a
@@ -8267,7 +8267,7 @@ label_77E1::
     call label_C05
     dec  [hl]
     jr   nz, label_77ED
-    ld   hl, WR0_EntitiesTypeTable
+    ld   hl, wEntitiesTypeTable
     add  hl, bc
     ld   [hl], b
     ret
@@ -8469,7 +8469,7 @@ label_79AE::
     ld   hl, label_7898
     add  hl, bc
     ld   a, [hl]
-    ld   [WR1_OBJ0Palette], a
+    ld   [wOBJ0Palette], a
     ld   hl, label_789C
     add  hl, bc
     ld   a, [hl]
@@ -8674,7 +8674,7 @@ label_7AB3::
     ld   [$D002], a
     ld   [$D003], a
     ld   [$D004], a
-    ld   [WR0_EntitiesTypeTable], a
+    ld   [wEntitiesTypeTable], a
     ld   [$C281], a
 
 label_7AE3::
@@ -8829,7 +8829,7 @@ IntroBGVerticalOffsetTable::
     db 3, 2, 1, 0, 0, 1, 2, 3
 
 label_7D01::
-    ld   hl, WR0_ScrollXOffsetForSection
+    ld   hl, wScrollXOffsetForSection
     ld   a, [hFrameCounter]
     and  $07
     jr   nz, label_7D0B
@@ -8878,7 +8878,7 @@ label_7D2F::
     add  hl, de
     ld   a, $00
     sub  a, [hl]
-    ld   [WR0_IntroBGYOffset], a
+    ld   [wIntroBGYOffset], a
 
 label_7D46::
     ld   a, [hFrameCounter]
@@ -8939,7 +8939,7 @@ label_7D9B::
     ret
 
 label_7D9C::
-    ld   hl, WR0_ScrollXOffsetForSection
+    ld   hl, wScrollXOffsetForSection
     ld   a, [hFrameCounter]
     and  $07
     jr   nz, label_7DA6
@@ -8973,7 +8973,7 @@ label_7DCC::
     jp   label_7D46
 
 label_7DCF::
-    ld   hl, WR0_ScrollXOffsetForSection
+    ld   hl, wScrollXOffsetForSection
     ld   a, [hFrameCounter]
     and  $0F
     jr   nz, label_7DD9

--- a/src/code/bank3.asm
+++ b/src/code/bank3.asm
@@ -4130,7 +4130,7 @@ label_E367::
 
 label_E36D::
     call label_D12A
-    ld   hl, WR1_SeashellsCount
+    ld   hl, wSeashellsCount
 
 label_E373::
     ld   a, [hl]

--- a/src/constants/gameplay.asm
+++ b/src/constants/gameplay.asm
@@ -4,7 +4,7 @@
 TILES_PER_ROW              equ $0B
 TILES_PER_MAP              equ $80
 
-; Values for WR1_GameplayType
+; Values for wGameplayType
 GAMEPLAY_INTRO             equ $00
 GAMEPLAY_CREDITS           equ $01
 GAMEPLAY_FILE_SELECT       equ $02
@@ -33,7 +33,7 @@ GAMEPLAY_PHOTO_KANALET     equ $18
 GAMEPLAY_PHOTO_GHOST       equ $19
 GAMEPLAY_PHOTO_BRIDGE      equ $20
 
-; Values for WR1_GameplaySubtype
+; Values for wGameplaySubtype
 ; (depends on the gameplay type)
 ; GAMEPLAY_INTRO Subtype
 GAMEPLAY_INTRO_SEA         equ $03
@@ -63,7 +63,7 @@ ENTITY_INTRO_MARIN         equ $06
 ENTITY_INTRO_INERT_LINK    equ $07
 ENTITY_INTRO_SPARKLE       equ $08
 
-; Values for WR0_DialogState
+; Values for wDialogState
 DIALOG_CLOSED              equ $00
 DIALOG_OPENING_1           equ $01
 DIALOG_OPENING_2           equ $02
@@ -81,7 +81,7 @@ DIALOG_CHOICE              equ $0D ; press A to choose
 DIALOG_CLOSING_1           equ $0E
 DIALOG_CLOSING_2           equ $0F
 
-; Values for WR0_WarpTransition
+; Values for wWarpTransition
 WARP_TRANSITION_DREAM_SHRINE equ $01 ; wavy transition when sleeping in the Dream Shrine
 WARP_TRANSITION_MANBO_IN     equ $02 ; wavy transition when departing using Manbo's Mambo
 WARP_TRANSITION_MANBO_OUT    equ $03 ; wavy transition when arriving using Manbo's Mambo

--- a/src/constants/wram.asm
+++ b/src/constants/wram.asm
@@ -77,7 +77,7 @@ WR0_ScreenShakeVertical:: ; C156
 WR0_C157 equ $C157
   ds $3
 
-WR0_ShieldLevel:: ; C15A
+WR0_HasMirrorShield:: ; C15A
   ds 1
 
 WR0_IsUsingShield:: ; C15B

--- a/src/constants/wram.asm
+++ b/src/constants/wram.asm
@@ -1,428 +1,623 @@
-label_C000 equ $C000
-label_C008 equ $C008
-label_C010 equ $C010
-label_C030 equ $C030
-WR0_ScrollXOffsetForSection equ $C100 ; Table of the scrollX offset to add for each screen section being drawn
-WR0_LCDSectionIndex         equ $C105 ; Portion of the screen being drawn (0 -> 4)
-WR0_IntroBGYOffset          equ $C106 ; Offset for compensating the sea movement when drawing bottom screen section on intro sea
-label_C108 equ $C108
-label_C10B equ $C10B
-label_C10D equ $C10D
-WR0_needsUpdatingNPCTiles   equ $C10E
-label_C10F equ $C10F
-label_C111 equ $C111
-label_C112 equ $C112
-label_C113 equ $C113
-label_C117 equ $C117
-label_C11A equ $C11A
-label_C11C equ $C11C
-label_C11D equ $C11D
-label_C11E equ $C11E
-label_C120 equ $C120 ; link animation state?
-label_C121 equ $C121
-label_C122 equ $C122
-label_C123 equ $C123
-WR0_MapSlideTransitionState equ $C124
-label_C125 equ $C125
-label_C127 equ $C127
-label_C128 equ $C128
-label_C12E equ $C12E
-label_C12F equ $C12F
-label_C130 equ $C130
-label_C134 equ $C134
-label_C136 equ $C136
-label_C137 equ $C137
-label_C138 equ $C138
-label_C139 equ $C139
-label_C13A equ $C13A
-label_C13B equ $C13B
-label_C13C equ $C13C
-WR0_RandomSeed              equ $C13D
-label_C140 equ $C140
-label_C142 equ $C142
-label_C144 equ $C144 ; Link sprite status (like is pushing something) ?
-label_C145 equ $C145
-label_C146 equ $C146
-label_C149 equ $C149
-label_C14A equ $C14A
-label_C14B equ $C14B
-label_C14C equ $C14C
-label_C14D equ $C14D
-label_C14E equ $C14E
-WR0_InventoryAppearing      equ $C14F
-label_C152 equ $C152
-label_C153 equ $C153
-WR0_ScreenShakeHorizontal   equ $C155 ; background offset for shaking the screen vertically
-WR0_ScreenShakeVertical     equ $C156 ; background offset for shaking the screen vertically
-label_C157 equ $C157
-label_C15A equ $C15A
-label_C15B equ $C15B
-label_C15C equ $C15C
-label_C15D equ $C15D
-label_C15F equ $C15F
-label_C160 equ $C160
-label_C164 equ $C164
-label_C165 equ $C165
-label_C167 equ $C167
-label_C16A equ $C16A
-WR0_TransitionSequenceCounter equ $C16B ; ?
-label_C16C equ $C16C
-label_C16D equ $C16D
-label_C16F equ $C16F
-label_C170 equ $C170
-label_C171 equ $C171
-WR0_DialogScrollDelay       equ $C172
-label_C173 equ $C173
-label_C175 equ $C175
-label_C176 equ $C176
-label_C177 equ $C177
-WR0_FreeMovementMode        equ $C17B ; See https://tcrf.net/The_Legend_of_Zelda:_Link%27s_Awakening#Mono_Pausing_the_Engine_and_Mono.2FDX_Free-Movement_Mode
-WR0_WarpTransition          equ $C17F ; See WARP_TRANSITION_* constants for possible values
-label_C180 equ $C180
-label_C181 equ $C181
-label_C18A equ $C18A
-label_C18B equ $C18B
-label_C18E equ $C18E
-label_C18F equ $C18F
-label_C193 equ $C193
-label_C197 equ $C197
-label_C19B equ $C19B
-label_C19C equ $C19C
-label_C19D equ $C19D
-WR0_DialogState             equ $C19F ; See DIALOG_* constants for possible values
-label_C1A4 equ $C1A4
-label_C1A5 equ $C1A5
-label_C1A8 equ $C1A8
-label_C1A9 equ $C1A9
-label_C1AA equ $C1AA
-label_C1AB equ $C1AB
-label_C1AC equ $C1AC
-label_C1AD equ $C1AD
-label_C1BC equ $C1BC
-label_C1BD equ $C1BD
-label_C1BF equ $C1BF
-label_C1C0 equ $C1C0
-label_C1C1 equ $C1C1
-label_C1C2 equ $C1C2
-label_C1C4 equ $C1C4
-label_C1C7 equ $C1C7
-label_C1C8 equ $C1C8
-label_C1CC equ $C1CC
-label_C1CF equ $C1CF
-label_C1D0 equ $C1D0
-label_C1E0 equ $C1E0
-label_C1F0 equ $C1F0
-WR0_EntitiesPosXTable       equ $C200 ; X position of visible entities
-WR0_EntitiesPosYTable       equ $C210 ; Y position of visible entities
-label_C220 equ $C220
-label_C230 equ $C230
-label_C240 equ $C240
-label_C250 equ $C250
-WR0_EntitiesTypeTable       equ $C280 ; type of visible entities
-label_C290 equ $C290
-label_C2A0 equ $C2A0
-label_C2E0 equ $C2E0
-label_C2F0 equ $C2F0
-label_C310 equ $C310
-label_C320 equ $C320
-label_C380 equ $C380
-label_C3A0 equ $C3A0
-label_C3B0 equ $C3B0
-label_C3C0 equ $C3C0
-label_C3C1 equ $C3C1
-label_C3C3 equ $C3C3
-label_C3C9 equ $C3C9
-label_C3CA equ $C3CA
-label_C3CB equ $C3CB
-label_C3CC equ $C3CC
-label_C3CD equ $C3CD
-label_C3CF equ $C3CF
-label_C3F0 equ $C3F0
-label_C400 equ $C400
-label_C410 equ $C410
-label_C430 equ $C430
-label_C450 equ $C450
-label_C460 equ $C460
-label_C4A0 equ $C4A0
-label_C4F0 equ $C4F0
-label_C500 equ $C500
-label_C502 equ $C502
-label_C509 equ $C509
-label_C50A equ $C50A
-label_C50E equ $C50E
-label_C510 equ $C510
-label_C520 equ $C520
-label_C530 equ $C530
-label_C540 equ $C540
-label_C5A6 equ $C5A6
-label_C5A7 equ $C5A7
-label_C5A9 equ $C5A9
-label_C5AB equ $C5AB
-label_C5B0 equ $C5B0
-label_C5C0 equ $C5C0
-label_C5D0 equ $C5D0
-label_CF00 equ $CF00
+section "WRAM Bank0", wram0
 
-WR0_IsUsingSpinAttack equ $C121
-WR0_IsShootingArrow   equ $C14C
-WR0_ProjectileCount   equ $C14D
-WR0_HasPlacedBomb     equ $C14E
-WR0_ShieldLevel       equ $C15A
-WR0_IsUsingShield     equ $C15B
+WR0_C000 equ $C000
+  ds $100
 
-label_D000 equ $D000
-WR0_IntroTimer        equ $D001
-WR0_IntroSubTimer     equ $D002
-label_D006 equ $D006
-label_D007 equ $D007
-label_D008 equ $D008
-label_D009 equ $D009
-;label_D16A equ $D16A
-; Overworld Music Track
-; 00: No music
-; 01: Title music when zelda logo appears
-; 02: Trendy game/Witch hut
-; 03: Game Over screen
-; 04: Mabe Village
-; 05: Overworld music
-; 06: Tal Tal Heights
-; 07: Village Shop
-; 08: Raft Ride Rapids
-; 09: Mysterious Forest
-; 0A: Home/trader house
-; 0B: Animal Village
-; 0C: Fairy House
-; 0D: Title music
-; 0E: BowWow kidnapped music
-; 0F: Found level 2 sword
-; 10: Found new weapon
-; 11: 2D underground dungeon
-; 12: Owl song
-; 13: Final Knightmare in Egg song
-; 14: Dream Shrine Entrance music
-; 15: Found an instrument
-; 16: Overworld cave
-; 17: Piece of Power/Acorn
-; 18: Received horn instrument
-; 19: Received bell instrument
-; 1A: Received harp instrument
-; 1B: Received xylophone instrument
-; 1C: Received ?? instrument
-; 1D: Received ?? instrument
-; 1E: Received thunder drum instrument
-; 1F: Marin singing
-; 20: Manbo's Mambo fish song
-; 21: Received ?? instrument
-; 22: Instruments song ??
-; 23: Instruments song ??
-; 24: Instruments song ??
-; 25: Instruments song when opening Egg
-; 26: Instruments song when opening Egg part 2
-; 27: Instruments song ??
-; 28: Lonely/ghost house
-; 29: Piece of Power part 2
-; 2A: Marin singing + Links ocarina
-; 2B: Level 5
-; 2C: Dungeon entrance Unlocking
-; 2D: Dream sequence sound?
-; 2E: At beach with Marin song
-; 2F: Unknown
-; 30: Dungeon sub-boss music
-; 31: Received level 1 sword at beach
-; 32: Mr Write's house
-; 33: Ulrira's house
-; 34: Tarin attacked by Bee's
-; 35: Song of Soul by Mamu frogs
-; 36: Monkey's building bridge
-; 37: Mr Write's house version 2
-; 38: Richard House Secret Song
-; 39: Turtle Rock entrance boss
-; 3A: Fishing/crane game
-; 3B: Received item
-; 3C: Hidden/Unused song!?
-; 3D: Nothing
-; 3E: BowWow stolen music
-; 3F: Ending music
-; 40: Richard's House
-; 41: Glitched noise, possibly unfinished song or Sound effect
-; 42: Glitched noise, possibly unfinished song or Sound effect
-; 43: Glitched noise, possibly unfinished song or Sound effect
-; 44: Glitchy music
-; 45: Glitchy music
-; 46: Glitchy music
-; 47: Silence
-; 48: Silence
-; 49: Glitchy noise
-; 4A: Silence
-; 4B: Glitchy music
-; 4C: Glitchy music
-; 4D: - 4F Silence
-; 50: - 57 Silence
-; 58: Glitchy music
-; 59: Silence
-; 5A: Glitchy music
-; 5B: Silence
-; 5C: Silence
-; 5D: Glitchy music
-; 5E: Silence
-; 5F: Silence
-; 60: Silence
-; 61: - 69 Color dungeon (DX only)
-; 6A: - F9 Untested
-; F0: Glitched music
-; FF: Nothing
-WR1_OverworldMusic          equ $D368
-label_D401 equ $D401
-WR1_KillCount               equ $D415
-label_D416 equ $D416
-label_D45F equ $D45F
-label_D463 equ $D463
-label_D464 equ $D464
-label_D473 equ $D473
-label_D474 equ $D474
-label_D478 equ $D478
-label_D47C equ $D47C
-WR1_DidStealItem            equ $D47E
-label_D47F equ $D47F
-label_D580 equ $D580
-label_D600 equ $D600
-label_D601 equ $D601
-label_D602 equ $D602
-label_D603 equ $D603
-label_D604 equ $D604
-label_D605 equ $D605
-label_D6F8 equ $D6F8
-label_D6FA equ $D6FA
-label_D6FB equ $D6FB
-WR1_EnginePaused            equ $D6FC
-WR1_LCDControl              equ $D6FD
-label_D6FE equ $D6FE
-label_D6FF equ $D6FF
-WR1_TileMap                 equ $D711
+WR0_ScrollXOffsetForSection:: ; C100
+  ; Table of the scrollX offset to add for each screen section being drawn
+  ds $5
+
+WR0_LCDSectionIndex:: ; C105
+  ; Portion of the screen being drawn (0 -> 4)
+  ds 1
+
+WR0_IntroBGYOffset:: ; C106
+  ; Offset for compensating the sea movement when drawing bottom screen section on intro sea
+  ds 1
+
+; Unlabeled
+WR0_C108 equ $C108
+
+  ds 7
+
+WR0_needsUpdatingNPCTiles:: ; C10E
+  ds 1
+
+; Unlabeled
+WR0_C10F equ $C10F
+  ds $12
+
+WR0_IsUsingSpinAttack:: ; C121
+  ds 1
+
+; Unlabeled
+WR0_C122 equ $C122
+  ds 2
+
+WR0_MapSlideTransitionState:: ; C124
+  ds 1
+
+; Unlabeled
+WR0_C125 equ $C125
+  ds $18
+
+WR0_RandomSeed:: ; C13D
+  ; Seed for the Random Number Generator
+  ds 1
+
+; Unlabeled
+WR0_C140 equ $C13E
+  ds $E
+
+WR0_IsShootingArrow:: ; C14C
+  ds 1
+
+WR0_ProjectileCount:: ; C14D
+  ds 1
+
+WR0_HasPlacedBomb:: ; C14E
+  ds 1
+
+WR0_InventoryAppearing:: ; C14F
+  ds 1
+
+; Unlabeled
+WR0_C150 equ $C150
+  ds 5
+
+WR0_ScreenShakeHorizontal:: ; C155
+  ; background offset for shaking the screen vertically
+  ds 1
+
+WR0_ScreenShakeVertical:: ; C156
+  ; background offset for shaking the screen vertically
+  ds 1
+
+; Unlabeled
+WR0_C157 equ $C157
+  ds $3
+
+WR0_ShieldLevel:: ; C15A
+  ds 1
+
+WR0_IsUsingShield:: ; C15B
+  ds 1
+
+; Unlabeled
+WR0_C15C equ $C15C
+  ds $F
+
+WR0_TransitionSequenceCounter:: ; C16B
+  ds 1
+
+; Unlabeled
+WR0_C16C equ $C16C
+  ds 6
+
+WR0_DialogScrollDelay:: ; C172
+  ds 1
+
+; Unlabeled
+WR0_C173 equ $C173
+  ds 8
+
+WR0_FreeMovementMode:: ; C17B
+  ; See https://tcrf.net/The_Legend_of_Zelda:_Link%27s_Awakening#Mono_Pausing_the_Engine_and_Mono.2FDX_Free-Movement_Mode
+  ds 1
+
+; Unlabeled
+WR0_C17C equ $C17C
+  ds 3
+
+WR0_WarpTransition:: ; C17F
+  ; See WARP_TRANSITION_* constants for possible values
+  ds 1
+
+; Unlabeled
+WR0_C180 equ $C180
+  ds $1F
+
+WR0_DialogState:: ; C19F
+  ; See DIALOG_* constants for possible values
+  ds 1
+
+WR0_C1A4 equ $C1A0
+  ds $60
+
+WR0_EntitiesPosXTable:: ; C200
+  ; X position of visible entities
+
+WR0_Entity0PosX:: ; C200
+  ds $1
+
+WR0_Entity1PosX:: ; C201
+  ds $1
+
+WR0_Entity2PosX:: ; C202
+
+WR0_IntroShipPosX:: ; C202
+  ; Position of the ship sprite during the intro sequence
+  ds $1
+
+WR0_Entity3PosX:: ; C203
+  ds $1
+
+WR0_Entity4PosX:: ; C204
+  ds $1
+
+WR0_Entity5PosX:: ; C205
+  ds $1
+
+WR0_Entity6PosX:: ; C206
+  ds $1
+
+WR0_Entity7PosX:: ; C207
+  ds $1
+
+WR0_Entity8PosX:: ; C208
+  ds $1
+
+WR0_Entity9PosX:: ; C209
+  ds $1
+
+WR0_Entity10PosX:: ; C20A
+  ds $1
+
+WR0_Entity11PosX:: ; C20B
+  ds $1
+
+WR0_Entity12PosX:: ; C20C
+  ds $1
+
+WR0_Entity13PosX:: ; C20D
+  ds $1
+
+WR0_Entity14PosX:: ; C20E
+  ds $1
+
+WR0_Entity15PosX:: ; C20F
+  ds $1
+
+WR0_EntitiesPosYTable:: ; C210
+  ; Y position of visible entities
+  ds $10
+
+; Unlabeled
+WR0_C220 equ $C220
+  ds $60
+
+WR0_EntitiesTypeTable:: ; C280
+  ; type of visible entities
+  ds 1
+
+section "WRAM Bank1", wramx, bank[1]
+
+; Unlabeled
+WR0_D000 equ $D000
+  ds 1
+
+WR0_IntroTimer:: ; D001
+  ds 1
+
+WR0_IntroSubTimer:: ; D002
+  ds 1
+
+; Unlabeled
+WR0_D003 equ $D003
+  ds $365
+
+WR1_OverworldMusic:: ; D368
+  ; Overworld Music Track
+  ; 00: No music
+  ; 01: Title music when zelda logo appears
+  ; 02: Trendy game/Witch hut
+  ; 03: Game Over screen
+  ; 04: Mabe Village
+  ; 05: Overworld music
+  ; 06: Tal Tal Heights
+  ; 07: Village Shop
+  ; 08: Raft Ride Rapids
+  ; 09: Mysterious Forest
+  ; 0A: Home/trader house
+  ; 0B: Animal Village
+  ; 0C: Fairy House
+  ; 0D: Title music
+  ; 0E: BowWow kidnapped music
+  ; 0F: Found level 2 sword
+  ; 10: Found new weapon
+  ; 11: 2D underground dungeon
+  ; 12: Owl song
+  ; 13: Final Knightmare in Egg song
+  ; 14: Dream Shrine Entrance music
+  ; 15: Found an instrument
+  ; 16: Overworld cave
+  ; 17: Piece of Power/Acorn
+  ; 18: Received horn instrument
+  ; 19: Received bell instrument
+  ; 1A: Received harp instrument
+  ; 1B: Received xylophone instrument
+  ; 1C: Received ?? instrument
+  ; 1D: Received ?? instrument
+  ; 1E: Received thunder drum instrument
+  ; 1F: Marin singing
+  ; 20: Manbo's Mambo fish song
+  ; 21: Received ?? instrument
+  ; 22: Instruments song ??
+  ; 23: Instruments song ??
+  ; 24: Instruments song ??
+  ; 25: Instruments song when opening Egg
+  ; 26: Instruments song when opening Egg part 2
+  ; 27: Instruments song ??
+  ; 28: Lonely/ghost house
+  ; 29: Piece of Power part 2
+  ; 2A: Marin singing + Links ocarina
+  ; 2B: Level 5
+  ; 2C: Dungeon entrance Unlocking
+  ; 2D: Dream sequence sound?
+  ; 2E: At beach with Marin song
+  ; 2F: Unknown
+  ; 30: Dungeon sub-boss music
+  ; 31: Received level 1 sword at beach
+  ; 32: Mr Write's house
+  ; 33: Ulrira's house
+  ; 34: Tarin attacked by Bee's
+  ; 35: Song of Soul by Mamu frogs
+  ; 36: Monkey's building bridge
+  ; 37: Mr Write's house version 2
+  ; 38: Richard House Secret Song
+  ; 39: Turtle Rock entrance boss
+  ; 3A: Fishing/crane game
+  ; 3B: Received item
+  ; 3C: Hidden/Unused song!?
+  ; 3D: Nothing
+  ; 3E: BowWow stolen music
+  ; 3F: Ending music
+  ; 40: Richard's House
+  ; 41: Glitched noise, possibly unfinished song or Sound effect
+  ; 42: Glitched noise, possibly unfinished song or Sound effect
+  ; 43: Glitched noise, possibly unfinished song or Sound effect
+  ; 44: Glitchy music
+  ; 45: Glitchy music
+  ; 46: Glitchy music
+  ; 47: Silence
+  ; 48: Silence
+  ; 49: Glitchy noise
+  ; 4A: Silence
+  ; 4B: Glitchy music
+  ; 4C: Glitchy music
+  ; 4D: - 4F Silence
+  ; 50: - 57 Silence
+  ; 58: Glitchy music
+  ; 59: Silence
+  ; 5A: Glitchy music
+  ; 5B: Silence
+  ; 5C: Silence
+  ; 5D: Glitchy music
+  ; 5E: Silence
+  ; 5F: Silence
+  ; 60: Silence
+  ; 61: - 69 Color dungeon (DX only)
+  ; 6A: - F9 Untested
+  ; F0: Glitched music
+  ; FF: Nothing
+  ds 1
+
+; Unlabeled
+WR1_D369 equ $D369
+  ds $AC
+
+WR1_KillCount:: ; D415
+  ds 1
+
+; Unlabeled
+WR0_D416 equ $D416
+  ds $68
+
+WR1_DidStealItem:: ; D47E
+  ds 1
+
+; Unlabeled
+WR0_D47F equ $D47F
+  ds $27D
+
+WR1_EnginePaused:: ; D6FC
+  ds 1
+
+WR1_LCDControl:: ; D6FD
+  ds 1
+
+; Unlabeled
+WR0_D6FE equ $D6FE
+  ds $13
+
+WR1_TileMap:: ; D711
+  ds 1
+
+; Unlabeled
+WR0_D712 equ $D712
+  ds $EE
+
 ; Minimap Tile
-; $D800 -> $D8FF
 ; Values:
 ;   0:     not discovered yet
 ;   non-0: various statuses
-WR1_MinimapTiles            equ $D800
-label_D900 equ $D900
-label_DA00 equ $DA00
-WR1_AButtonSlot             equ $DB00
-WR1_BButtonSlot             equ $DB01
-WR1_InventoryItem1          equ $DB02
-WR1_InventoryItem2          equ $DB03
-WR1_InventoryItem3          equ $DB04
-WR1_InventoryItem4          equ $DB05
-WR1_InventoryItem5          equ $DB06
-WR1_InventoryItem6          equ $DB07
-WR1_InventoryItem7          equ $DB08
-WR1_InventoryItem8          equ $DB09
-WR1_InventoryItem9          equ $DB0A
-WR1_InventoryItem10         equ $DB0B
-WR1_HasFlippers             equ $DB0C
-WR1_HasMedicine             equ $DB0D
-; Trade Sequence items:
-; $00 Nothing
-; $01 Yoshi Doll
-; $02 Ribbon
-; $03 Dog Food
-; $04 Bananas
-; $05 Stick
-; $06 Honeycomb
-; $07 Pineapple
-; $08 Hibiscus
-; $09 Letter
-; $0A Broom
-; $0B Fishing Hook
-; $0C Necklace
-; $0D Scale
-; $0E Magnifying glass
-WR1_TradeSequenceItem       equ $DB0E
-WR1_SeashellsCount          equ $DB0F
-label_DB10 equ $DB10
-WR1_HasTailKey              equ $DB11
-WR1_HasAnglerKey            equ $DB12
-WR1_HasFaceKey              equ $DB13
-WR1_HasBirdKey              equ $DB14
+WR1_MinimapTiles:: ; D800
+  ds $ff
+
+; Unlabeled
+WR0_D900 equ $D900
+  ds $201
+
+WR1_AButtonSlot:: ; DB00
+  ds 1
+
+WR1_BButtonSlot:: ; DB01
+  ds 1
+
+WR1_InventoryItem1:: ; DB02
+  ds 1
+
+WR1_InventoryItem2:: ; DB03
+  ds 1
+
+WR1_InventoryItem3:: ; DB04
+  ds 1
+
+WR1_InventoryItem4:: ; DB05
+  ds 1
+
+WR1_InventoryItem5:: ; DB06
+  ds 1
+
+WR1_InventoryItem6:: ; DB07
+  ds 1
+
+WR1_InventoryItem7:: ; DB08
+  ds 1
+
+WR1_InventoryItem8:: ; DB09
+  ds 1
+
+WR1_InventoryItem9:: ; DB0A
+  ds 1
+
+WR1_InventoryItem10:: ; DB0B
+  ds 1
+
+WR1_HasFlippers:: ; DB0C
+  ds 1
+
+WR1_HasMedicine:: ; DB0D
+  ds 1
+
+WR1_TradeSequenceItem:: ; DB0E
+  ; Trade Sequence items:
+  ; $00 Nothing
+  ; $01 Yoshi Doll
+  ; $02 Ribbon
+  ; $03 Dog Food
+  ; $04 Bananas
+  ; $05 Stick
+  ; $06 Honeycomb
+  ; $07 Pineapple
+  ; $08 Hibiscus
+  ; $09 Letter
+  ; $0A Broom
+  ; $0B Fishing Hook
+  ; $0C Necklace
+  ; $0D Scale
+  ; $0E Magnifying glass
+  ds 1
+
+WR1_SeashellsCount:: ; DB0F
+  ds 1
+
+; Unlabeled
+WR0_DB10 equ $DB10
+  ds 1
+
+WR1_HasTailKey:: ; DB11
+  ds 1
+
+WR1_HasAnglerKey:: ; DB12
+  ds 1
+
+WR1_HasFaceKey:: ; DB13
+  ds 1
+
+WR1_HasBirdKey:: ; DB14
+  ds 1
+
 ; Golden Leaves count
 ; 0-5: number of Golden Leaves
 ; 6  : Slime Key
-WR1_GoldenLeavesCount       equ $DB15
-WR1_ShieldLevel             equ $DB44
-WR1_ArrowCount              equ $DB45
-label_DB46                  equ $DB46
-label_DB49                  equ $DB49
-label_DB4B                  equ $DB4B
-label_DB4C                  equ $DB4C
-WR1_BombCount               equ $DB4D
-WR1_MarinAndTarinAtHome     equ $DB4E
-label_DB4F                  equ $DB4F
-WR1_IsBowWowFollowingLink   equ $DB56
-label_DB5A                  equ $DB5A
-label_DB5F                  equ $DB5F
-WR1_HasInstrument1          equ $DB65  ; 0: false, 2: true
-WR1_HasInstrument2          equ $DB66  ; 0: false, 2: true
-WR1_HasInstrument3          equ $DB67  ; 0: false, 2: true
-WR1_HasInstrument4          equ $DB68  ; 0: false, 2: true
-WR1_HasInstrument5          equ $DB69  ; 0: false, 2: true
-WR1_HasInstrument6          equ $DB6A  ; 0: false, 2: true
-WR1_HasInstrument7          equ $DB6B  ; 0: false, 2: true
-WR1_HasInstrument8          equ $DB6C  ; 0: false, 2: true
-label_DB6E                  equ $DB6E
-label_DB6F                  equ $DB6F
-label_DB70                  equ $DB70
-label_DB71                  equ $DB71
-WR1_IsMarinFollowingLink    equ $DB73
-WR1_IsGhostFollowingLink    equ $DB79
-WR1_IsRoosterFollowingLink  equ $DB7B
-WR1_GameplayType            equ $DB95 ; See GAMEPLAY_* constants for possible values
-WR1_GameplaySubtype         equ $DB96 ; Value depens on GameplayType: this can be a sequence index, or a frame counter.
-WR1_BGPalette               equ $DB97
-WR1_OBJ0Palette             equ $DB98
-WR1_OBJ1Palette             equ $DB99
-WR1_WindowY                 equ $DB9A
-label_DB9D equ $DB9D
-label_DB9E equ $DB9E
-label_DBA5 equ $DBA5 ; current room?
-WR1_SaveSlot                equ $DBA6
-label_DBAE equ $DBAE
-WR1_CurrentBank             equ $DBAF
-label_DBB6 equ $DBB6
-label_DBC7 equ $DBC7
-label_DBC8 equ $DBC8 ; link position after room transition?
-label_DBC9 equ $DBC9
-WR1_HasDungeonMap           equ $DBCC
-WR1_HasDungeonCompass       equ $DBCD
-WR1_HasDungeonStoneSlab     equ $DBCE
-WR1_HasDungeonBossKey       equ $DBCF
+WR1_GoldenLeavesCount:: ; DB15
+  ds 1
+
+; Unlabeled
+WR0_DB16 equ $DB16
+  ds $2E
+
+WR1_ShieldLevel:: ; DB44
+  ds 1
+
+WR1_ArrowCount:: ; DB45
+  ds 1
+
+; Unlabeled
+WR0_DB46 equ $DB46
+  ds 7
+
+WR1_BombCount:: ; DB4D
+  ds 1
+
+WR1_MarinAndTarinAtHome:: ; DB4E
+  ds 1
+
+; Unlabeled
+WR0_DB4F equ $DB4F
+  ds 7
+
+WR1_IsBowWowFollowingLink:: ; DB56
+  ds 1
+
+; Unlabeled
+WR0_DB57 equ $DB57
+  ds $6
+
+WR1_RupeeCountHigh:: ; DB5D
+  ds 1
+
+WR1_RupeeCountLow:: ; DB5E
+  ds 1
+
+; Unlabeled
+WR0_DB5F equ $DB5F
+  ds $6
+
+WR1_HasInstrument1:: ; DB65
+  ; 0: false, 2: true
+  ds 1
+
+WR1_HasInstrument2:: ; DB66
+  ; 0: false, 2: true
+  ds 1
+
+WR1_HasInstrument3:: ; DB67
+  ; 0: false, 2: true
+  ds 1
+
+WR1_HasInstrument4:: ; DB68
+  ; 0: false, 2: true
+  ds 1
+
+WR1_HasInstrument5:: ; DB69
+  ; 0: false, 2: true
+  ds 1
+
+WR1_HasInstrument6:: ; DB6A
+  ; 0: false, 2: true
+  ds 1
+
+WR1_HasInstrument7:: ; DB6B
+  ; 0: false, 2: true
+  ds 1
+
+WR1_HasInstrument8:: ; DB6C
+  ; 0: false, 2: true
+  ds 1
+
+; Unlabeled
+WR0_DB6E equ $DB6E
+  ds 6
+
+WR1_IsMarinFollowingLink:: ; DB73
+  ds 1
+
+; Unlabeled
+WR0_DB74 equ $DB74
+  ds 5
+
+WR1_IsGhostFollowingLink:: ; DB79
+  ds 1
+
+WR1_DB7A:: ; DB7A
+  ds 1
+
+WR1_IsRoosterFollowingLink:: ; DB7B
+  ds 1
+
+; Unlabeled
+WR0_DB7C equ $DB7C
+  ds $14
+
+; This appears to be the amount of rupees being added to your wallet
+WR1_AddRupeeBuffer:: ; DB90
+  ds 1
+
+; Unlabeled
+WR0_DB91 equ $DB91
+  ds $4
+
+WR1_GameplayType:: ; DB95
+  ; See GAMEPLAY_* constants for possible values
+  ds 1
+
+WR1_GameplaySubtype:: ; DB96
+  ; Value depens on GameplayType: this can be a sequence index, or a frame counter.
+  ds 1
+
+WR1_BGPalette:: ; DB97
+  ds 1
+
+WR1_OBJ0Palette:: ; DB98
+  ds 1
+
+WR1_OBJ1Palette:: ; DB99
+  ds 1
+
+WR1_WindowY:: ; DB9A
+  ds 1
+
+; Unlabeled
+WR0_DB9B equ $DB9B
+  ds $A
+
+WR1_ActiveRoom:: ; $DBA5
+  ; Current room?
+  ds 1
+
+WR1_SaveSlot:: ; DBA6
+  ds 1
+
+; Unlabeled
+WR0_DBA7 equ $DBA7
+  ds 8
+
+WR1_CurrentBank:: ; DBAF
+  ds 1
+
+; Unlabeled
+WR0_DBB0 equ $DBB0
+  ds $5
+
+WR1_KillCount2:: ; DBB5
+  ds 1
+
+; Unlabeled
+WR0_DBB6 equ $DBB6
+  ds $16
+
+WR1_HasDungeonMap:: ; DBCC
+  ds 1
+
+WR1_HasDungeonCompass:: ; DBCD
+  ds 1
+
+WR1_HasDungeonStoneSlab:: ; DBCE
+  ds 1
+
+WR1_HasDungeonBossKey:: ; DBCF
+  ds 1
+
+; Unlabeled
+WR0_DBD0 equ $DBD0
+  ds $3C
+
 ; Photos 1-8 (bitfield)
-WR1_Photos1                 equ $DC0C
+WR1_Photos1:: ; DC0C
+  ds 1
+
 ; Photos 9-12 (bitfield)
-WR1_Photos2                 equ $DC0D
+WR1_Photos2:: ; DC0D
+  ds 1
+
+WR1_DC0E::
+  ds 1
+
 ; Tunic Type (GBC only)
 ; 0: green
 ; 1: red
 ; 2: blue
-WR1_TunicType               equ $DC0F
-label_DC90 equ $DC90
-label_DC91 equ $DC91
-label_DCC0 equ $DCC0
-label_DCDD equ $DCDD
-label_DDD2 equ $DDD2
-label_DDD5 equ $DDD5
-label_DDD6 equ $DDD6
-label_DDD7 equ $DDD7
-label_DDD8 equ $DDD8
-label_DDE0 equ $DDE0
-label_DE01 equ $DE01
-label_DE02 equ $DE02
-label_DE03 equ $DE03
-label_DE04 equ $DE04
-label_DFFF equ $DFFF
-
-WR1_RupeeCountHigh          equ $DB5D
-WR1_RupeeCountLow           equ $DB5E
-; This appears to be the amount of rupees being added to your wallet
-WR1_AddRupeeBuffer          equ $DB90 
-WR1_KillCount2              equ $DBB5
-
+WR1_TunicType:: ; DC0F
+  ds 1

--- a/src/constants/wram.asm
+++ b/src/constants/wram.asm
@@ -1,215 +1,215 @@
 section "WRAM Bank0", wram0
 
-WR0_C000 equ $C000
+wC000 equ $C000
   ds $100
 
-WR0_ScrollXOffsetForSection:: ; C100
+wScrollXOffsetForSection:: ; C100
   ; Table of the scrollX offset to add for each screen section being drawn
   ds $5
 
-WR0_LCDSectionIndex:: ; C105
+wLCDSectionIndex:: ; C105
   ; Portion of the screen being drawn (0 -> 4)
   ds 1
 
-WR0_IntroBGYOffset:: ; C106
+wIntroBGYOffset:: ; C106
   ; Offset for compensating the sea movement when drawing bottom screen section on intro sea
   ds 1
 
 ; Unlabeled
-WR0_C108 equ $C108
+wC108 equ $C108
 
   ds 7
 
-WR0_needsUpdatingNPCTiles:: ; C10E
+wneedsUpdatingNPCTiles:: ; C10E
   ds 1
 
 ; Unlabeled
-WR0_C10F equ $C10F
+wC10F equ $C10F
   ds $12
 
-WR0_IsUsingSpinAttack:: ; C121
+wIsUsingSpinAttack:: ; C121
   ds 1
 
 ; Unlabeled
-WR0_C122 equ $C122
+wC122 equ $C122
   ds 2
 
-WR0_MapSlideTransitionState:: ; C124
+wMapSlideTransitionState:: ; C124
   ds 1
 
 ; Unlabeled
-WR0_C125 equ $C125
+wC125 equ $C125
   ds $18
 
-WR0_RandomSeed:: ; C13D
+wRandomSeed:: ; C13D
   ; Seed for the Random Number Generator
   ds 1
 
 ; Unlabeled
-WR0_C140 equ $C13E
+wC140 equ $C13E
   ds $E
 
-WR0_IsShootingArrow:: ; C14C
+wIsShootingArrow:: ; C14C
   ds 1
 
-WR0_ProjectileCount:: ; C14D
+wProjectileCount:: ; C14D
   ds 1
 
-WR0_HasPlacedBomb:: ; C14E
+wHasPlacedBomb:: ; C14E
   ds 1
 
-WR0_InventoryAppearing:: ; C14F
+wInventoryAppearing:: ; C14F
   ds 1
 
 ; Unlabeled
-WR0_C150 equ $C150
+wC150 equ $C150
   ds 5
 
-WR0_ScreenShakeHorizontal:: ; C155
+wScreenShakeHorizontal:: ; C155
   ; background offset for shaking the screen vertically
   ds 1
 
-WR0_ScreenShakeVertical:: ; C156
+wScreenShakeVertical:: ; C156
   ; background offset for shaking the screen vertically
   ds 1
 
 ; Unlabeled
-WR0_C157 equ $C157
+wC157 equ $C157
   ds $2
 
-WR0_InventoryCursorFrameCounter:: ; C159
+wInventoryCursorFrameCounter:: ; C159
   ds 1
 
-WR0_HasMirrorShield:: ; C15A
+wHasMirrorShield:: ; C15A
   ds 1
 
-WR0_IsUsingShield:: ; C15B
+wIsUsingShield:: ; C15B
   ds 1
 
 ; Unlabeled
-WR0_C15C equ $C15C
+wC15C equ $C15C
   ds $F
 
-WR0_TransitionSequenceCounter:: ; C16B
+wTransitionSequenceCounter:: ; C16B
   ds 1
 
 ; Unlabeled
-WR0_C16C equ $C16C
+wC16C equ $C16C
   ds 6
 
-WR0_DialogScrollDelay:: ; C172
+wDialogScrollDelay:: ; C172
   ds 1
 
 ; Unlabeled
-WR0_C173 equ $C173
+wC173 equ $C173
   ds 8
 
-WR0_FreeMovementMode:: ; C17B
+wFreeMovementMode:: ; C17B
   ; See https://tcrf.net/The_Legend_of_Zelda:_Link%27s_Awakening#Mono_Pausing_the_Engine_and_Mono.2FDX_Free-Movement_Mode
   ds 1
 
 ; Unlabeled
-WR0_C17C equ $C17C
+wC17C equ $C17C
   ds 3
 
-WR0_WarpTransition:: ; C17F
+wWarpTransition:: ; C17F
   ; See WARP_TRANSITION_* constants for possible values
   ds 1
 
 ; Unlabeled
-WR0_C180 equ $C180
+wC180 equ $C180
   ds $1F
 
-WR0_DialogState:: ; C19F
+wDialogState:: ; C19F
   ; See DIALOG_* constants for possible values
   ds 1
 
-WR0_C1A4 equ $C1A0
+wC1A4 equ $C1A0
   ds $60
 
-WR0_EntitiesPosXTable:: ; C200
+wEntitiesPosXTable:: ; C200
   ; X position of visible entities
 
-WR0_Entity0PosX:: ; C200
+wEntity0PosX:: ; C200
   ds $1
 
-WR0_Entity1PosX:: ; C201
+wEntity1PosX:: ; C201
   ds $1
 
-WR0_Entity2PosX:: ; C202
+wEntity2PosX:: ; C202
 
-WR0_IntroShipPosX:: ; C202
+wIntroShipPosX:: ; C202
   ; Position of the ship sprite during the intro sequence
   ds $1
 
-WR0_Entity3PosX:: ; C203
+wEntity3PosX:: ; C203
   ds $1
 
-WR0_Entity4PosX:: ; C204
+wEntity4PosX:: ; C204
   ds $1
 
-WR0_Entity5PosX:: ; C205
+wEntity5PosX:: ; C205
   ds $1
 
-WR0_Entity6PosX:: ; C206
+wEntity6PosX:: ; C206
   ds $1
 
-WR0_Entity7PosX:: ; C207
+wEntity7PosX:: ; C207
   ds $1
 
-WR0_Entity8PosX:: ; C208
+wEntity8PosX:: ; C208
   ds $1
 
-WR0_Entity9PosX:: ; C209
+wEntity9PosX:: ; C209
   ds $1
 
-WR0_Entity10PosX:: ; C20A
+wEntity10PosX:: ; C20A
   ds $1
 
-WR0_Entity11PosX:: ; C20B
+wEntity11PosX:: ; C20B
   ds $1
 
-WR0_Entity12PosX:: ; C20C
+wEntity12PosX:: ; C20C
   ds $1
 
-WR0_Entity13PosX:: ; C20D
+wEntity13PosX:: ; C20D
   ds $1
 
-WR0_Entity14PosX:: ; C20E
+wEntity14PosX:: ; C20E
   ds $1
 
-WR0_Entity15PosX:: ; C20F
+wEntity15PosX:: ; C20F
   ds $1
 
-WR0_EntitiesPosYTable:: ; C210
+wEntitiesPosYTable:: ; C210
   ; Y position of visible entities
   ds $10
 
 ; Unlabeled
-WR0_C220 equ $C220
+wC220 equ $C220
   ds $60
 
-WR0_EntitiesTypeTable:: ; C280
+wEntitiesTypeTable:: ; C280
   ; type of visible entities
   ds 1
 
 section "WRAM Bank1", wramx, bank[1]
 
 ; Unlabeled
-WR0_D000 equ $D000
+wD000 equ $D000
   ds 1
 
-WR0_IntroTimer:: ; D001
+wIntroTimer:: ; D001
   ds 1
 
-WR0_IntroSubTimer:: ; D002
+wIntroSubTimer:: ; D002
   ds 1
 
 ; Unlabeled
-WR0_D003 equ $D003
+wD003 equ $D003
   ds $365
 
-WR1_OverworldMusic:: ; D368
+wOverworldMusic:: ; D368
   ; Overworld Music Track
   ; 00: No music
   ; 01: Title music when zelda logo appears
@@ -306,94 +306,94 @@ WR1_OverworldMusic:: ; D368
   ds 1
 
 ; Unlabeled
-WR1_D369 equ $D369
+wD369 equ $D369
   ds $AC
 
-WR1_KillCount:: ; D415
+wKillCount:: ; D415
   ds 1
 
 ; Unlabeled
-WR0_D416 equ $D416
+wD416 equ $D416
   ds $68
 
-WR1_DidStealItem:: ; D47E
+wDidStealItem:: ; D47E
   ds 1
 
 ; Unlabeled
-WR0_D47F equ $D47F
+wD47F equ $D47F
   ds $27D
 
-WR1_EnginePaused:: ; D6FC
+wEnginePaused:: ; D6FC
   ds 1
 
-WR1_LCDControl:: ; D6FD
+wLCDControl:: ; D6FD
   ds 1
 
 ; Unlabeled
-WR0_D6FE equ $D6FE
+wD6FE equ $D6FE
   ds $13
 
-WR1_TileMap:: ; D711
+wTileMap:: ; D711
   ds 1
 
 ; Unlabeled
-WR0_D712 equ $D712
+wD712 equ $D712
   ds $EE
 
 ; Minimap Tile
 ; Values:
 ;   0:     not discovered yet
 ;   non-0: various statuses
-WR1_MinimapTiles:: ; D800
+wMinimapTiles:: ; D800
   ds $ff
 
 ; Unlabeled
-WR0_D900 equ $D900
+wD900 equ $D900
   ds $201
 
-WR1_AButtonSlot:: ; DB00
+wAButtonSlot:: ; DB00
   ds 1
 
-WR1_BButtonSlot:: ; DB01
+wBButtonSlot:: ; DB01
   ds 1
 
-WR1_InventoryItem1:: ; DB02
+wInventoryItem1:: ; DB02
   ds 1
 
-WR1_InventoryItem2:: ; DB03
+wInventoryItem2:: ; DB03
   ds 1
 
-WR1_InventoryItem3:: ; DB04
+wInventoryItem3:: ; DB04
   ds 1
 
-WR1_InventoryItem4:: ; DB05
+wInventoryItem4:: ; DB05
   ds 1
 
-WR1_InventoryItem5:: ; DB06
+wInventoryItem5:: ; DB06
   ds 1
 
-WR1_InventoryItem6:: ; DB07
+wInventoryItem6:: ; DB07
   ds 1
 
-WR1_InventoryItem7:: ; DB08
+wInventoryItem7:: ; DB08
   ds 1
 
-WR1_InventoryItem8:: ; DB09
+wInventoryItem8:: ; DB09
   ds 1
 
-WR1_InventoryItem9:: ; DB0A
+wInventoryItem9:: ; DB0A
   ds 1
 
-WR1_InventoryItem10:: ; DB0B
+wInventoryItem10:: ; DB0B
   ds 1
 
-WR1_HasFlippers:: ; DB0C
+wHasFlippers:: ; DB0C
   ds 1
 
-WR1_HasMedicine:: ; DB0D
+wHasMedicine:: ; DB0D
   ds 1
 
-WR1_TradeSequenceItem:: ; DB0E
+wTradeSequenceItem:: ; DB0E
   ; Trade Sequence items:
   ; $00 Nothing
   ; $01 Yoshi Doll
@@ -412,218 +412,218 @@ WR1_TradeSequenceItem:: ; DB0E
   ; $0E Magnifying glass
   ds 1
 
-WR1_SeashellsCount:: ; DB0F
+wSeashellsCount:: ; DB0F
   ds 1
 
 ; Unlabeled
-WR0_DB10 equ $DB10
+wDB10 equ $DB10
   ds 1
 
-WR1_HasTailKey:: ; DB11
+wHasTailKey:: ; DB11
   ds 1
 
-WR1_HasAnglerKey:: ; DB12
+wHasAnglerKey:: ; DB12
   ds 1
 
-WR1_HasFaceKey:: ; DB13
+wHasFaceKey:: ; DB13
   ds 1
 
-WR1_HasBirdKey:: ; DB14
+wHasBirdKey:: ; DB14
   ds 1
 
 ; Golden Leaves count
 ; 0-5: number of Golden Leaves
 ; 6  : Slime Key
-WR1_GoldenLeavesCount:: ; DB15
+wGoldenLeavesCount:: ; DB15
   ds 1
 
 ; Unlabeled
-WR0_DB16 equ $DB16
+wDB16 equ $DB16
   ds $2D
 
-WR1_PowerBraceletLevel:: ; DB43
+wPowerBraceletLevel:: ; DB43
   ds 1
 
-WR1_ShieldLevel:: ; DB44
+wShieldLevel:: ; DB44
   ds 1
 
-WR1_ArrowCount:: ; DB45
+wArrowCount:: ; DB45
   ds 1
 
 ; Unlabeled
-WR0_DB46 equ $DB46
+wDB46 equ $DB46
   ds 7
 
-WR1_BombCount:: ; DB4D
+wBombCount:: ; DB4D
   ds 1
 
-WR1_MarinAndTarinAtHome:: ; DB4E
+wMarinAndTarinAtHome:: ; DB4E
   ds 1
 
 ; Unlabeled
-WR0_DB4F equ $DB4F
+wDB4F equ $DB4F
   ds 7
 
-WR1_IsBowWowFollowingLink:: ; DB56
+wIsBowWowFollowingLink:: ; DB56
   ds 1
 
 ; Unlabeled
-WR0_DB57 equ $DB57
+wDB57 equ $DB57
   ds $6
 
-WR1_RupeeCountHigh:: ; DB5D
+wRupeeCountHigh:: ; DB5D
   ds 1
 
-WR1_RupeeCountLow:: ; DB5E
+wRupeeCountLow:: ; DB5E
   ds 1
 
 ; Unlabeled
-WR0_DB5F equ $DB5F
+wDB5F equ $DB5F
   ds $6
 
-WR1_HasInstrument1:: ; DB65
+wHasInstrument1:: ; DB65
   ; 0: false, 2: true
   ds 1
 
-WR1_HasInstrument2:: ; DB66
+wHasInstrument2:: ; DB66
   ; 0: false, 2: true
   ds 1
 
-WR1_HasInstrument3:: ; DB67
+wHasInstrument3:: ; DB67
   ; 0: false, 2: true
   ds 1
 
-WR1_HasInstrument4:: ; DB68
+wHasInstrument4:: ; DB68
   ; 0: false, 2: true
   ds 1
 
-WR1_HasInstrument5:: ; DB69
+wHasInstrument5:: ; DB69
   ; 0: false, 2: true
   ds 1
 
-WR1_HasInstrument6:: ; DB6A
+wHasInstrument6:: ; DB6A
   ; 0: false, 2: true
   ds 1
 
-WR1_HasInstrument7:: ; DB6B
+wHasInstrument7:: ; DB6B
   ; 0: false, 2: true
   ds 1
 
-WR1_HasInstrument8:: ; DB6C
+wHasInstrument8:: ; DB6C
   ; 0: false, 2: true
   ds 1
 
 ; Unlabeled
-WR0_DB6E equ $DB6E
+wDB6E equ $DB6E
   ds 6
 
-WR1_IsMarinFollowingLink:: ; DB73
+wIsMarinFollowingLink:: ; DB73
   ds 1
 
 ; Unlabeled
-WR0_DB74 equ $DB74
+wDB74 equ $DB74
   ds 5
 
-WR1_IsGhostFollowingLink:: ; DB79
+wIsGhostFollowingLink:: ; DB79
   ds 1
 
-WR1_DB7A:: ; DB7A
+wDB7A:: ; DB7A
   ds 1
 
-WR1_IsRoosterFollowingLink:: ; DB7B
+wIsRoosterFollowingLink:: ; DB7B
   ds 1
 
 ; Unlabeled
-WR0_DB7C equ $DB7C
+wDB7C equ $DB7C
   ds $14
 
 ; This appears to be the amount of rupees being added to your wallet
-WR1_AddRupeeBuffer:: ; DB90
+wAddRupeeBuffer:: ; DB90
   ds 1
 
 ; Unlabeled
-WR0_DB91 equ $DB91
+wDB91 equ $DB91
   ds $4
 
-WR1_GameplayType:: ; DB95
+wGameplayType:: ; DB95
   ; See GAMEPLAY_* constants for possible values
   ds 1
 
-WR1_GameplaySubtype:: ; DB96
+wGameplaySubtype:: ; DB96
   ; Value depens on GameplayType: this can be a sequence index, or a frame counter.
   ds 1
 
-WR1_BGPalette:: ; DB97
+wBGPalette:: ; DB97
   ds 1
 
-WR1_OBJ0Palette:: ; DB98
+wOBJ0Palette:: ; DB98
   ds 1
 
-WR1_OBJ1Palette:: ; DB99
+wOBJ1Palette:: ; DB99
   ds 1
 
-WR1_WindowY:: ; DB9A
+wWindowY:: ; DB9A
   ds 1
 
 ; Unlabeled
-WR0_DB9B equ $DB9B
+wDB9B equ $DB9B
   ds $A
 
-WR1_ActiveRoom:: ; $DBA5
+wActiveRoom:: ; $DBA5
   ; Current room?
   ds 1
 
-WR1_SaveSlot:: ; DBA6
+wSaveSlot:: ; DBA6
   ds 1
 
 ; Unlabeled
-WR0_DBA7 equ $DBA7
+wDBA7 equ $DBA7
   ds 8
 
-WR1_CurrentBank:: ; DBAF
+wCurrentBank:: ; DBAF
   ds 1
 
 ; Unlabeled
-WR0_DBB0 equ $DBB0
+wDBB0 equ $DBB0
   ds $5
 
-WR1_KillCount2:: ; DBB5
+wKillCount2:: ; DBB5
   ds 1
 
 ; Unlabeled
-WR0_DBB6 equ $DBB6
+wDBB6 equ $DBB6
   ds $16
 
-WR1_HasDungeonMap:: ; DBCC
+wHasDungeonMap:: ; DBCC
   ds 1
 
-WR1_HasDungeonCompass:: ; DBCD
+wHasDungeonCompass:: ; DBCD
   ds 1
 
-WR1_HasDungeonStoneSlab:: ; DBCE
+wHasDungeonStoneSlab:: ; DBCE
   ds 1
 
-WR1_HasDungeonBossKey:: ; DBCF
+wHasDungeonBossKey:: ; DBCF
   ds 1
 
 ; Unlabeled
-WR0_DBD0 equ $DBD0
+wDBD0 equ $DBD0
   ds $3C
 
 ; Photos 1-8 (bitfield)
-WR1_Photos1:: ; DC0C
+wPhotos1:: ; DC0C
   ds 1
 
 ; Photos 9-12 (bitfield)
-WR1_Photos2:: ; DC0D
+wPhotos2:: ; DC0D
   ds 1
 
-WR1_DC0E::
+wDC0E::
   ds 1
 
 ; Tunic Type (GBC only)
 ; 0: green
 ; 1: red
 ; 2: blue
-WR1_TunicType:: ; DC0F
+wTunicType:: ; DC0F
   ds 1

--- a/src/constants/wram.asm
+++ b/src/constants/wram.asm
@@ -75,7 +75,10 @@ WR0_ScreenShakeVertical:: ; C156
 
 ; Unlabeled
 WR0_C157 equ $C157
-  ds $3
+  ds $2
+
+WR0_InventoryCursorFrameCounter:: ; C159
+  ds 1
 
 WR0_HasMirrorShield:: ; C15A
   ds 1
@@ -436,7 +439,10 @@ WR1_GoldenLeavesCount:: ; DB15
 
 ; Unlabeled
 WR0_DB16 equ $DB16
-  ds $2E
+  ds $2D
+
+WR1_PowerBraceletLevel:: ; DB43
+  ds 1
 
 WR1_ShieldLevel:: ; DB44
   ds 1


### PR DESCRIPTION
Locations in WRAM are currently labeled as constants (`wShieldLevel EQU $DB44`). This is very flexible.

The downside is that labeled locations are not exported in the debug symbols – which means emulators and disassemblers don't have access to the labels.

This PR turns WRAM labels into ASM labels. Which means WRAM labels now show up in emulators ; and disassembly tools can use them. A small inconvenient is that we need to map exactly the WRAM storage – including explicitly reserving space for locations that are not labeled yet. Still worth it IMHO.

_This change was inspired by the way the [pokered disassembly](https://github.com/pret/pokered) is organized._