### PR TITLE
Turn HRAM constants into labels

### DIFF
--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -5,7 +5,7 @@
 SelectRomBank_2100 equ $2100
 
 Start::
-    cp   $11 ; is running on Game Boy Color?
+    cp   GBC ; is running on Game Boy Color?
     jr   nz, .notGBC
     ld   a, [rKEY1]
     and  $80 ; do we need to switch the CPU speed?

--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -28,7 +28,7 @@ Start::
     xor  a ; isGBC = false
 
 Init::
-    ld   [hIsGBC], a ; Save isGBC value
+    ldh  [hIsGBC], a ; Save isGBC value
     call LCDOff
     ld   sp, $DFFF ; init stack pointer
     ld   a, $3C ; 60
@@ -75,7 +75,7 @@ Init::
 RenderLoop::
     ; Set DidRenderFrame
     ld   a, 1
-    ld   [hDidRenderFrame], a
+    ldh  [hDidRenderFrame], a
 
     ; Special case for $C500 == 1 (alternate background position)
     ; If $C500 != 0...
@@ -87,7 +87,7 @@ RenderLoop::
     cp   GAMEPLAY_OVERWORLD
     jr   nz, .applyRegularScrollYOffset
     ; set scroll Y to $00 or $80 alternatively every other frame.
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     rrca
     and  $80
     jr   .setScrollY
@@ -95,14 +95,14 @@ RenderLoop::
 .applyRegularScrollYOffset
     ; Compose the base offset and the screen shake offset
     ld   hl, wScreenShakeVertical
-    ld   a, [hBaseScrollY]
+    ldh  a, [hBaseScrollY]
     add  a, [hl]
 
 .setScrollY
     ld   [rSCY], a ; scrollY
 
     ; Set ScrollX
-    ld   a, [hBaseScrollX]
+    ldh  a, [hBaseScrollX]
     ld   hl, wScreenShakeHorizontal
     add  a, [hl]
     ld   hl, $C1BF
@@ -208,7 +208,7 @@ label_2A0::
     push af
     cp   $60
     jr   c, label_2B7
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_2B4
     ld   a, $20
@@ -248,7 +248,7 @@ RenderInteractiveFrame::
     call ReadJoypadState
 
     ; If NeedsUpdatingBGTiles or NeedsUpdatingEnnemiesTiles or NeedsUpdatingNPCTiles…
-    ld   a, [hNeedsUpdatingBGTiles]
+    ldh  a, [hNeedsUpdatingBGTiles]
     ld   hl, hNeedsUpdatingEnnemiesTiles
     or   [hl]
     ld   hl, wneedsUpdatingNPCTiles
@@ -265,7 +265,7 @@ RenderInteractiveFrame::
     and  a  ; Is engine already paused?
     jr   nz, .engineIsPaused
 
-    ld   a, [hPressedButtonsMask]
+    ldh  a, [hPressedButtonsMask]
     and  J_RIGHT | J_LEFT | J_UP | J_DOWN ; Are none of the directional keys pressed?
     jr   z, .saveEngineStatus
 
@@ -317,7 +317,7 @@ RenderGameplay::
 
 RenderPalettes::
     ; If isGBC
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, .resetDDD2
     ; update palettes
@@ -344,18 +344,18 @@ WaitForNextFrame::
     call SwitchBank
 
     xor  a
-    ld   [hDidRenderFrame], a ; Waiting for next frame
+    ldh  [hDidRenderFrame], a ; Waiting for next frame
     halt
 
 PollNeedsRenderingFrame::
     ; Loop until hNeedsRenderingFrame != 0
-    ld   a, [hNeedsRenderingFrame]
+    ldh  a, [hNeedsRenderingFrame]
     and  a
     jr   z, PollNeedsRenderingFrame
 
     ; Clear hNeedsRenderingFrame
     xor  a
-    ld   [hNeedsRenderingFrame], a
+    ldh  [hNeedsRenderingFrame], a
 
     ; Jump to the top of the render loop
     jp   RenderLoop
@@ -395,7 +395,7 @@ InterruptLCDStatus::
 
 setStandardScrollY::
     ; Set standard scrollY, without specific offset
-    ld   a, [hBaseScrollY]
+    ldh  a, [hBaseScrollY]
 
 setScrollY::
     ld   [rSCY], a ; scrollY
@@ -582,7 +582,7 @@ InterruptVBlank::
     jp  c, PhotoAlbumVBlankHandler
 
 .continue
-    ld   a, [hDidRenderFrame]
+    ldh  a, [hDidRenderFrame]
     and  a
     jp   nz, WaitForVBlankAndReturn  ; if not already waiting for next frame, do
 
@@ -645,7 +645,7 @@ vBlankContinue::
     ld   a, [$D6FE]
     and  a
     jr   nz, WaitForVBlankAndReturn
-    ld   a, [hNeedsUpdatingBGTiles]
+    ldh  a, [hNeedsUpdatingBGTiles]
     ld   [$FFE8], a
     ld   hl, hNeedsUpdatingEnnemiesTiles
     or   [hl]
@@ -686,7 +686,7 @@ label_521::
     call AnimateTiles
 
 label_52B::
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, .notGBC
     ld   a, $24
@@ -704,7 +704,7 @@ label_52B::
     ld   [SelectRomBank_2100], a
     call label_72BA
     call label_FFC0
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, WaitForVBlankAndReturn
     ld   a, $21
@@ -724,18 +724,18 @@ WaitForVBlankAndReturn_direct::
     pop  de
     pop  bc
     ld   a, $01
-    ld   [hNeedsRenderingFrame], a
+    ldh  [hNeedsRenderingFrame], a
     pop  af
     reti
 
 PhotoAlbumVBlankHandler::
     ld   a, [wCurrentBank]
     push af
-    ld   a, [hDidRenderFrame]
+    ldh  a, [hDidRenderFrame]
     and  a
     jr   nz, label_5AB
     call label_FFC0
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_598
     ld   a, $21
@@ -765,7 +765,7 @@ label_5AB::
 
 ; Copy tiles?
 label_5BC::
-    ld   a, [hNeedsUpdatingBGTiles]
+    ldh  a, [hNeedsUpdatingBGTiles]
     and  a
     jp   z, label_69E
     cp   $07
@@ -783,7 +783,7 @@ label_5BC::
     ld   a, [$DBA5]
     and  a
     jp   z, label_656
-    ld   a, [hNeedsUpdatingBGTiles]
+    ldh  a, [hNeedsUpdatingBGTiles]
     cp   $02
     jp   z, label_826
     ld   a, $0D
@@ -842,7 +842,7 @@ label_647::
     cp   $04
     jr   nz, label_655
     xor  a
-    ld   [hNeedsUpdatingBGTiles], a
+    ldh  [hNeedsUpdatingBGTiles], a
     ld   [$FF92], a
 
 label_655::
@@ -884,14 +884,14 @@ label_656::
     cp   $08
     jr   nz, label_69D
     xor  a
-    ld   [hNeedsUpdatingBGTiles], a
+    ldh  [hNeedsUpdatingBGTiles], a
     ld   [$FF92], a
 
 label_69D::
     ret
 
 label_69E::
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_6CB
     ld   a, [$FFF7]
@@ -913,7 +913,7 @@ label_69E::
     jr   label_738
 
 label_6CB::
-    ld   a, [hNeedsUpdatingEnnemiesTiles]
+    ldh  a, [hNeedsUpdatingEnnemiesTiles]
     and  a
     jp   z, label_73E
     ld   a, [$C197]
@@ -979,7 +979,7 @@ label_6F7::
 
 label_738::
     xor  a
-    ld   [hNeedsUpdatingEnnemiesTiles], a
+    ldh  [hNeedsUpdatingEnnemiesTiles], a
     ld   [$FF93], a
 
 label_73D::
@@ -1087,7 +1087,7 @@ label_7D3::
     ld   [SelectRomBank_2100], a
     ld   bc, $0040
     call CopyData
-    ld   a, [hNeedsUpdatingBGTiles]
+    ldh  a, [hNeedsUpdatingBGTiles]
     cp   $0A
     jr   z, label_808
     cp   $0D
@@ -1096,16 +1096,16 @@ label_800::
     jr   z, label_808
 
 label_802::
-    ld   a, [hNeedsUpdatingBGTiles]
+    ldh  a, [hNeedsUpdatingBGTiles]
     inc  a
 
 label_805::
-    ld   [hNeedsUpdatingBGTiles], a
+    ldh  [hNeedsUpdatingBGTiles], a
     ret
 
 label_808::
     xor  a
-    ld   [hNeedsUpdatingBGTiles], a
+    ldh  [hNeedsUpdatingBGTiles], a
     ret
 
 ; Switch to the bank defined in a, and save the active bank
@@ -1172,7 +1172,7 @@ label_865::
     ld   [SelectRomBank_2100], a
     call label_67E5
     xor  a
-    ld   [hNeedsUpdatingBGTiles], a
+    ldh  [hNeedsUpdatingBGTiles], a
     ld   [$FF92], a
     ret
 
@@ -1216,7 +1216,7 @@ PlayAudioStep::
     jr   z, label_8C6
     cp   $02
     jr   nz, label_8C3
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $01
     jr   nz, label_8D6
     jr   label_8C6
@@ -1445,7 +1445,7 @@ label_A01::
 
 label_A13::
     ld   [SelectRomBank_2100], a
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_A01
     ld   a, b
@@ -1597,7 +1597,7 @@ label_B02::
 AdjustBankNumberForGBC::
     push bc
     ld   b, a
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a           ; if !isGBC
     jr   z, .notGBC  ;   handle standard GB
     ld   a, b        ; else
@@ -1623,7 +1623,7 @@ label_0B1A::
 
 label_B2F::
     ld   [$FFD9], a
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     ret  z
     ld   a, [$DBA5]
@@ -1659,7 +1659,7 @@ label_B54::
     ret
     push hl
     ld   [SelectRomBank_2100], a
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_B80
     ld   de, $0168
@@ -1986,7 +1986,7 @@ label_D45::
     cp   $FF
     jr   z, label_D57
     ld   a, $01
-    ld   [hNeedsUpdatingBGTiles], a
+    ldh  [hNeedsUpdatingBGTiles], a
 
 label_D57::
     jr   label_D91
@@ -2028,7 +2028,7 @@ label_D60::
 label_D8B::
     ld   [$FF94], a
     ld   a, $01
-    ld   [hNeedsUpdatingBGTiles], a
+    ldh  [hNeedsUpdatingBGTiles], a
 
 label_D91::
     xor  a
@@ -2089,7 +2089,7 @@ label_DDB::
     cp   $FF
     jr   nz, label_DF1
     ld   a, $01
-    ld   [hNeedsUpdatingEnnemiesTiles], a
+    ldh  [hNeedsUpdatingEnnemiesTiles], a
     jr   label_E31
 
 label_DF1::
@@ -2128,7 +2128,7 @@ label_E1E::
     ld   a, d
     ld   [$C197], a
     ld   a, $01
-    ld   [hNeedsUpdatingEnnemiesTiles], a
+    ldh  [hNeedsUpdatingEnnemiesTiles], a
 
 label_E29::
     inc  hl
@@ -2172,7 +2172,7 @@ presentSaveScreenIfNeeded::
     jr   nc, jumpToGameplayHandler
 
     ; If not all A + B + Start + Select buttons are pressed
-    ld   a, [hPressedButtonsMask]
+    ldh  a, [hPressedButtonsMask]
     cp   J_A | J_B | J_START | J_SELECT
     jr   nz, jumpToGameplayHandler
 
@@ -2396,7 +2396,7 @@ label_F97::
     call SwitchBank
     call label_5487
     ld   hl, $D601
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $03
     or   [hl]
     jr   nz, label_1012
@@ -2408,7 +2408,7 @@ label_F97::
 
 label_1000::
     ld   e, $00
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $04
 
 label_1006::
@@ -2432,7 +2432,7 @@ returnFromGameplayHandler::
 
 label_101F::
     call label_2321
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     ret  z
     ld   a, $24
@@ -2494,10 +2494,10 @@ label_106D::
     ld   d, c
 
 label_107F::
-    ld   a, [hPressedButtonsMask]
+    ldh  a, [hPressedButtonsMask]
     and  $B0
     jr   nz, label_10DB
-    ld   a, [hPressedButtonsMask]
+    ldh  a, [hPressedButtonsMask]
     and  $40
     jr   z, label_10DB
     ld   a, [$D45F]
@@ -2508,7 +2508,7 @@ label_107F::
     ld   a, [$FFA1]
     cp   $02
     jr   z, label_10DB
-    ld   a, [hLinkAnimationState]
+    ldh  a, [hLinkAnimationState]
     cp   $FF
     jr   z, label_10DB
     ld   a, [$C11C]
@@ -2694,7 +2694,7 @@ label_11E8::
     ld   a, [wAButtonSlot]
     cp   $08
     jr   nz, label_11FE
-    ld   a, [hPressedButtonsMask]
+    ldh  a, [hPressedButtonsMask]
     and  $20
     jr   z, label_11FA
     call label_1705
@@ -2708,7 +2708,7 @@ label_11FE::
     ld   a, [wBButtonSlot]
     cp   $08
     jr   nz, label_1214
-    ld   a, [hPressedButtonsMask]
+    ldh  a, [hPressedButtonsMask]
     and  $10
     jr   z, label_1210
     call label_1705
@@ -2726,7 +2726,7 @@ label_1214::
     jr   nz, label_1235
     ld   a, [wShieldLevel]
     ld   [wHasMirrorShield], a
-    ld   a, [hPressedButtonsMask]
+    ldh  a, [hPressedButtonsMask]
     and  $10
     jr   z, label_1235
     ld   a, [$C1AD]
@@ -2742,7 +2742,7 @@ label_1235::
     jr   nz, label_124B
     ld   a, [wShieldLevel]
     ld   [wHasMirrorShield], a
-    ld   a, [hPressedButtonsMask]
+    ldh  a, [hPressedButtonsMask]
     and  $20
     jr   z, label_124B
     call label_1340
@@ -2770,14 +2770,14 @@ label_125E::
     call ItemFunction
 
 label_1275::
-    ld   a, [hPressedButtonsMask]
+    ldh  a, [hPressedButtonsMask]
     and  $20
     jr   z, label_1281
     ld   a, [wAButtonSlot]
     call label_1321
 
 label_1281::
-    ld   a, [hPressedButtonsMask]
+    ldh  a, [hPressedButtonsMask]
     and  $10
     jr   z, label_128D
     ld   a, [wBButtonSlot]
@@ -3139,7 +3139,7 @@ UseRocksFeather::
     and  a
     jr   z, label_1508
     call label_1508
-    ld   a, [hPressedButtonsMask]
+    ldh  a, [hPressedButtonsMask]
     and  $03
     ld   a, $EA
     jr   z, label_14F8
@@ -3225,7 +3225,7 @@ label_1562::
     ret
 
 label_157C::
-    ld   a, [hPressedButtonsMask]
+    ldh  a, [hPressedButtonsMask]
     and  $0F
     ld   e, a
     ld   d, $00
@@ -3525,7 +3525,7 @@ label_1713::
     ret
 
 label_1756::
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $07
     ld   hl, $FFA2
     or   [hl]
@@ -3581,7 +3581,7 @@ label_1794::
     ld   a, [$C122]
     cp   $28
     jr   c, label_17C6
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     rla
     rla
     and  $10
@@ -3661,8 +3661,8 @@ label_1847::
     cp   $04
     jp   nz, label_19D9
     xor  a
-    ld   [hBaseScrollX], a
-    ld   [hBaseScrollY], a
+    ldh  [hBaseScrollX], a
+    ldh  [hBaseScrollY], a
     ld   [$FFB4], a
     ld   [$DDD6], a
     ld   [$DDD7], a
@@ -3691,7 +3691,7 @@ label_186C::
     ld   a, $01
     ld   [wDidStealItem], a
     xor  a
-    ld   [hLinkAnimationState], a
+    ldh  [hLinkAnimationState], a
 
 label_1898::
     ld   a, [$FFF9]
@@ -4053,7 +4053,7 @@ label_1AC4::
 label_1AC7::
     add  hl, bc
     ld   a, [hl]
-    ld   [hLinkAnimationState], a
+    ldh  [hLinkAnimationState], a
     ret
 
 AnimateMarinBeachTiles::
@@ -4065,7 +4065,7 @@ AnimateMarinBeachTiles::
     ld   [SelectRomBank_2100], a
     ld   hl, $6500
     ld   de, $9500
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $0F
     jr   z, .skip
     cp   $08
@@ -4074,7 +4074,7 @@ AnimateMarinBeachTiles::
     ld   e, l
 
 .skip
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $30
     ld   c, a
     ld   b, $00
@@ -4115,7 +4115,7 @@ AnimateTiles::
     ld   a, [$D601]
     and  a                ; if $D601 != 0
     jp   nz, .returnEarly ;   return immediatly
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $0F
     cp   $04              ; else if FrameCounter 4-lower-bits < 4
     jr   c, .returnEarly  ;   return immediately
@@ -4433,10 +4433,10 @@ label_1D1E::
 
 DrawLinkSprite::
 DrawLinkSpriteAndReturn::
-    ld   a, [hLinkAnimationState]
+    ldh  a, [hLinkAnimationState]
     inc  a
     ret  z
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_1D42
     ld   a, [$DBC7]
@@ -4474,13 +4474,13 @@ label_1D49::
     ld   a, [$C11D]
     or   d
     ld   [hl], a
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_1DA1
     ld   a, [$DBC7]
     and  $04
     jr   nz, label_1DA1
-    ld   a, [hLinkAnimationState]
+    ldh  a, [hLinkAnimationState]
     cp   $50
     jr   c, label_1D8C
     cp   $55
@@ -4499,7 +4499,7 @@ label_1D8C::
     ld   [hl], a
 
 label_1D95::
-    ld   a, [hLinkAnimationState]
+    ldh  a, [hLinkAnimationState]
     cp   $4E
     jr   z, label_1D9F
     cp   $4F
@@ -4523,13 +4523,13 @@ label_1DA1::
     ld   a, [$C11E]
     or   d
     ld   [hl], a
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_1DE7
     ld   a, [$DBC7]
     and  $04
     jr   nz, label_1DE7
-    ld   a, [hLinkAnimationState]
+    ldh  a, [hLinkAnimationState]
     cp   $50
     jr   c, label_1DD2
     cp   $55
@@ -4548,7 +4548,7 @@ label_1DD2::
     ld   [hl], a
 
 label_1DDB::
-    ld   a, [hLinkAnimationState]
+    ldh  a, [hLinkAnimationState]
     cp   $4E
     jr   z, label_1DE5
     cp   $4F
@@ -5006,7 +5006,7 @@ label_20CF::
     ld   a, [wAButtonSlot]
     cp   $03
     jr   nz, label_20DD
-    ld   a, [hPressedButtonsMask]
+    ldh  a, [hPressedButtonsMask]
     and  $20
     jr   nz, label_20EC
     ret
@@ -5015,7 +5015,7 @@ label_20DD::
     ld   a, [wBButtonSlot]
     cp   $03
     jp   nz, label_2177
-    ld   a, [hPressedButtonsMask]
+    ldh  a, [hPressedButtonsMask]
     and  $10
     jp   z, label_2177
 
@@ -5032,10 +5032,10 @@ label_20EC::
 
     add  hl, de
     ld   a, [hl]
-    ld   [hLinkAnimationState], a
+    ldh  [hLinkAnimationState], a
     ld   hl, data_1F55
     add  hl, de
-    ld   a, [hPressedButtonsMask]
+    ldh  a, [hPressedButtonsMask]
     and  [hl]
     jr   z, label_214E
     ld   hl, data_1F59
@@ -5247,7 +5247,7 @@ label_2241::
     add  hl, bc
     ld   b, $00
     ld   c, [hl]
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_2262
     ld   a, [$DBA5]
@@ -5268,7 +5268,7 @@ label_2262::
     and  a
     jr   z, label_2286
     ld   hl, $4000
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_2299
     ld   hl, $43B0
@@ -5280,7 +5280,7 @@ label_2262::
 
 label_2286::
     ld   hl, $6749
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_2299
     ld   hl, $6B1D
@@ -5299,7 +5299,7 @@ label_2299::
     and  $02
     jr   z, label_22D3
     call label_2214
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_22D1
     push bc
@@ -5327,7 +5327,7 @@ label_22D1::
 
 label_22D3::
     call label_2224
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_22FE
     push bc
@@ -5514,7 +5514,7 @@ label_23EF::
     xor  a
     ld   e, a
     ld   d, a
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   nz, label_2444
 
@@ -6114,7 +6114,7 @@ label_278B::
     ld   [$FFF2], a
 
 label_27AA::
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $10
     ret  z
     ld   a, $17
@@ -6183,7 +6183,7 @@ label_2802::
 ; Return a random number in `a`
 GetRandomByte::
     push hl
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     ld   hl, wRandomSeed
     add  a, [hl]
     ld   hl, rLY
@@ -6220,7 +6220,7 @@ label_283F::
 
 label_284C::
     xor  a
-    ld   [hPressedButtonsMask], a
+    ldh  [hPressedButtonsMask], a
     ld   [$FFCC], a
     ret
 
@@ -6247,12 +6247,12 @@ label_2852::
     and  $F0
     or   b
     ld   c, a
-    ld   a, [hPressedButtonsMask]
+    ldh  a, [hPressedButtonsMask]
     xor  c
     and  c
     ld   [$FFCC], a
     ld   a, c
-    ld   [hPressedButtonsMask], a
+    ldh  [hPressedButtonsMask], a
     ld   a, $30
     ld   [rJOYP], a
 
@@ -6552,7 +6552,7 @@ label_29DC::
     ld   hl, $C000
 
 ZeroMemory::
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     push af
 
 .ZeroMemory_loop
@@ -6563,7 +6563,7 @@ ZeroMemory::
     or   c
     jr   nz, .ZeroMemory_loop
     pop  af
-    ld   [hIsGBC], a
+    ldh  [hIsGBC], a
     ret
 
 label_29ED::
@@ -6680,7 +6680,7 @@ label_2A66::
     ld   bc, $0800
     jp   CopyData
     ld   hl, $4000
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_2B01
     ld   hl, $6800
@@ -6719,7 +6719,7 @@ label_2B06::
     ld   bc, $0080
     call CopyData
     call PlayAudioStep
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   nz, label_2B61
     ld   a, $10
@@ -6737,14 +6737,14 @@ label_2B61::
     ld   bc, $0800
     jp   CopyData
     ld   hl, $7800
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_2B90
     ld   hl, $7800
     ld   a, $35
     jr   label_2B95
     ld   hl, $4800
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_2B90
     ld   hl, $7000
@@ -7005,7 +7005,7 @@ label_2D50::
     call CopyData
     ld   a, $38
     call SwitchBank
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   nz, label_2DC7
     ld   hl, $5C00
@@ -7018,7 +7018,7 @@ label_2DCA::
     ld   de, $8400
     ld   bc, $0400
     call CopyData
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   nz, label_2DDD
     ld   hl, $6600
@@ -7256,7 +7256,7 @@ label_2F69::
     ret
 
 label_2F87::
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     ret  z
     ld   a, [$FFF7]
@@ -7444,7 +7444,7 @@ label_30A9::
     push de
     push hl
     push bc
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   nz, label_30B6
     call label_2FCD
@@ -7504,7 +7504,7 @@ label_30F4::
     ld   a, $20
     ld   [SelectRomBank_2100], a
     call label_4CA3
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_3119
     ld   a, $21
@@ -7984,7 +7984,7 @@ label_33DC::
     ld   a, [$C3CD]
     add  a, $04
     ld   [$C3CD], a
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   nz, label_3406
     ld   a, $04
@@ -8862,7 +8862,7 @@ label_39AE::
     ld   [$C3C1], a
     ld   a, [$FFF7]
     cp   $0A
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     jr   c, label_39C1
     xor  a
 
@@ -9198,7 +9198,7 @@ label_3C08::
     ld   hl, $FFED
     xor  [hl]
     ld   [de], a
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_3C21
     ld   a, [$FFED]
@@ -9246,7 +9246,7 @@ label_3C4B::
     ld   hl, $FFED
     xor  [hl]
     ld   [de], a
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_3C63
     ld   a, [$FFED]
@@ -9312,7 +9312,7 @@ label_3C9C::
     ld   a, [hli]
     ld   [de], a
     inc  de
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_3CD0
     ld   a, [wGameplayType]
@@ -9406,7 +9406,7 @@ label_3D28::
     xor  [hl]
     ld   [de], a
     inc  hl
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_3D3F
     ld   a, [$FFED]
@@ -9628,7 +9628,7 @@ label_3E8E::
     ld   a, [hl]
     and  a
     ret  z
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     xor  c
     and  $03
     ret  nz
@@ -9826,7 +9826,7 @@ label_3FBD::
     ld   [SelectRomBank_2100], a
     jp   DrawLinkSpriteAndReturn
     ld   b, $34
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_3FD9
     inc  b

--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -65,7 +65,7 @@ Init::
     ld   [SelectRomBank_2100], a
     call label_4000
     ld   a, $18
-    ld   [$FFB5], a
+    ldh  [$FFB5], a
     ei
     ld   a, $20
     ld   [SelectRomBank_2100], a
@@ -270,7 +270,7 @@ RenderInteractiveFrame::
     jr   z, .saveEngineStatus
 
 .engineIsPaused
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  J_SELECT  ; Was Select button just pressed?
     jr   z, .saveEngineStatus
 
@@ -646,14 +646,14 @@ vBlankContinue::
     and  a
     jr   nz, WaitForVBlankAndReturn
     ldh  a, [hNeedsUpdatingBGTiles]
-    ld   [$FFE8], a
+    ldh  [$FFE8], a
     ld   hl, hNeedsUpdatingEnnemiesTiles
     or   [hl]
     ld   hl, wneedsUpdatingNPCTiles
     or   [hl]
     jr   z, label_509
     call label_5BC ; Copy tiles?
-    ld   a, [$FFE8]
+    ldh  a, [$FFE8]
     cp   $08
     jr   nc, label_504
 
@@ -665,11 +665,11 @@ label_504::
     jr   WaitForVBlankAndReturn
 
 label_509::
-    ld   a, [$FFBB]
+    ldh  a, [$FFBB]
     and  a
     jr   z, label_521
     dec  a
-    ld   [$FFBB], a
+    ldh  [$FFBB], a
     ld   e, a
     ld   d, $00
     ld   hl, data_046A
@@ -789,7 +789,7 @@ label_5BC::
     ld   a, $0D
     call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
-    ld   a, [$FF92]
+    ldh  a, [$FF92]
     ld   c, a
     ld   b, $00
     sla  c
@@ -809,7 +809,7 @@ label_5BC::
     ld   e, l
     ld   d, h
     ld   hl, $5000
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_62F
     ld   a, $20
@@ -819,14 +819,14 @@ label_5BC::
     jr   label_641
 
 label_62F::
-    ld   a, [$FF94]
+    ldh  a, [$FF94]
     add  a, $50
     ld   h, a
     add  hl, bc
-    ld   a, [$FFBB]
+    ldh  a, [$FFBB]
     and  a
     jr   z, label_641
-    ld   a, [$FF92]
+    ldh  a, [$FF92]
     dec  a
     cp   $02
     jr   c, label_647
@@ -836,14 +836,14 @@ label_641::
     call CopyData
 
 label_647::
-    ld   a, [$FF92]
+    ldh  a, [$FF92]
     inc  a
-    ld   [$FF92], a
+    ldh  [$FF92], a
     cp   $04
     jr   nz, label_655
     xor  a
     ldh  [hNeedsUpdatingBGTiles], a
-    ld   [$FF92], a
+    ldh  [$FF92], a
 
 label_655::
     ret
@@ -852,7 +852,7 @@ label_656::
     ld   a, $0F
     call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
-    ld   a, [$FF92]
+    ldh  a, [$FF92]
     ld   c, a
     ld   b, $00
     sla  c
@@ -871,21 +871,21 @@ label_656::
     add  hl, bc
     ld   e, l
     ld   d, h
-    ld   a, [$FF94]
+    ldh  a, [$FF94]
     add  a, $40
     ld   h, a
     ld   l, $00
     add  hl, bc
     ld   bc, $0040
     call CopyData
-    ld   a, [$FF92]
+    ldh  a, [$FF92]
     inc  a
-    ld   [$FF92], a
+    ldh  [$FF92], a
     cp   $08
     jr   nz, label_69D
     xor  a
     ldh  [hNeedsUpdatingBGTiles], a
-    ld   [$FF92], a
+    ldh  [$FF92], a
 
 label_69D::
     ret
@@ -894,7 +894,7 @@ label_69E::
     ldh  a, [hIsGBC]
     and  a
     jr   z, label_6CB
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_6CB
     ld   a, $20
@@ -942,7 +942,7 @@ label_6CB::
 
 label_6F7::
     ld   [SelectRomBank_2100], a
-    ld   a, [$FF93]
+    ldh  a, [$FF93]
     ld   c, a
     ld   b, $00
     sla  c
@@ -971,16 +971,16 @@ label_6F7::
     pop  hl
     ld   bc, $0040
     call CopyData
-    ld   a, [$FF93]
+    ldh  a, [$FF93]
     inc  a
-    ld   [$FF93], a
+    ldh  [$FF93], a
     cp   $04
     jr   nz, label_73D
 
 label_738::
     xor  a
     ldh  [hNeedsUpdatingEnnemiesTiles], a
-    ld   [$FF93], a
+    ldh  [$FF93], a
 
 label_73D::
     ret
@@ -1134,7 +1134,7 @@ label_826::
     ld   a, $12
     call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
-    ld   a, [$FF92]
+    ldh  a, [$FF92]
     cp   $08
     jr   c, label_873
     jr   nz, label_843
@@ -1173,7 +1173,7 @@ label_865::
     call label_67E5
     xor  a
     ldh  [hNeedsUpdatingBGTiles], a
-    ld   [$FF92], a
+    ldh  [$FF92], a
     ret
 
 label_873::
@@ -1199,16 +1199,16 @@ label_873::
     add  hl, bc
     ld   bc, $0040
     call CopyData
-    ld   a, [$FF92]
+    ldh  a, [$FF92]
     inc  a
-    ld   [$FF92], a
+    ldh  [$FF92], a
     ret
 
 PlayAudioStep::
     ld   a, $1F
     call SwitchBank
     call label_4006
-    ld   a, [$FFF3]
+    ldh  a, [$FFF3]
     and  a
     jr   nz, label_8D6
     ld   a, [$C10B]
@@ -1297,7 +1297,7 @@ label_92F::
     ld   a, $1A
     ld   [SelectRomBank_2100], a
     call label_6576
-    ld   a, [$FFDF]
+    ldh  a, [$FFDF]
     ld   [SelectRomBank_2100], a
     ld   hl, $DC91
     ld   a, [$DC90]
@@ -1306,13 +1306,13 @@ label_92F::
     ld   [$DC90], a
     ld   d, $00
     add  hl, de
-    ld   a, [$FFE0]
+    ldh  a, [$FFE0]
     ld   d, a
-    ld   a, [$FFE1]
+    ldh  a, [$FFE1]
     ld   e, a
-    ld   a, [$FFCF]
+    ldh  a, [$FFCF]
     ldi  [hl], a
-    ld   a, [$FFD0]
+    ldh  a, [$FFD0]
     ldi  [hl], a
     ld   a, $81
     ldi  [hl], a
@@ -1323,9 +1323,9 @@ label_92F::
     ld   a, [de]
     ldi  [hl], a
     dec  de
-    ld   a, [$FFCF]
+    ldh  a, [$FFCF]
     ldi  [hl], a
-    ld   a, [$FFD0]
+    ldh  a, [$FFD0]
     inc  a
     ldi  [hl], a
     ld   a, $81
@@ -1356,11 +1356,11 @@ label_983::
     ld   a, $1A
     ld   [SelectRomBank_2100], a
     call label_6710
-    ld   a, [$FFDF]
+    ldh  a, [$FFDF]
     ld   [SelectRomBank_2100], a
-    ld   a, [$FFE0]
+    ldh  a, [$FFE0]
     ld   h, a
-    ld   a, [$FFE1]
+    ldh  a, [$FFE1]
     ld   l, a
     ld   a, [hl]
     inc  de
@@ -1370,10 +1370,10 @@ label_999::
     push af
     push bc
     call label_983
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     pop  bc
     call label_983
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     ld   a, [$DC90]
     ld   c, a
     ld   b, $00
@@ -1381,15 +1381,15 @@ label_999::
     ld   [$DC90], a
     ld   hl, $DC91
     add  hl, bc
-    ld   a, [$FFCF]
+    ldh  a, [$FFCF]
     ldi  [hl], a
-    ld   a, [$FFD0]
+    ldh  a, [$FFD0]
     ldi  [hl], a
     ld   a, $01
     ldi  [hl], a
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     ldi  [hl], a
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     ldi  [hl], a
     xor  a
     ldi  [hl], a
@@ -1610,7 +1610,7 @@ AdjustBankNumberForGBC::
     ret
 
 label_0B1A::
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     ld   [SelectRomBank_2100], a
     ld   a, $02
     ld   [rSVBK], a
@@ -1622,7 +1622,7 @@ label_0B1A::
     ret
 
 label_B2F::
-    ld   [$FFD9], a
+    ldh  [$FFD9], a
     ldh  a, [hIsGBC]
     and  a
     ret  z
@@ -1630,7 +1630,7 @@ label_B2F::
     and  a
     ret  nz
     push bc
-    ld   a, [$FFD9]
+    ldh  a, [$FFD9]
     and  $80
     jr   nz, label_B4B
     ld   a, $20
@@ -1647,7 +1647,7 @@ label_B4B::
     ld   [rSVBK], a
 
 label_B54::
-    ld   a, [$FFD9]
+    ldh  a, [$FFD9]
     and  $7F
     ld   [SelectRomBank_2100], a
     pop  bc
@@ -1681,7 +1681,7 @@ label_B80::
     call label_BB5
 
 label_B90::
-    ld   a, [$FFE6]
+    ldh  a, [$FFE6]
     ld   [SelectRomBank_2100], a
     ret
 
@@ -1766,11 +1766,11 @@ label_C08::
     ret
     ld   a, $AF
     call label_3B86
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     ld   hl, $C200
     add  hl, de
     ld   [hl], a
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     ld   hl, $C210
     add  hl, de
     ld   [hl], a
@@ -1778,7 +1778,7 @@ label_C08::
 
 label_C20::
     ld   a, $1D
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     ret
 
 label_C25::
@@ -1839,7 +1839,7 @@ label_C60::
     and  a
     jr   nz, label_C7B
     ld   a, $02
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
 
 label_C7B::
     pop  af
@@ -1847,10 +1847,10 @@ label_C7B::
 
 label_C7D::
     ld   a, $30
-    ld   [$FFA8], a
+    ldh  [$FFA8], a
     jr   label_C9A
     ld   a, $30
-    ld   [$FFA8], a
+    ldh  [$FFA8], a
     jr   label_C9E
     ld   a, [$D401]
     cp   $01
@@ -1859,11 +1859,11 @@ label_C7D::
     and  a
     jr   z, label_C7D
     ld   a, $01
-    ld   [$FFBC], a
+    ldh  [$FFBC], a
 
 label_C9A::
     ld   a, $06
-    ld   [$FFF4], a
+    ldh  [$FFF4], a
 
 label_C9E::
     ld   a, $03
@@ -1887,10 +1887,10 @@ label_CB6::
     ret
 
 label_CBE::
-    ld   a, [$FF9F]
-    ld   [$FF98], a
-    ld   a, [$FFA0]
-    ld   [$FF99], a
+    ldh  a, [$FF9F]
+    ldh  [$FF98], a
+    ldh  a, [$FFA0]
+    ldh  [$FF99], a
     ret
 
 label_CC7::
@@ -1925,11 +1925,11 @@ label_CEC::
     ld   hl, $C510
     add  hl, de
     ld   [hl], a
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     ld   hl, $C540
     add  hl, de
     ld   [hl], a
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     ld   hl, $C530
     add  hl, de
     ld   [hl], a
@@ -1941,14 +1941,14 @@ label_CEC::
 label_D07::
     ld   a, [$C140]
     sub  a, $08
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   a, [$C142]
     sub  a, $08
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
 
 label_D15::
     ld   a, $07
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     ld   a, $05
     jp   label_CC7
 
@@ -1958,11 +1958,11 @@ label_D1E::
     ld   a, [$DBA5]
     and  a
     jr   z, label_D59
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     ld   e, a
     ld   d, $00
     ld   hl, $6EB3
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_D3C
     ld   hl, $70B3
@@ -1977,12 +1977,12 @@ label_D3C::
 
 label_D45::
     add  hl, de
-    ld   a, [$FF94]
+    ldh  a, [$FF94]
     ld   e, a
     ld   a, [hl]
     cp   e
     jr   z, label_D57
-    ld   [$FF94], a
+    ldh  [$FF94], a
     cp   $FF
     jr   z, label_D57
     ld   a, $01
@@ -1992,7 +1992,7 @@ label_D57::
     jr   label_D91
 
 label_D59::
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $07
     jr   nz, label_D60
     inc  a
@@ -2011,7 +2011,7 @@ label_D60::
     ld   d, $00
     ld   hl, $6E73
     add  hl, de
-    ld   a, [$FF94]
+    ldh  a, [$FF94]
     ld   e, a
     ld   a, [hl]
     cp   e
@@ -2020,26 +2020,26 @@ label_D60::
     jr   z, label_D91
     cp   $1A
     jr   nz, label_D8B
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $37
     jr   nz, label_D91
     ld   a, [hl]
 
 label_D8B::
-    ld   [$FF94], a
+    ldh  [$FF94], a
     ld   a, $01
     ldh  [hNeedsUpdatingBGTiles], a
 
 label_D91::
     xor  a
-    ld   [$FFD7], a
-    ld   a, [$FFF6]
+    ldh  [$FFD7], a
+    ldh  a, [$FFF6]
     ld   e, a
     ld   d, $00
     ld   hl, $70D3
     ld   a, [$DBA5]
     ld   d, a
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $1A
     jr   nc, label_DAB
     cp   $06
@@ -2052,10 +2052,10 @@ label_DAB::
     ld   a, d
     and  a
     jr   z, label_DC1
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $10
     jr   nz, label_DDB
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $B5
     jr   nz, label_DDB
     ld   e, $3D
@@ -2085,7 +2085,7 @@ label_DDB::
     rl   d
     sla  e
     rl   d
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_DF1
     ld   a, $01
@@ -2113,7 +2113,7 @@ label_E03::
     cp   $FF
     jr   z, label_E29
     ld   [bc], a
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     and  a
     jr   z, label_E1E
     ld   a, d
@@ -2124,7 +2124,7 @@ label_E03::
 
 label_E1E::
     inc  a
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   a, d
     ld   [$C197], a
     ld   a, $01
@@ -2362,13 +2362,13 @@ label_F8F::
     dec  [hl]
 
 label_F97::
-    ld   a, [$FF98]
-    ld   [$FF9F], a
-    ld   a, [$FF99]
-    ld   [$FFA0], a
+    ldh  a, [$FF98]
+    ldh  [$FF9F], a
+    ldh  a, [$FF99]
+    ldh  [$FFA0], a
     ld   hl, $FFA2
     sub  a, [hl]
-    ld   [$FFB3], a
+    ldh  [$FFB3], a
     call label_60E0
     xor  a
     ld   [$C140], a
@@ -2444,7 +2444,7 @@ label_102E::
     jr   z, label_101F
 
 label_1033::
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     ld   hl, $FFA2
     sub  a, [hl]
     ld   [$C145], a
@@ -2505,7 +2505,7 @@ label_107F::
     ld   [$D45F], a
     cp   $04
     jr   c, label_10DF
-    ld   a, [$FFA1]
+    ldh  a, [$FFA1]
     cp   $02
     jr   z, label_10DB
     ldh  a, [hLinkAnimationState]
@@ -2542,18 +2542,18 @@ label_10DB::
     ld   [$D45F], a
 
 label_10DF::
-    ld   a, [$FFB7]
+    ldh  a, [$FFB7]
     and  a
     jr   z, label_10E7
     dec  a
-    ld   [$FFB7], a
+    ldh  [$FFB7], a
 
 label_10E7::
-    ld   a, [$FFB6]
+    ldh  a, [$FFB6]
     and  a
     jr   z, label_10EF
     dec  a
-    ld   [$FFB6], a
+    ldh  [$FFB6], a
 
 label_10EF::
     ld   a, [wDialogState]
@@ -2574,20 +2574,20 @@ label_10EF::
     ld   a, $07
     ld   [$C11C], a
     ld   a, $BF
-    ld   [$FFB7], a
+    ldh  [$FFB7], a
     ld   a, $10
     ld   [$C3CC], a
     xor  a
 
 label_1120::
     ld   [$DBC7], a
-    ld   [$FF9C], a
+    ldh  [$FF9C], a
     ld   [$DDD6], a
     ld   [$DDD7], a
     ld   [$D464], a
     call label_27F2
     ld   a, $08
-    ld   [$FFF3], a
+    ldh  [$FFF3], a
 
 label_1135::
     ld   a, [$C11C]
@@ -2686,7 +2686,7 @@ label_11C3::
     jr   nc, label_11E8
 
 label_11E2::
-    ld   a, [$FFA1]
+    ldh  a, [$FFA1]
     and  a
     jp   nz, label_12ED
 
@@ -2748,7 +2748,7 @@ label_1235::
     call label_1340
 
 label_124B::
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $20
     jr   z, label_125E
     ld   a, [$C1AD]
@@ -2758,7 +2758,7 @@ label_124B::
     call ItemFunction
 
 label_125E::
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $10
     jr   z, label_1275
     ld   a, [$C1AD]
@@ -2835,7 +2835,7 @@ UseShield::
     and  a
     ret  nz
     ld   a, $16
-    ld   [$FFF4], a
+    ldh  [$FFF4], a
     ret
 
 UseShovel::
@@ -2848,12 +2848,12 @@ label_1300::
     call label_4D20
     jr   nc, label_130B
     ld   a, $07
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     jr   label_130F
 
 label_130B::
     ld   a, $0E
-    ld   [$FFF4], a
+    ldh  [$FFF4], a
 
 label_130F::
     ld   a, $01
@@ -2993,12 +2993,12 @@ ShootArrow::
 
 label_1401::
     ld   a, $0A
-    ld   [$FFF4], a
+    ldh  [$FFF4], a
     ld   a, $06
 
 label_1407::
     ld   [$C1C0], a
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     ld   c, a
     ld   b, $00
 
@@ -3033,24 +3033,24 @@ label_142F::
     ld   a, $0C
     ld   [$C19B], a
     push bc
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     ld   c, a
     ld   b, $00
     ld   hl, data_139D
     add  hl, bc
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     add  a, [hl]
     ld   hl, $C200
     add  hl, de
     ld   [hl], a
     ld   hl, data_13A1
     add  hl, bc
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     add  a, [hl]
     ld   hl, $C210
     add  hl, de
     ld   [hl], a
-    ld   a, [$FFA2]
+    ldh  a, [$FFA2]
     inc  a
     ld   hl, $C310
     add  hl, de
@@ -3067,7 +3067,7 @@ label_142F::
     ld   hl, $C250
     add  hl, de
     ld   [hl], a
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     ld   hl, $C3B0
     add  hl, de
     ld   [hl], a
@@ -3092,7 +3092,7 @@ UseMagicPowder::
     ld   a, [$DB4B]
     and  a
     jr   z, label_14A7
-    ld   a, [$FFA2]
+    ldh  a, [$FFA2]
     and  a
     ret  nz
     ld   a, $02
@@ -3134,8 +3134,8 @@ UseRocksFeather::
     ld   [$C152], a
     ld   [$C153], a
     ld   a, $0D
-    ld   [$FFF2], a
-    ld   a, [$FFF9]
+    ldh  [$FFF2], a
+    ldh  a, [$FFF9]
     and  a
     jr   z, label_1508
     call label_1508
@@ -3146,9 +3146,9 @@ UseRocksFeather::
     ld   a, $E8
 
 label_14F8::
-    ld   [$FF9B], a
+    ldh  [$FF9B], a
     xor  a
-    ld   [$FFA3], a
+    ldh  [$FFA3], a
     call label_21A8
     ld   a, $02
     call SwitchBank
@@ -3156,21 +3156,21 @@ label_14F8::
 
 label_1508::
     ld   a, $20
-    ld   [$FFA3], a
+    ldh  [$FFA3], a
     ld   a, [$C14A]
     and  a
     ret  z
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     ld   e, a
     ld   d, b
     ld   hl, data_14C3
     add  hl, de
     ld   a, [hl]
-    ld   [$FF9A], a
+    ldh  [$FF9A], a
     ld   hl, data_14C7
     add  hl, de
     ld   a, [hl]
-    ld   [$FF9B], a
+    ldh  [$FF9B], a
 
 label_1523::
     ret
@@ -3200,7 +3200,7 @@ label_1535::
     ld   hl, data_1524
     add  hl, de
     ld   a, [hl]
-    ld   [$FFF4], a
+    ldh  [$FFF4], a
     call label_157C
     ld   a, [$C146]
     and  a
@@ -3234,7 +3234,7 @@ label_157C::
     ld   a, [hl]
     cp   $0F
     jr   z, label_158E
-    ld   [$FF9E], a
+    ldh  [$FF9E], a
 
 label_158E::
     ret
@@ -3273,27 +3273,27 @@ label_15C0::
     jr   label_15CF
 
 label_15CD::
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
 
 label_15CF::
     ld   e, a
     ld   d, $00
     ld   hl, $158F ; TODO: Check this
     add  hl, de
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     add  a, [hl]
     sub  a, $08
     and  $F0
-    ld   [$FFCE], a
+    ldh  [$FFCE], a
     swap a
     ld   c, a
     ld   hl, $159B ; TODO: Check this
     add  hl, de
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     add  a, [hl]
     sub  a, $10
     and  $F0
-    ld   [$FFCD], a
+    ldh  [$FFCD], a
     or   c
     ld   e, a
     ld   hl, wTileMap
@@ -3303,7 +3303,7 @@ label_15CF::
     ret  nz
     push de
     ld   a, [hl]
-    ld   [$FFAF], a
+    ldh  [$FFAF], a
     ld   e, a
     ld   a, [$DBA5]
     ld   d, a
@@ -3333,7 +3333,7 @@ label_1616::
     nop
     ld   a, [$DBA5]
     and  a
-    ld   a, [$FFAF]
+    ldh  a, [$FFAF]
     jr   z, label_1629
     cp   $DD
     jr   z, label_1637
@@ -3351,7 +3351,7 @@ label_1629::
 
 label_1637::
     ld   a, c
-    ld   [$FFF1], a
+    ldh  [$FFF1], a
     call label_2178
     ld   a, [$C14A]
     and  a
@@ -3372,17 +3372,17 @@ label_1653::
     ld   [$C19B], a
     ld   hl, $C200
     add  hl, de
-    ld   a, [$FFCE]
+    ldh  a, [$FFCE]
     add  a, $08
     ld   [hl], a
     ld   hl, $C210
     add  hl, de
-    ld   a, [$FFCD]
+    ldh  a, [$FFCD]
     add  a, $10
     ld   [hl], a
     ld   hl, $C3B0
     add  hl, de
-    ld   a, [$FFF1]
+    ldh  a, [$FFF1]
     ld   [hl], a
     ld   c, e
     ld   b, d
@@ -3392,7 +3392,7 @@ label_167C::
     call GetRandomByte
     and  $07
     ret  nz
-    ld   a, [$FFAF]
+    ldh  a, [$FFAF]
     cp   $D3
     ret  z
     call GetRandomByte
@@ -3406,12 +3406,12 @@ label_1691::
     ret  c
     ld   hl, $C200
     add  hl, de
-    ld   a, [$FFCE]
+    ldh  a, [$FFCE]
     add  a, $08
     ld   [hl], a
     ld   hl, $C210
     add  hl, de
-    ld   a, [$FFCD]
+    ldh  a, [$FFCD]
     add  a, $10
     ld   [hl], a
     ld   hl, $C450
@@ -3436,19 +3436,19 @@ label_16C2::
     ld   a, [$C16D]
     and  a
     ret  z
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     ld   e, a
     ld   d, $00
     ld   hl, data_16BA
     add  hl, de
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     add  a, [hl]
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   hl, data_16BE
     add  hl, de
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     add  a, [hl]
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
 
 label_16DF::
     ld   a, $04
@@ -3461,14 +3461,14 @@ label_16DF::
     cp   $90
     jr   z, label_16F8
     ld   a, $07
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     ret
 
 label_16F8::
     ld   a, $17
 
 label_16FA::
-    ld   [$FFF4], a
+    ldh  [$FFF4], a
     ret
 
 data_16FD::
@@ -3478,13 +3478,13 @@ data_1701::
     db   0, 0, $E0, $20
 
 label_1705::
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     jr   z, label_1713
-    ld   a, [$FF9C]
+    ldh  a, [$FF9C]
     and  a
     ret  nz
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     and  $02
     ret  nz
 
@@ -3492,7 +3492,7 @@ label_1713::
     ld   a, [$C14A]
     and  a
     ret  nz
-    ld   a, [$FFA2]
+    ldh  a, [$FFA2]
     ld   hl, $C146
     or   [hl]
     ret  nz
@@ -3509,17 +3509,17 @@ label_1713::
     xor  a
     ld   [wIsUsingSpinAttack], a
     ld   [$C122], a
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     ld   e, a
     ld   d, $00
     ld   hl, data_16FD
     add  hl, de
     ld   a, [hl]
-    ld   [$FF9A], a
+    ldh  [$FF9A], a
     ld   hl, data_1701
     add  hl, de
     ld   a, [hl]
-    ld   [$FF9B], a
+    ldh  [$FF9B], a
     xor  a
     ld   [$C1AC], a
     ret
@@ -3534,31 +3534,31 @@ label_1756::
     ld   hl, $C146
     or   [hl]
     ret  nz
-    ld   a, [$FF98]
-    ld   [$FFD7], a
+    ldh  a, [$FF98]
+    ldh  [$FFD7], a
     ld   a, [$C181]
     cp   $05
     jr   z, label_1781
     ld   a, $07
-    ld   [$FFF4], a
-    ld   a, [$FF99]
+    ldh  [$FFF4], a
+    ldh  a, [$FF99]
     add  a, $06
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     ld   a, $0B
     jp   label_CC7
 
 label_1781::
-    ld   a, [$FF99]
-    ld   [$FFD8], a
+    ldh  a, [$FF99]
+    ldh  [$FFD8], a
     ld   a, $0E
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     ld   a, $0C
     jp   label_CC7
 
 label_178E::
     xor  a
-    ld   [$FF9A], a
-    ld   [$FF9B], a
+    ldh  [$FF9A], a
+    ldh  [$FF9B], a
     ret
 
 label_1794::
@@ -3573,9 +3573,9 @@ label_1794::
     ld   a, [$C145]
     ld   hl, $C13B
     add  a, [hl]
-    ld   [$FFD7], a
-    ld   a, [$FF98]
-    ld   [$FFD8], a
+    ldh  [$FFD7], a
+    ldh  a, [$FF98]
+    ldh  [$FFD8], a
     ld   hl, $FFDA
     ld   [hl], $00
     ld   a, [$C122]
@@ -3593,8 +3593,8 @@ label_17C6::
     ld   a, [$C13A]
     ld   l, a
     ld   a, [$C136]
-    ld   [$FFD9], a
-    ld   a, [$FF99]
+    ldh  [$FFD9], a
+    ldh  a, [$FF99]
     cp   $88
     ret  nc
     jp   label_1819
@@ -3620,7 +3620,7 @@ label_17DB::
     call label_142F
     jr   c, label_1814
     ld   a, $0D
-    ld   [$FFF4], a
+    ldh  [$FFF4], a
     ld   a, $02
     call SwitchBank
     call label_538B
@@ -3663,7 +3663,7 @@ label_1847::
     xor  a
     ldh  [hBaseScrollX], a
     ldh  [hBaseScrollY], a
-    ld   [$FFB4], a
+    ldh  [$FFB4], a
     ld   [$DDD6], a
     ld   [$DDD7], a
     ld   e, $10
@@ -3694,28 +3694,28 @@ label_186C::
     ldh  [hLinkAnimationState], a
 
 label_1898::
-    ld   a, [$FFF9]
-    ld   [$FFE4], a
+    ldh  a, [$FFF9]
+    ldh  [$FFE4], a
     ld   a, GAMEPLAY_OVERWORLD
     ld   [wGameplayType], a
     xor  a
     ld   [wGameplaySubtype], a
     ld   [$C3CB], a
-    ld   [$FFF9], a
+    ldh  [$FFF9], a
     ld   hl, $D401
     ld   a, [$DBA5]
-    ld   [$FFE6], a
+    ldh  [$FFE6], a
     and  a
     jr   nz, label_18DF
     ld   hl, $D416
     ld   c, $00
 
 label_18BA::
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     swap a
     and  $0F
     ld   e, a
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     sub  a, $08
     and  $F0
     or   e
@@ -3743,21 +3743,21 @@ label_18DF::
     ld   [$DBA5], a
     cp   $02
     jr   nz, label_18F2
-    ld   [$FFF9], a
+    ldh  [$FFF9], a
     dec  a
     ld   [$DBA5], a
     ld   a, $01
-    ld   [$FF9C], a
+    ldh  [$FF9C], a
 
 label_18F2::
     ld   a, [hli]
-    ld   [$FFF7], a
+    ldh  [$FFF7], a
     ld   a, [$DBA5]
     and  a
     ld   a, [hli]
-    ld   [$FFF6], a
+    ldh  [$FFF6], a
     jr   nz, label_1909
-    ld   a, [$FFE6]
+    ldh  a, [$FFE6]
     and  a
     jr   z, label_1907
     xor  a
@@ -3771,7 +3771,7 @@ label_1909::
     ld   a, $14
     call SwitchBank
     push hl
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     swap a
     ld   e, a
     ld   d, $00
@@ -3781,7 +3781,7 @@ label_1909::
     rl   d
     ld   hl, $4220
     add  hl, de
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_192E
     ld   hl, $44E0
@@ -3810,19 +3810,19 @@ label_193E::
 label_1948::
     ld   a, e
     ld   [$DBAE], a
-    ld   a, [$FFE6]
+    ldh  a, [$FFE6]
     and  a
     jr   nz, label_196E
     xor  a
     ld   [$D47C], a
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $0A
     jr   nc, label_196E
     ld   a, $02
     call SwitchBank
     call label_6709
     ld   a, $30
-    ld   [$FFB4], a
+    ldh  [$FFB4], a
     xor  a
     ld   [$D6FB], a
     ld   [$D6F8], a
@@ -3836,16 +3836,16 @@ label_196F::
     ld   a, [hl]
     ld   [$DB9E], a
     pop  hl
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     jr   nz, label_19DA
-    ld   a, [$FFE4]
+    ldh  a, [$FFE4]
     and  a
     jr   nz, label_19D9
     ld   a, [$DBA5]
     and  a
     jr   z, label_19C2
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_1993
     ld   hl, $4E3C
@@ -3868,7 +3868,7 @@ label_19A4::
     ld   [SelectRomBank_2100], a
     call label_19C2
     push de
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_19B7
     ld   a, $3A
@@ -3888,16 +3888,16 @@ label_19BF::
 
 label_19C2::
     ld   a, $00
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   de, $DB5F
 
 label_19C9::
     ld   a, [hli]
     ld   [de], a
     inc  de
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     inc  a
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     cp   $05
     jr   nz, label_19C9
     ld   a, [$DBAE]
@@ -3908,7 +3908,7 @@ label_19D9::
 
 label_19DA::
     xor  a
-    ld   [$FF9E], a
+    ldh  [$FF9E], a
     ret
     call label_754F
     ld   a, [$D474]
@@ -3978,7 +3978,7 @@ label_1A50::
     sra  a
     and  $01
     ld   d, a
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     sla  a
     or   d
     ld   c, a
@@ -3987,7 +3987,7 @@ label_1A50::
     ld   a, [$C11C]
     cp   $01
     jr   nz, label_1A78
-    ld   a, [$FF9C]
+    ldh  a, [$FF9C]
     and  a
     jr   z, label_1A76
     ld   hl, $4950
@@ -3996,10 +3996,10 @@ label_1A76::
     jr   label_1AC7
 
 label_1A78::
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     jr   z, label_1A88
-    ld   a, [$FF9C]
+    ldh  a, [$FF9C]
     cp   $02
     jr   nz, label_1A88
     ld   hl, $4958
@@ -4009,7 +4009,7 @@ label_1A88::
     ld   a, [$C15C]
     cp   $01
     jr   z, label_1AC4
-    ld   a, [$FFB2]
+    ldh  a, [$FFB2]
     and  a
     jr   nz, label_1A9A
     ld   a, [$C144]
@@ -4089,8 +4089,8 @@ AnimateMarinBeachTiles::
     jp   CopyData
     jr   nz, AnimateTilesStep4
     and  b
-    ld   [$FFE0], a
-    ld   [$FFA0], a
+    ldh  [$FFE0], a
+    ldh  [$FFA0], a
     ld   h, b
 
 AnimateTiles::
@@ -4147,7 +4147,7 @@ AnimateTilesStep2::
     jr   nz, AnimateTilesStep3
 
     ; GameplayType == CREDITS
-    ld   a, [$FFA5]
+    ldh  a, [$FFA5]
     and  a                          ; if $FFA5 != 0
     jr   nz, AnimateEndCreditsTiles ;   handle end credits animated tiles
     ret
@@ -4184,7 +4184,7 @@ AnimateTilesStep4::
     jp   DrawLinkSpriteAndReturn
 
 label_1B7D::
-    ld   a, [$FFA5]
+    ldh  a, [$FFA5]
     and  a
     jr   z, label_1BCD
 
@@ -4225,12 +4225,12 @@ label_1BC5::
 
 label_1BCD::
     ; Increment $FFA6 (count of tiles animations run?)
-    ld   a, [$FFA6]
+    ldh  a, [$FFA6]
     inc  a
-    ld   [$FFA6], a
+    ldh  [$FFA6], a
 
 label_1BD2::
-    ld   a, [$FFA4]
+    ldh  a, [$FFA4]
     JP_TABLE
     ; Code below is actually data for the jump table
     ld   e, $1D
@@ -4265,7 +4265,7 @@ label_1BD2::
     inc  e
     rst  $38
     inc  e
-    ld   a, [$FFA6]
+    ldh  a, [$FFA6]
     and  $07
     jp   nz, label_1D1E
     ld   a, $01
@@ -4288,7 +4288,7 @@ label_1C13::
     ld   h, $6A
 
 label_1C24::
-    ld   a, [$FFA6]
+    ldh  a, [$FFA6]
     and  $0F
     jp   nz, label_1D1E
     call label_1CE8
@@ -4298,10 +4298,10 @@ data_1C31::
     db 0, $40, $80, $C0, $C0, $C0, $80, $40
 
 label_1C39::
-    ld   a, [$FFA6]
+    ldh  a, [$FFA6]
     and  $07
     jp   nz, label_1D1E
-    ld   a, [$FFA6]
+    ldh  a, [$FFA6]
     rra
     rra
     rra
@@ -4319,7 +4319,7 @@ label_1C51::
 label_1C54::
     ld   bc, $0040
     call CopyData
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_1C87
     ld   a, $20
@@ -4344,10 +4344,10 @@ label_1C87::
     jp   DrawLinkSpriteAndReturn
     ld   h, $6E
     jr   label_1C24
-    ld   a, [$FFA6]
+    ldh  a, [$FFA6]
     and  $07
     jp   nz, label_1D1E
-    ld   a, [$FFA6]
+    ldh  a, [$FFA6]
     rra
     rra
     rra
@@ -4360,14 +4360,14 @@ label_1C87::
     ld   h, $6F
     jp   label_1C51
     ld   hl, $DCC0
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_1CB8
     ld   de, $8400
     jp   label_1C54
 
 label_1CB8::
-    ld   a, [$FFA6]
+    ldh  a, [$FFA6]
     inc  a
     and  $03
     jp   nz, label_1C39
@@ -4376,7 +4376,7 @@ label_1CB8::
     ld   h, $70
 
 label_1CC8::
-    ld   a, [$FFA6]
+    ldh  a, [$FFA6]
     and  $07
     jp   nz, label_1D1E
     call label_1CE8
@@ -4384,7 +4384,7 @@ label_1CC8::
     ld   h, $71
 
 label_1CD7::
-    ld   a, [$FFA6]
+    ldh  a, [$FFA6]
     and  $03
     jp   nz, label_1D1E
     call label_1CE8
@@ -4393,9 +4393,9 @@ label_1CD7::
     jr   label_1CD7
 
 label_1CE8::
-    ld   a, [$FFA7]
+    ldh  a, [$FFA7]
     add  a, $40
-    ld   [$FFA7], a
+    ldh  [$FFA7], a
     ret
     ld   h, $75
     jr   label_1CD7
@@ -4464,7 +4464,7 @@ label_1D49::
     ldi  [hl], a
     ld   a, [$C13C]
     ld   c, a
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     add  a, c
     ldi  [hl], a
     ld   a, $00
@@ -4512,7 +4512,7 @@ label_1DA1::
     inc  hl
     pop  af
     ldi  [hl], a
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     add  a, c
     add  a, $08
     ldi  [hl], a
@@ -4627,7 +4627,7 @@ label_1E55::
     ld   bc, $0040
     call CopyData
     xor  a
-    ld   [$FFA5], a
+    ldh  [$FFA5], a
     ld   a, $0C
     call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
@@ -4770,7 +4770,7 @@ label_1F3B::
 
 label_1F3E::
     xor  a
-    ld   [$FFA5], a
+    ldh  [$FFA5], a
     ld   a, $0C
     ld   [SelectRomBank_2100], a
     jp   DrawLinkSpriteAndReturn
@@ -4807,44 +4807,44 @@ label_1F69::
     ld   hl, $C11C
     or   [hl]
     jp   nz, label_2177
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     ld   e, a
     ld   d, $00
     ld   hl, data_1F49
     add  hl, de
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     add  a, [hl]
     sub  a, $08
     and  $F0
-    ld   [$FFCE], a
+    ldh  [$FFCE], a
     swap a
     ld   c, a
     ld   hl, data_1F4D
     add  hl, de
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     add  a, [hl]
     sub  a, $10
     and  $F0
-    ld   [$FFCD], a
+    ldh  [$FFCD], a
     or   c
     ld   e, a
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     ld   hl, wTileMap
     add  hl, de
     ld   a, h
     cp   $D7
     jp   nz, label_214E
     ld   a, [hl]
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   e, a
     ld   a, [$DBA5]
     ld   d, a
     call label_2A26
-    ld   [$FFDC], a
-    ld   a, [$FFD7]
+    ldh  [$FFDC], a
+    ldh  a, [$FFD7]
     cp   $9A
     jr   z, label_1FFE
-    ld   a, [$FFDC]
+    ldh  a, [$FFDC]
     cp   $00
     jp   z, label_214E
     cp   $01
@@ -4863,7 +4863,7 @@ label_1F69::
     jp   nc, label_214E
 
 label_1FE6::
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     ld   e, a
     cp   $6F
     jr   z, label_1FF6
@@ -4880,12 +4880,12 @@ label_1FF6::
 
 label_1FFE::
     ld   e, a
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     cp   $02
     jp   nz, label_20CF
     ld   a, $02
     ld   [$C1AD], a
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $30
     jp   z, label_20CF
     ld   a, e
@@ -4907,7 +4907,7 @@ label_1FFE::
 label_2030::
     ld   a, [$DB4E]
     and  a
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     jr   nz, label_203E
     ld   e, $FF
     cp   $A3
@@ -4924,7 +4924,7 @@ label_2046::
     jr   label_208E
 
 label_2049::
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     ld   e, a
     ld   d, $00
     ld   a, $14
@@ -4945,11 +4945,11 @@ label_2066::
     jr   nz, label_2080
     bit  0, e
     jr   nz, label_2080
-    ld   a, [$FFCE]
+    ldh  a, [$FFCE]
     swap a
     and  $0F
     ld   e, a
-    ld   a, [$FFCD]
+    ldh  a, [$FFCD]
     and  $F0
     or   e
     ld   [$D473], a
@@ -4980,17 +4980,17 @@ label_2098::
     and  $1F
     cp   $0D
     jr   z, label_20CF
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     cp   $02
     jr   nz, label_20CF
     ld   [$C1AD], a
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $30
     jr   z, label_20CF
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     jr   nz, label_20BF
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     cp   $02
     jr   nz, label_20CF
 
@@ -5024,8 +5024,8 @@ label_20EC::
     ld   [SelectRomBank_2100], a
     call label_48B0
     ld   a, $01
-    ld   [$FFA1], a
-    ld   a, [$FF9E]
+    ldh  [$FFA1], a
+    ldh  a, [$FF9E]
     ld   e, a
     ld   d, $00
     ld   hl, data_1F51
@@ -5061,8 +5061,8 @@ label_212C::
     cp   e
     jr   c, label_214D
     xor  a
-    ld   [$FFE5], a
-    ld   a, [$FFD7]
+    ldh  [$FFE5], a
+    ldh  a, [$FFD7]
     cp   $8E
     jr   z, label_2153
     cp   $20
@@ -5070,7 +5070,7 @@ label_212C::
     ld   a, [$DBA5]
     and  a
     jr   nz, label_214D
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     cp   $5C
     jr   z, label_2161
 
@@ -5091,15 +5091,15 @@ label_2153::
 
 label_2161::
     ld   a, $01
-    ld   [$FFE5], a
+    ldh  [$FFE5], a
 
 label_2165::
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     ld   e, a
-    ld   a, [$FFD7]
-    ld   [$FFAF], a
+    ldh  a, [$FFD7]
+    ldh  [$FFAF], a
     call label_2178
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     ld   [$C15D], a
     jp   label_2183
 
@@ -5117,13 +5117,13 @@ label_2183::
     call label_142F
     jr   c, label_21A7
     ld   a, $02
-    ld   [$FFF3], a
+    ldh  [$FFF3], a
     ld   hl, wEntitiesTypeTable
     add  hl, de
     ld   [hl], $07
     ld   hl, $C3B0
     add  hl, de
-    ld   a, [$FFE5]
+    ldh  a, [$FFE5]
     ld   [hl], a
     ld   c, e
     ld   b, d
@@ -5142,7 +5142,7 @@ label_21A8::
     ld   c, $01
     call label_21B6
     ld   c, $00
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
 
 label_21B6::
     ld   b, $00
@@ -5173,7 +5173,7 @@ label_21D7::
     adc  a, [hl]
     ld   [hl], a
     ret
-    ld   a, [$FFA3]
+    ldh  a, [$FFA3]
     push af
     swap a
     and  $F0
@@ -5240,7 +5240,7 @@ label_222C::
 label_2241::
     push bc
     push de
-    ld   a, [$FFD9]
+    ldh  a, [$FFD9]
     ld   c, a
     ld   b, $00
     ld   hl, wTileMap
@@ -5272,7 +5272,7 @@ label_2262::
     and  a
     jr   z, label_2299
     ld   hl, $43B0
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_2291
     ld   hl, $4760
@@ -5307,17 +5307,17 @@ label_2299::
     ld   a, $20
     ld   [SelectRomBank_2100], a
     call label_49D9
-    ld   a, [$FFDF]
+    ldh  a, [$FFDF]
     ld   [SelectRomBank_2100], a
     call label_2214
     ld   a, b
-    ld   [$FFE2], a
+    ldh  [$FFE2], a
     ld   a, c
-    ld   [$FFE3], a
+    ldh  [$FFE3], a
     ld   a, d
-    ld   [$FFE4], a
+    ldh  [$FFE4], a
     ld   a, e
-    ld   [$FFE5], a
+    ldh  [$FFE5], a
     call label_3905
     pop  de
     pop  bc
@@ -5335,17 +5335,17 @@ label_22D3::
     ld   a, $20
     ld   [SelectRomBank_2100], a
     call label_49D9
-    ld   a, [$FFDF]
+    ldh  a, [$FFDF]
     ld   [SelectRomBank_2100], a
     call label_2224
     ld   a, b
-    ld   [$FFE2], a
+    ldh  [$FFE2], a
     ld   a, c
-    ld   [$FFE3], a
+    ldh  [$FFE3], a
     ld   a, d
-    ld   [$FFE4], a
+    ldh  [$FFE4], a
     ld   a, e
-    ld   [$FFE5], a
+    ldh  [$FFE5], a
     call label_3905
     pop  de
     pop  bc
@@ -5357,9 +5357,9 @@ label_22FE::
     ld   b, $00
     ld   hl, data_2205
     add  hl, bc
-    ld   a, [$FFD9]
+    ldh  a, [$FFD9]
     add  a, [hl]
-    ld   [$FFD9], a
+    ldh  [$FFD9], a
     pop  bc
     ld   a, [$C128]
     dec  a
@@ -5381,7 +5381,7 @@ label_2321::
     ld   a, $7F
 
 label_2332::
-    ld   [$FFE8], a
+    ldh  [$FFE8], a
     ld   a, [$C164]
     and  a
     ld   a, [$C170]
@@ -5457,7 +5457,7 @@ label_2385::
     ld   [$C112], a
     ld   a, $0F
     ld   [$C5AB], a
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     cp   $48
     rra
     and  $80
@@ -5503,13 +5503,13 @@ label_23EF::
     ld   a, [$C12F]
     add  a, [hl]
     ld   l, a
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   hl, data_23D6
     add  hl, de
     ld   a, [$C12E]
     add  a, [hl]
     ld   h, a
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     ld   l, a
     xor  a
     ld   e, a
@@ -5536,9 +5536,9 @@ label_242B::
     cp   $12
     jr   nz, label_241E
     ld   e, $00
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     add  a, $20
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     jr   nc, label_243C
     inc  h
 
@@ -5583,9 +5583,9 @@ label_2464::
     cp   $12
     jr   nz, label_2444
     ld   e, $00
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     add  a, $20
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     jr   nc, label_2475
     inc  h
 
@@ -5607,7 +5607,7 @@ label_2485::
     ld   a, [$C1AB]
     and  a
     jr   nz, label_24AE
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $30
     jr   z, label_24AE
 
@@ -5759,7 +5759,7 @@ label_2529::
     ld   [$C3C3], a
     call ReloadSavedBank
     ld   a, e
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     cp   $FE
     jr   nz, label_25A4
     pop  hl
@@ -5774,7 +5774,7 @@ label_2595::
 
 label_259F::
     ld   a, $15
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     ret
 
 label_25A4::
@@ -5814,7 +5814,7 @@ label_25D4::
     and  e
     jr   nz, label_25DF
     ld   a, d
-    ld   [$FFF3], a
+    ldh  [$FFF3], a
 
 label_25DF::
     pop  af
@@ -5847,7 +5847,7 @@ label_25FF::
     ld   a, $20
 
 label_2608::
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     ld   e, a
     ld   a, $1C
     ld   [SelectRomBank_2100], a
@@ -5881,7 +5881,7 @@ label_2633::
     push hl
     ld   a, $1C
     ld   [SelectRomBank_2100], a
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     ld   e, a
     ld   d, $00
     xor  a
@@ -5954,7 +5954,7 @@ label_2695::
 
 label_26B6::
     call label_27BB
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     bit  4, a
     jr   nz, label_26E1
     bit  5, a
@@ -5995,7 +5995,7 @@ label_26EB::
     ld   [$D602], a
     ld   a, $4F
     ld   [$D603], a
-    ld   a, [$FFE8]
+    ldh  a, [$FFE8]
     ld   [$D604], a
     xor  a
     ld   [$D605], a
@@ -6053,7 +6053,7 @@ label_2739::
     ld   a, l
     add  a, $20
     ld   l, a
-    ld   a, [$FFE8]
+    ldh  a, [$FFE8]
     ld   [hl], a
     pop  bc
     inc  bc
@@ -6100,7 +6100,7 @@ label_278B::
     ld   a, $02
     ld   [$C177], a
     jp   label_2496
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     bit  4, a
     jp   nz, label_27B7
     and  $03
@@ -6111,7 +6111,7 @@ label_278B::
     and  $01
     ld   [hl], a
     ld   a, $0A
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
 
 label_27AA::
     ldh  a, [hFrameCounter]
@@ -6133,11 +6133,11 @@ label_27BB::
 ; Set overworld music track?
 label_27C3::
     ld   [wOverworldMusic], a
-    ld   [$FFBF], a
+    ldh  [$FFBF], a
     ld   a, $38
-    ld   [$FFAB], a
+    ldh  [$FFAB], a
     xor  a
-    ld   [$FFA8], a
+    ldh  [$FFA8], a
     ret
 
 EnableExternalRAMWriting::
@@ -6159,13 +6159,13 @@ label_27DD::
 
 label_27EA::
     ld   a, $38
-    ld   [$FFA8], a
+    ldh  [$FFA8], a
     xor  a
-    ld   [$FFAB], a
+    ldh  [$FFAB], a
     ret
 
 label_27F2::
-    ld   a, [$FFBC]
+    ldh  a, [$FFBC]
     and  a
     jr   nz, .skip
     ld   a, $1F
@@ -6206,7 +6206,7 @@ ReadJoypadState::
     ld   a, [$C11C]
     cp   $07
     jr   nz, label_283F
-    ld   a, [$FF9C]
+    ldh  a, [$FF9C]
     cp   $04
     jr   z, label_2852
 
@@ -6221,7 +6221,7 @@ label_283F::
 label_284C::
     xor  a
     ldh  [hPressedButtonsMask], a
-    ld   [$FFCC], a
+    ldh  [$FFCC], a
     ret
 
 label_2852::
@@ -6250,7 +6250,7 @@ label_2852::
     ldh  a, [hPressedButtonsMask]
     xor  c
     and  c
-    ld   [$FFCC], a
+    ldh  [$FFCC], a
     ld   a, c
     ldh  [hPressedButtonsMask], a
     ld   a, $30
@@ -6261,7 +6261,7 @@ label_2886::
 
 label_2887::
     push bc
-    ld   a, [$FFCD]
+    ldh  a, [$FFCD]
     ld   hl, hBaseScrollY
     add  a, [hl]
     and  $F8
@@ -6278,7 +6278,7 @@ label_289F::
     dec  b
     jr   nz, label_289F
     push hl
-    ld   a, [$FFCE]
+    ldh  a, [$FFCE]
     ld   hl, hBaseScrollX
     add  a, [hl]
     pop  hl
@@ -6290,9 +6290,9 @@ label_289F::
     ld   e, a
     add  hl, de
     ld   a, h
-    ld   [$FFCF], a
+    ldh  [$FFCF], a
     ld   a, l
-    ld   [$FFD0], a
+    ldh  [$FFD0], a
     pop  bc
     ret
 
@@ -6324,7 +6324,7 @@ TableJump::
 ; Turn off LCD at next vertical blanking
 LCDOff::
     ld   a, [rIE]
-    ld   [$FFD2], a ; Save interrupts configuration
+    ldh  [$FFD2], a ; Save interrupts configuration
     res  0, a
     ld   [rIE], a   ; Disable all interrupts
 .waitForEndOfLine
@@ -6334,7 +6334,7 @@ LCDOff::
     ld   a, [rLCDC]  ; \
     and  $7F         ; | Switch off LCD screen
     ld   [rLCDC], a  ; /
-    ld   a, [$FFD2]
+    ldh  a, [$FFD2]
     ld   [rIE], a    ; Restore interrupts configuration
     ret
 
@@ -6590,7 +6590,7 @@ label_2A12::
     ld   a, $08
     ld   [SelectRomBank_2100], a
     ld   hl, $4AD4
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_2A23
     ld   hl, $4BD4
@@ -6822,7 +6822,7 @@ label_2C28::
     ld   a, $20
     call SwitchBank
     ld   hl, $4589
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     ld   e, a
     ld   d, $00
     cp   $FF
@@ -6862,7 +6862,7 @@ label_2C5D::
     pop  de
     push de
     ld   hl, $45A9
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_2C8A
     ld   hl, $45C9
@@ -6892,7 +6892,7 @@ label_2C8A::
     ld   l, $00
     ld   a, $12
     call SwitchAdjustedBank
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_2CD1
     ld   hl, $6100
@@ -6906,7 +6906,7 @@ label_2CD1::
     ld   a, [wCurrentBank]
     ld   [SelectRomBank_2100], a
     ld   hl, $7D00
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   z, label_2CF5
     cp   $0A
@@ -6930,7 +6930,7 @@ label_2D07::
     ld   a, [$DBA5]
     and  a
     jr   z, label_2D17
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   z, label_2D21
     cp   $0A
@@ -6947,7 +6947,7 @@ label_2D21::
     cp   $02
     jr   c, label_2D2C
     ld   a, $0D
-    ld   [$FFA5], a
+    ldh  [$FFA5], a
 
 label_2D2C::
     ret
@@ -6966,8 +6966,8 @@ label_2D2C::
 
 label_2D50::
     xor  a
-    ld   [$FFA6], a
-    ld   [$FFA7], a
+    ldh  [$FFA6], a
+    ldh  [$FFA7], a
     call label_1BD2
     ld   a, $0C
     call AdjustBankNumberForGBC
@@ -7088,7 +7088,7 @@ label_2E70::
     ld   de, $120E
 
 label_2E73::
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_2E84
     ld   a, $20
@@ -7100,7 +7100,7 @@ label_2E84::
     xor  a
 
 label_2E85::
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   hl, $C193
     ld   e, a
     ld   d, $00
@@ -7110,15 +7110,15 @@ label_2E85::
     ld   a, [$DBA5]
     and  a
     jr   z, label_2EB0
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     jr   nz, label_2ED3
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $14
     jr   z, label_2ED3
     cp   $0A
     jr   c, label_2ED3
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $FD
     jr   z, label_2ED3
     cp   $B1
@@ -7171,7 +7171,7 @@ label_2ED4::
 
 label_2EF2::
     ld   [SelectRomBank_2100], a
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     ld   d, a
     ld   e, $00
     ld   hl, $8400
@@ -7184,7 +7184,7 @@ label_2EF2::
     call CopyData
 
 label_2F0A::
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     inc  a
     cp   $04
     jp   nz, label_2E85
@@ -7197,11 +7197,11 @@ label_2F12::
     ld   a, $0D
     call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     jr   z, label_2F4B
     ld   hl, $7000
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $06
     jr   z, label_2F41
     cp   $0A
@@ -7212,7 +7212,7 @@ label_2F36::
     jr   label_2F41
 
 label_2F3B::
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $E9
     jr   z, label_2F36
 
@@ -7223,16 +7223,16 @@ label_2F41::
     ret
 
 label_2F4B::
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_2F57
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $12
     jr   nz, label_2F69
 
 label_2F57::
     ld   hl, $5000
-    ld   a, [$FF94]
+    ldh  a, [$FF94]
     cp   $FF
     jr   z, label_2F69
     add  a, $50
@@ -7241,10 +7241,10 @@ label_2F57::
     call CopyData
 
 label_2F69::
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $10
     jr   nz, label_2F87
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $B5
     jr   nz, label_2F87
     ld   a, $35
@@ -7259,7 +7259,7 @@ label_2F87::
     ldh  a, [hIsGBC]
     and  a
     ret  z
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     and  a
     ret  nz
     ld   a, $35
@@ -7278,7 +7278,7 @@ label_2FAD::
     ld   a, $0F
     call AdjustBankNumberForGBC
     ld   [SelectRomBank_2100], a
-    ld   a, [$FF94]
+    ldh  a, [$FF94]
     cp   $0F
     jr   z, label_2FC6
     add  a, $40
@@ -7307,12 +7307,12 @@ label_2FCD::
     sla  c
     rl   b
     ld   hl, $6749
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   z, label_2FEC
     cp   $10
     jr   nz, label_2FF1
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $B5
     jr   nz, label_2FF1
 
@@ -7371,12 +7371,12 @@ label_3019::
     and  a
     jr   z, label_304C
     ld   hl, $43B0
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   z, label_3047
     cp   $10
     jr   nz, label_304F
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $B5
     jr   nz, label_304F
 
@@ -7393,11 +7393,11 @@ label_304F::
     call label_2FC7
     pop  de
     push hl
-    ld   a, [$FFDF]
+    ldh  a, [$FFDF]
     ld   [SelectRomBank_2100], a
-    ld   a, [$FFE0]
+    ldh  a, [$FFE0]
     ld   h, a
-    ld   a, [$FFE1]
+    ldh  a, [$FFE1]
     ld   l, a
     ld   a, $01
     ld   [rVBK], a
@@ -7406,9 +7406,9 @@ label_304F::
     ld   [rVBK], a
     call label_3905
     ld   a, h
-    ld   [$FFE0], a
+    ldh  [$FFE0], a
     ld   a, l
-    ld   [$FFE1], a
+    ldh  [$FFE1], a
     pop  hl
     ld   a, e
     add  a, $1F
@@ -7419,11 +7419,11 @@ label_304F::
     push de
     call label_2FC7
     pop  de
-    ld   a, [$FFDF]
+    ldh  a, [$FFDF]
     ld   [SelectRomBank_2100], a
-    ld   a, [$FFE0]
+    ldh  a, [$FFE0]
     ld   h, a
-    ld   a, [$FFE1]
+    ldh  a, [$FFE1]
     ld   l, a
     ld   a, $01
     ld   [rVBK], a
@@ -7522,7 +7522,7 @@ label_3119::
     jr   z, label_313A
     ld   a, $14
     ld   [SelectRomBank_2100], a
-    ld   [$FFE8], a
+    ldh  [$FFE8], a
     call label_5897
     ld   e, a
     ld   hl, wKillCount2
@@ -7536,7 +7536,7 @@ label_3132::
     jr   nz, label_3132
 
 label_313A::
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     ld   e, a
     ld   d, $00
     ld   hl, wMinimapTiles
@@ -7544,7 +7544,7 @@ label_313A::
     and  a
     jr   z, label_3161
     ld   hl, $D900
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_3156
     ld   hl, $DDE0
@@ -7559,7 +7559,7 @@ label_3156::
 
 label_3161::
     add  hl, de
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     ld   a, [hl]
     jr   nz, label_316B
@@ -7567,8 +7567,8 @@ label_3161::
     ld   [hl], a
 
 label_316B::
-    ld   [$FFF8], a
-    ld   a, [$FFF6]
+    ldh  [$FFF8], a
+    ldh  a, [$FFF6]
     ld   c, a
     ld   b, $00
     sla  c
@@ -7578,8 +7578,8 @@ label_316B::
     jr   z, label_31BF
     ld   a, $0A
     ld   [SelectRomBank_2100], a
-    ld   [$FFE8], a
-    ld   a, [$FFF7]
+    ldh  [$FFE8], a
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_318F
     ld   hl, $7B77
@@ -7588,7 +7588,7 @@ label_316B::
 label_318F::
     cp   $1F
     jr   nz, label_31A6
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $F5
     jr   nz, label_31A6
     ld   a, [wTradeSequenceItem]
@@ -7599,19 +7599,19 @@ label_318F::
 
 label_31A6::
     ld   hl, $4000
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $1A
     jr   nc, label_3224
     cp   $06
     jr   c, label_3224
     ld   a, $0B
     ld   [SelectRomBank_2100], a
-    ld   [$FFE8], a
+    ldh  [$FFE8], a
     ld   hl, $4000
     jr   label_3224
 
 label_31BF::
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $0E
     jr   nz, label_31D1
     ld   a, [$D80E]
@@ -7679,7 +7679,7 @@ label_3224::
     jr   nz, label_323A
 
 label_322F::
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $80
     jr   c, label_323A
     ld   a, $1A
@@ -7689,7 +7689,7 @@ label_323A::
     ld   a, [bc]
     cp   $FE
     jr   z, endOfRoom
-    ld   [$FFA4], a
+    ldh  [$FFA4], a
     inc  bc
     ld   a, [$DBA5]
     and  a
@@ -7713,7 +7713,7 @@ CopyMapToTileMapLoop::
     and  $FC
     cp   $E0
     jr   nz, CopyMapToTileMapLoop_consecutive_tiles
-    ld   a, [$FFE6]
+    ldh  a, [$FFE6]
     ld   e, a
     ld   d, $00
     ld   hl, $D401
@@ -7735,7 +7735,7 @@ CopyMapToTileMapLoop::
     ldi  [hl], a
     ld   a, e
     add  a, $05
-    ld   [$FFE6], a
+    ldh  [$FFE6], a
     jr   CopyMapToTileMapLoop
 
 CopyMapToTileMapLoop_consecutive_tiles::
@@ -7759,18 +7759,18 @@ endOfRoom::
 
 label_32A9::
     xor  a
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   a, [bc] ; tile address
     bit  7, a
     jr   z, label_32B8
     bit  4, a
     jr   nz, label_32B8
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     inc  bc ; increment tile address
 
 label_32B8::
     inc  bc
-    ld   a, [$FFF8]
+    ldh  a, [$FFF8]
     ld   e, a
     ld   a, [$DBA5]
     and  a
@@ -7897,7 +7897,7 @@ MoveToNextLine_notTileBA::
     jr   nz, MoveToNextLine_notTileD3
     bit  4, e
     jr   z, MoveToNextLine_notTileD3
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $75
     jr   z, label_337C
     cp   $07
@@ -7915,7 +7915,7 @@ label_337C::
 
 MoveToNextLine_notTileD3::
     ld   a, d
-    ld   [$FFE0], a
+    ldh  [$FFE0], a
     cp   $C2
     jr   z, label_33A8
     cp   $E1
@@ -7950,7 +7950,7 @@ label_33A8::
     inc  bc
 
 MoveToNextLine_noSpecialTile::
-    ld   a, [$FFE0]
+    ldh  a, [$FFE0]
     cp   $C5
     jp   z, label_347D
     cp   $C6
@@ -7959,7 +7959,7 @@ MoveToNextLine_noSpecialTile::
 
 label_33CB::
     add  a, $EC
-    ld   [$FFE0], a
+    ldh  [$FFE0], a
     push af
     cp   $CF
     jr   c, label_33DC
@@ -7973,9 +7973,9 @@ label_33DC::
     jr   nz, label_3407
     xor  a
     ld   [$C3CB], a
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $C4
-    ld   a, [$FFE0]
+    ldh  a, [$FFE0]
     jr   z, label_3407
     ld   hl, $DBC9
     inc  [hl]
@@ -8068,7 +8068,7 @@ label_345B::
     bit  4, e
     jr   nz, label_3467
     pop  af
-    ld   a, [$FFE9]
+    ldh  a, [$FFE9]
     push af
 
 label_3467::
@@ -8090,16 +8090,16 @@ label_3471::
 label_347D::
     dec  bc
     ld   a, $01
-    ld   [$FFAC], a
+    ldh  [$FFAC], a
     ld   a, [bc]
     and  $F0
     add  a, $10
-    ld   [$FFAE], a
+    ldh  [$FFAE], a
     ld   a, [bc]
     swap a
     and  $F0
     add  a, $08
-    ld   [$FFAD], a
+    ldh  [$FFAD], a
     inc  bc
     jp   MoveToNextLine_finallyBeginSomething
 
@@ -8130,9 +8130,9 @@ label_34AE::
     push af
 
 label_34B6::
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $0A
-    ld   a, [$FFE0]
+    ldh  a, [$FFE0]
     jr   c, label_34C2
     cp   $A9
     jr   z, label_34C6
@@ -8161,7 +8161,7 @@ MoveToNextLine_finallyBeginSomething::
 
 MoveToNextLine_tileTypeNotA0::
     ld   d, $00
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     and  a
     jr   z, label_352D
     dec  bc ; decrement tile address
@@ -8169,7 +8169,7 @@ MoveToNextLine_tileTypeNotA0::
     ld   e, a
     ld   hl, wTileMap ; prepare tile map
     add  hl, de ; add current tile offset
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     and  $0F
     ld   e, a ; load repeat count from higher-bits of a
     pop  af ;
@@ -8179,7 +8179,7 @@ MoveToNextLine_tileTypeNotA0::
 FillMapWithConsecutiveTiles::
     ld   a, d
     ldi  [hl], a
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     and  $40
     jr   z, FillMapWithConsecutiveTiles_continue
     ld   a, l
@@ -8197,7 +8197,7 @@ label_3500::
     ret  z
     cp   $09
     jr   nz, label_350E
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $97
     ret  nz
     jr   label_3527
@@ -8205,7 +8205,7 @@ label_3500::
 label_350E::
     cp   $E1
     jr   nz, label_351D
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $0E
     ret  z
     cp   $0C
@@ -8214,7 +8214,7 @@ label_350E::
     ret  z
 
 label_351D::
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $80
     jr   nc, label_3527
     ld   a, $09
@@ -8240,7 +8240,7 @@ label_352D::
     ret
 
 label_353B::
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $80
     jr   nc, label_3545
     ld   a, $09
@@ -8358,7 +8358,7 @@ label_35CB::
     ret  z
     cp   $09
     jr   nz, label_35D9
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $97
     ret  nz
     jr   label_35E8
@@ -8366,7 +8366,7 @@ label_35CB::
 label_35D9::
     cp   $E1
     jr   nz, label_35E8
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $0E
     ret  z
     cp   $0C
@@ -8394,7 +8394,7 @@ data_35F8::
 label_35FA::
     ld   e, 0
     call label_373F
-    ld   a, [$FFF8]
+    ldh  a, [$FFF8]
     and  $04
     jp   nz, label_36B2
     push bc
@@ -8437,10 +8437,10 @@ label_36B2::
 label_36C4::
     push af
     ld   hl, $D900
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     ld   e, a
     ld   d, $00
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_36D8
     ld   hl, $DDE0
@@ -8458,7 +8458,7 @@ label_36E1::
     pop  af
     or   [hl]
     ld   [hl], a
-    ld   [$FFF8], a
+    ldh  [$FFF8], a
     ret
 
 data_36E8::
@@ -8503,7 +8503,7 @@ data_3724::
 label_3726::
     ld   e, $08
     call label_373F
-    ld   a, [$FFF8]
+    ldh  a, [$FFF8]
     and  $04
     jp   nz, label_36B2
     push bc
@@ -8565,7 +8565,7 @@ data_37E4::
 
 ; Fill the tile map with whatever is in register a
 FillTileMapWith::
-    ld   [$FFE9], a
+    ldh  [$FFE9], a
     ld   d, TILES_PER_MAP
     ld   hl, wTileMap
     ld   e, a
@@ -8591,8 +8591,8 @@ label_37FE::
     ld   a, $16
     ld   [SelectRomBank_2100], a
     xor  a
-    ld   [$FFE4], a
-    ld   a, [$FFF6]
+    ldh  [$FFE4], a
+    ldh  a, [$FFF6]
     ld   c, a
     ld   b, $00
     sla  c
@@ -8601,7 +8601,7 @@ label_37FE::
     ld   a, [$DBA5]
     and  a
     jr   z, label_3868
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $06
     jr   nz, label_3850
     ld   a, [$DB6F]
@@ -8623,11 +8623,11 @@ label_37FE::
     add  hl, de
     ld   [hl], $FF
     xor  a
-    ld   [$FFE4], a
+    ldh  [$FFE4], a
 
 label_3850::
     ld   hl, $4200
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_385E
     ld   hl, $4600
@@ -8663,14 +8663,14 @@ data_387B::
     db 1, 2, 4, 8, $10, $20, $40, $80
 
 label_3883::
-    ld   a, [$FFE4]
+    ldh  a, [$FFE4]
     cp   $08
     jr   nc, label_389B
     ld   e, a
     ld   d, $00
     ld   hl, data_387B
     add  hl, de
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     ld   e, a
     ld   a, [hl]
     ld   hl, $CF00
@@ -8741,7 +8741,7 @@ label_38EA::
     push bc
     call label_4880
     pop  bc
-    ld   a, [$FFE8]
+    ldh  a, [$FFE8]
     ld   [SelectRomBank_2100], a
     ret
 
@@ -8841,7 +8841,7 @@ label_398D::
     dec  [hl]
     jr   nz, label_399B
     ld   a, $10
-    ld   [$FFF3], a
+    ldh  [$FFF3], a
 
 label_399B::
     ld   a, [wDialogState]
@@ -8860,7 +8860,7 @@ label_39AE::
     ret  z
     xor  a
     ld   [$C3C1], a
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $0A
     ldh  a, [hFrameCounter]
     jr   c, label_39C1
@@ -8900,7 +8900,7 @@ label_39F2::
     ld   a, [hl]
     and  a
     jr   z, label_3A03
-    ld   [$FFEA], a
+    ldh  [$FFEA], a
     call label_3A18
 
 label_3A03::
@@ -8922,27 +8922,27 @@ label_3A18::
     ld   hl, $C3A0
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFEB], a
+    ldh  [$FFEB], a
     ld   hl, $C290
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFF0], a
+    ldh  [$FFF0], a
     ld   hl, $C3B0
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFF1], a
+    ldh  [$FFF1], a
     ld   a, $19
     ld   [wCurrentBank], a
     ld   [SelectRomBank_2100], a
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $6A
     jr   nz, label_3A40
-    ld   a, [$FFB2]
+    ldh  a, [$FFB2]
     and  a
     jr   nz, label_3A46
 
 label_3A40::
-    ld   a, [$FFEA]
+    ldh  a, [$FFEA]
     cp   $07
     jr   nz, label_3A4E
 
@@ -8963,7 +8963,7 @@ label_3A54::
     ld   a, $03
     ld   [wCurrentBank], a
     ld   [SelectRomBank_2100], a
-    ld   a, [$FFEA]
+    ldh  a, [$FFEA]
     cp   $05
     jp   z, label_3A8D
     JP_TABLE
@@ -8980,7 +8980,7 @@ label_3A81::
 label_3A8D::
     ld   a, $20
     ld   [SelectRomBank_2100], a
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     ld   e, a
     ld   d, b
     ld   hl, $4000
@@ -9143,7 +9143,7 @@ label_3BB5::
     jp   ReloadSavedBank
 
 label_3BC0::
-    ld   a, [$FFF1]
+    ldh  a, [$FFF1]
     inc  a
     ret  z
     call label_3D57
@@ -9155,12 +9155,12 @@ label_3BC0::
     add  hl, de
     ld   e, l
     ld   d, h
-    ld   a, [$FFEC]
+    ldh  a, [$FFEC]
     ld   [de], a
     inc  de
     ld   a, [wScreenShakeHorizontal]
     ld   c, a
-    ld   a, [$FFED]
+    ldh  a, [$FFED]
     and  $20
     rra
     rra
@@ -9169,7 +9169,7 @@ label_3BC0::
     sub  a, c
     ld   [de], a
     inc  de
-    ld   a, [$FFF1]
+    ldh  a, [$FFF1]
     ld   c, a
     ld   b, $00
     sla  c
@@ -9178,7 +9178,7 @@ label_3BC0::
     rl   b
     pop  hl
     add  hl, bc
-    ld   a, [$FFF5]
+    ldh  a, [$FFF5]
     ld   c, a
     ld   a, [hli]
     add  a, c
@@ -9201,7 +9201,7 @@ label_3C08::
     ldh  a, [hIsGBC]
     and  a
     jr   z, label_3C21
-    ld   a, [$FFED]
+    ldh  a, [$FFED]
     and  $10
     jr   z, label_3C21
     ld   a, [de]
@@ -9211,12 +9211,12 @@ label_3C08::
 
 label_3C21::
     inc  de
-    ld   a, [$FFEC]
+    ldh  a, [$FFEC]
     ld   [de], a
     inc  de
     ld   a, [wScreenShakeHorizontal]
     ld   c, a
-    ld   a, [$FFED]
+    ldh  a, [$FFED]
     and  $20
     xor  $20
     rra
@@ -9227,7 +9227,7 @@ label_3C21::
     ld   [de], a
     inc  de
     pop  hl
-    ld   a, [$FFF5]
+    ldh  a, [$FFF5]
     ld   c, a
     ld   a, [hli]
     add  a, c
@@ -9249,7 +9249,7 @@ label_3C4B::
     ldh  a, [hIsGBC]
     and  a
     jr   z, label_3C63
-    ld   a, [$FFED]
+    ldh  a, [$FFED]
     and  $10
     jr   z, label_3C63
     ld   a, [de]
@@ -9270,7 +9270,7 @@ label_3C71::
     jp   ReloadSavedBank
 
 label_3C77::
-    ld   a, [$FFF1]
+    ldh  a, [$FFF1]
     inc  a
     ret  z
     call label_3D57
@@ -9285,24 +9285,24 @@ label_3C77::
     ld   a, [$C123]
     ld   c, a
     ld   b, $00
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
-    ld   a, [$FFEC]
+    ldh  a, [$FFEC]
     jr   z, label_3C9C
     sub  a, $04
-    ld   [$FFEC], a
+    ldh  [$FFEC], a
 
 label_3C9C::
     ld   [de], a
     inc  de
     ld   a, [wScreenShakeHorizontal]
     ld   h, a
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     add  a, $04
     sub  a, h
     ld   [de], a
     inc  de
-    ld   a, [$FFF1]
+    ldh  a, [$FFF1]
     ld   c, a
     ld   b, $00
     sla  c
@@ -9318,7 +9318,7 @@ label_3C9C::
     ld   a, [wGameplayType]
     cp   GAMEPLAY_CREDITS
     jr   z, label_3CD0
-    ld   a, [$FFED]
+    ldh  a, [$FFED]
     and  a
     jr   z, label_3CD0
     ld   a, [hl]
@@ -9348,7 +9348,7 @@ label_3CE0::
     jr   label_3CF6
 
 label_3CE6::
-    ld   a, [$FFF1]
+    ldh  a, [$FFF1]
     inc  a
     jr   z, label_3D52
     push hl
@@ -9363,15 +9363,15 @@ label_3CF6::
     ld   d, h
     pop  hl
     ld   a, c
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   a, [$C123]
     ld   c, a
     call label_3D57
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     ld   c, a
 
 label_3D06::
-    ld   a, [$FFEC]
+    ldh  a, [$FFEC]
     add  a, [hl]
     ld   [de], a
     inc  hl
@@ -9379,13 +9379,13 @@ label_3D06::
     push bc
     ld   a, [wScreenShakeHorizontal]
     ld   c, a
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     add  a, [hl]
     sub  a, c
     ld   [de], a
     inc  hl
     inc  de
-    ld   a, [$FFF5]
+    ldh  a, [$FFF5]
     ld   c, a
     ld   a, [hli]
     push af
@@ -9402,14 +9402,14 @@ label_3D06::
 label_3D28::
     pop  bc
     inc  de
-    ld   a, [$FFED]
+    ldh  a, [$FFED]
     xor  [hl]
     ld   [de], a
     inc  hl
     ldh  a, [hIsGBC]
     and  a
     jr   z, label_3D3F
-    ld   a, [$FFED]
+    ldh  a, [$FFED]
     and  a
     jr   z, label_3D3F
     ld   a, [de]
@@ -9438,11 +9438,11 @@ label_3D57::
     ld   a, [wMapSlideTransitionState]
     and  a
     jr   z, label_3D7D
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     dec  a
     cp   $C0
     jr   nc, label_3D7C
-    ld   a, [$FFEC]
+    ldh  a, [$FFEC]
     dec  a
     cp   $88
     jr   nc, label_3D7C
@@ -9477,15 +9477,15 @@ label_3D8A::
     ld   hl, $C200
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFEE], a
+    ldh  [$FFEE], a
     ld   hl, $C210
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFEF], a
+    ldh  [$FFEF], a
     ld   hl, $C310
     add  hl, bc
     sub  a, [hl]
-    ld   [$FFEC], a
+    ldh  [$FFEC], a
     ret
 
 label_3DA0::
@@ -9632,10 +9632,10 @@ label_3E8E::
     xor  c
     and  $03
     ret  nz
-    ld   a, [$FFEE]
-    ld   [$FFD7], a
-    ld   a, [$FFEC]
-    ld   [$FFD8], a
+    ldh  a, [$FFEE]
+    ldh  [$FFD7], a
+    ldh  a, [$FFEC]
+    ldh  [$FFD8], a
     ld   a, $08
     call label_CC7
     ld   hl, $C520
@@ -9653,7 +9653,7 @@ label_3EAF::
     inc  a
 
 label_3EBA::
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   hl, $C400
     add  hl, bc
     ld   a, [hl]
@@ -9713,11 +9713,11 @@ label_3EFB::
 
 label_3F11::
     ld   [$D368], a
-    ld   [$FFBD], a
+    ldh  [$FFBD], a
     ld   a, [wTransitionSequenceCounter]
     cp   $04
     ret  nz
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $87
     jr   nz, label_3F26
     ld   a, $DA
@@ -9735,7 +9735,7 @@ label_3F2E::
     ld   a, [hl]
     and  $04
     ret  nz
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     ret  z
     cp   $05
@@ -9782,7 +9782,7 @@ label_3F78::
     ld   d, b
     ld   hl, data_3F48
     add  hl, de
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     ld   e, a
     ld   d, b
     ld   a, [hl]
@@ -9821,7 +9821,7 @@ label_3FBD::
     ld   bc, $0010
     call CopyData
     xor  a
-    ld   [$FFA5], a
+    ldh  [$FFA5], a
     ld   a, $0C
     ld   [SelectRomBank_2100], a
     jp   DrawLinkSpriteAndReturn

--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -61,9 +61,9 @@ label_4042::
     cp   $04
     jr   nz, label_4072
     ld   a, $03
-    ld   [$FFA9], a
+    ldh  [$FFA9], a
     ld   a, $30
-    ld   [$FFAA], a
+    ldh  [$FFAA], a
     call IncrementGameplaySubtype
     xor  a
     ld   [$C1BF], a
@@ -87,7 +87,7 @@ label_4072::
     ld   [wWindowY], a
     xor  a
     ldh  [hBaseScrollX], a
-    ld   [$FF97], a
+    ldh  [$FF97], a
     ld   [$C16B], a
     ld   [$C16C], a
     ld   a, $01
@@ -102,11 +102,11 @@ label_4072::
 label_40A9::
     ret
     call label_412A
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $B0
     jr   z, label_4127
     ld   a, $13
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     ld   a, [$C13F]
     cp   $01
     jr   z, label_40F9
@@ -130,9 +130,9 @@ label_40D5::
     ld   [rOBP1], a
     ld   [wBGPalette], a
     ld   [rBGP], a
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     ld   [$DB9D], a
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     ld   [$DB9E], a
     call label_52A4
     ld   a, $80
@@ -144,7 +144,7 @@ label_40F9::
     call label_5DE6
     call label_29CB
     xor  a
-    ld   [$FFF5], a
+    ldh  [$FFF5], a
     ld   a, $01
     ld   [$DBAF], a
     call label_6162
@@ -157,9 +157,9 @@ label_40F9::
     ld   [wWindowY], a
     ld   [rWY], a
     ld   a, $07
-    ld   [$FFA9], a
+    ldh  [$FFA9], a
     ld   a, $70
-    ld   [$FFAA], a
+    ldh  [$FFAA], a
 
 label_4127::
     ret
@@ -171,7 +171,7 @@ label_4128::
 label_412A::
     ld   hl, $C13F
     call label_6BA8
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $0C
     jr   z, label_413B
     ld   a, [hl]
@@ -193,7 +193,7 @@ label_413B::
     ldi  [hl], a
     ld   [hl], $00
     ret
-    ld   a, [$FFB7]
+    ldh  a, [$FFB7]
     and  a
     jp   nz, label_41BB
     ld   e, $70
@@ -327,15 +327,15 @@ label_41E7::
     db   $af ; Undefined instruction
     ld   [wScreenShakeHorizontal], a
     ld   [wScreenShakeVertical], a
-    ld   a, [$FFB7]
+    ldh  a, [$FFB7]
     and  a
 
 label_420D::
     jr   nz, label_4259
     ld   a, $10
-    ld   [$FFB7], a
+    ldh  [$FFB7], a
     ld   a, $01
-    ld   [$FF9C], a
+    ldh  [$FF9C], a
     ld   a, $0F
     ld   [$D6FE], a
     ld   a, $FF
@@ -378,7 +378,7 @@ label_4259::
     add  hl, de
     ld   a, [hl]
     ldh  [hLinkAnimationState], a
-    ld   a, [$FFB7]
+    ldh  a, [$FFB7]
     rra
     rra
     rra
@@ -411,7 +411,7 @@ label_4259::
     ld   [wWindowY], a
     xor  a
     ldh  [hBaseScrollX], a
-    ld   [$FF97], a
+    ldh  [$FF97], a
     ld   hl, $FF9C
     inc  [hl]
     call label_905
@@ -439,7 +439,7 @@ label_4259::
 label_42D8::
     ret
     call label_4339
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $B0
     jr   z, label_4335
     ld   a, [$C13F]
@@ -470,9 +470,9 @@ label_42FB::
     ld   [rBGP], a
     ld   [$D6FB], a
     ld   [$D475], a
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     ld   [$DB9D], a
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     ld   [$DB9E], a
     call label_52A4
     ld   a, $01
@@ -484,7 +484,7 @@ label_42FB::
 label_432C::
     call label_5DE6
     xor  a
-    ld   [$FFF5], a
+    ldh  [$FFF5], a
     call label_6162
 
 label_4335::
@@ -498,7 +498,7 @@ label_4336::
 label_4339::
     ld   hl, $C13F
     call label_6BA8
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $08
     jr   z, label_434D
     ld   a, [hl]
@@ -511,7 +511,7 @@ label_434C::
     ld   [hl], a
 
 label_434D::
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $04
     jr   z, label_435C
     ld   a, [hl]
@@ -583,7 +583,7 @@ label_43A7::
     ld   a, [$DBA5]
     and  a
     jr   z, label_4414
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_43B8
     ld   hl, $DDDA
@@ -604,7 +604,7 @@ label_43C5::
     ld   c, $05
 
 label_43CA::
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   z, label_43DB
     cp   $08
@@ -624,7 +624,7 @@ label_43DC::
     inc  de
     dec  c
     jr   nz, label_43CA
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_43E9
     ld   a, $0F
@@ -636,7 +636,7 @@ label_43E9::
     add  hl, de
     ld   a, [hl]
     ld   [$DBB0], a
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   z, label_440B
     cp   $08
@@ -645,7 +645,7 @@ label_43E9::
     jr   nc, label_4425
     cp   $06
     jr   nz, label_440B
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     jr   nz, label_4425
 
@@ -662,7 +662,7 @@ label_4414::
     ld   hl, hFrameCounter
     or   [hl]
     and  $03
-    ld   [$FFB9], a
+    ldh  [$FFB9], a
     ret
 
 label_4425::
@@ -676,13 +676,13 @@ label_442B::
     ld   [$C11C], a
     call IncrementGameplaySubtype
     ld   a, [$DB9D]
-    ld   [$FF98], a
+    ldh  [$FF98], a
     ld   [$DBB1], a
     ld   a, [$DB9E]
-    ld   [$FF99], a
+    ldh  [$FF99], a
     ld   [$DBB2], a
     ld   a, [$DBC8]
-    ld   [$FFA2], a
+    ldh  [$FFA2], a
     and  a
     jr   z, label_4452
     ld   a, $02
@@ -695,12 +695,12 @@ label_4452::
     call label_37FE
     call label_5FB3
     ld   a, $FF
-    ld   [$FFA6], a
+    ldh  [$FFA6], a
     ld   a, [$DBA5]
     and  a
     jr   z, label_44A6
     ld   d, a
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_4475
     ld   d, $00
@@ -714,7 +714,7 @@ label_4475::
     inc  d
 
 label_447E::
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     ld   e, a
     call label_29ED
     cp   $1A
@@ -730,7 +730,7 @@ label_4495::
     ld   a, [$DBCD]
     and  a
     jr   z, label_44A6
-    ld   a, [$FFF8]
+    ldh  a, [$FFF8]
     and  $10
     jr   nz, label_44A6
     ld   a, $0C
@@ -749,7 +749,7 @@ label_44B0::
 
 label_44B4::
     ld   a, $0F
-    ld   [$FF94], a
+    ldh  [$FF94], a
     ldh  a, [hIsGBC]
     and  a
     jr   z, label_44C9
@@ -787,7 +787,7 @@ label_44DB::
     and  a
     jr   z, label_44F5
     ld   a, $03
-    ld   [$FFA5], a
+    ldh  [$FFA5], a
 
 label_44F5::
     call IncrementGameplaySubtype
@@ -834,7 +834,7 @@ label_4507::
 
 label_4548::
     jp   label_27DD
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $90
     jp   z, TransitionReturn
 
@@ -928,7 +928,7 @@ label_4555::
     xor  a
     ld   [wGameplaySubtype], a
     xor  a
-    ld   [$FF97], a
+    ldh  [$FF97], a
     ldh  [hBaseScrollX], a
     ld   a, $00
     ld   [wBGPalette], a
@@ -1198,7 +1198,7 @@ label_4852::
     ld   a, $05
 
 label_486D::
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   a, [de]
     and  a
     ld   a, $7E
@@ -1216,7 +1216,7 @@ label_486D::
 label_4881::
     ldi  [hl], a
     inc  de
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     dec  a
     jr   nz, label_486D
     ld   a, b
@@ -1230,7 +1230,7 @@ label_4881::
     ld   a, $05
 
 label_4894::
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   a, [de]
     and  a
     jr   label_489D
@@ -1249,7 +1249,7 @@ label_489D::
 label_48A9::
     ldi  [hl], a
     inc  de
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     dec  a
     jr   nz, label_4894
     xor  a
@@ -1287,13 +1287,13 @@ label_48E4::
     ld   l, e
     add  a, e
     call label_6BA8
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $90
     jr   z, label_48F4
     jp   IncrementGameplaySubtypeAndReturn
 
 label_48F4::
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $0C
     jr   z, label_4920
     ld   c, $02
@@ -1303,7 +1303,7 @@ label_48F4::
     inc  c
 
 label_4903::
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     bit  2, a
     jr   nz, label_4915
     ld   a, [$DBA6]
@@ -1327,7 +1327,7 @@ label_4920::
     ld   a, [$DBA6]
     cp   $03
     jr   nz, label_4954
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $03
     jr   z, label_4938
     call label_6BAE
@@ -1430,7 +1430,7 @@ label_49AE::
 
 label_49BE::
     ld   a, $13
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     ret
 
 label_49C3::
@@ -1570,7 +1570,7 @@ label_4A98::
     ld   d, h
     ld   bc, $984A
     call label_4852
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $80
     jr   z, label_4B29
     call label_49BE
@@ -1809,17 +1809,17 @@ label_4BB5::
 
 
 label_4BF5::
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
 
 label_4BF7::
-    ld   [$FFD7], a
-    ld   a, [$FFD7]
+    ldh  [$FFD7], a
+    ldh  a, [$FFD7]
     and  $0C
     jr   nz, label_4C41
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     and  $03
     jr   nz, label_4C21
-    ld   a, [$FFCB]
+    ldh  a, [$FFCB]
     ld   hl, $C182
     and  $0F
     jr   nz, label_4C12
@@ -1834,7 +1834,7 @@ label_4C12::
     cp   $18
     jr   nz, label_4C1F
     ld   [hl], $15
-    ld   a, [$FFCB]
+    ldh  a, [$FFCB]
     jr   label_4BF7
 
 label_4C1F::
@@ -1907,7 +1907,7 @@ label_4C63::
     ret
 
 label_4C8A::
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $30
     jr   z, label_4CB7
     bit  5, a
@@ -2080,11 +2080,11 @@ label_4DA6::
     and  $01
     jr   z, label_4DBD
     xor  a
-    ld   [$FFDB], a
+    ldh  [$FFDB], a
     ld   a, [$DC06]
-    ld   [$FFD9], a
+    ldh  [$FFD9], a
     ld   a, [$DC09]
-    ld   [$FFDA], a
+    ldh  [$FFDA], a
     jp   label_5D53
 
 label_4DBD::
@@ -2095,11 +2095,11 @@ label_4DBE::
     and  $02
     jr   z, label_4DBD
     ld   a, $01
-    ld   [$FFDB], a
+    ldh  [$FFDB], a
     ld   a, [$DC07]
-    ld   [$FFD9], a
+    ldh  [$FFD9], a
     ld   a, [$DC0A]
-    ld   [$FFDA], a
+    ldh  [$FFDA], a
     jp   label_5D53
 
 label_4DD6::
@@ -2107,11 +2107,11 @@ label_4DD6::
     and  $04
     jr   z, label_4DBD
     ld   a, $02
-    ld   [$FFDB], a
+    ldh  [$FFDB], a
     ld   a, [$DC08]
-    ld   [$FFD9], a
+    ldh  [$FFD9], a
     ld   a, [$DC0B]
-    ld   [$FFDA], a
+    ldh  [$FFDA], a
     jp   label_5D53
 
 label_4DEE::
@@ -2140,7 +2140,7 @@ label_4DEE::
     ld   b, h
     ld   a, [hl]
     call label_6BA8
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $08
     jr   z, label_4E18
     ld   a, [$DBA6]
@@ -2149,7 +2149,7 @@ label_4DEE::
     ld   [$DBA6], a
 
 label_4E18::
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $04
     jr   z, label_4E2B
     ld   a, [$DBA6]
@@ -2162,7 +2162,7 @@ label_4E28::
     ld   [$DBA6], a
 
 label_4E2B::
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $90
     jr   z, label_4E67
     ld   a, [$DBA6]
@@ -2196,7 +2196,7 @@ label_4E5D::
 label_4E67::
     call label_4954
     ret
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     bit  5, a
     jr   nz, label_4E9E
     and  $90
@@ -2300,7 +2300,7 @@ label_4F03::
     ret
 
 label_4F0C::
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $03
     jr   z, label_4F1D
     call label_6BAE
@@ -2433,7 +2433,7 @@ label_4F45::
     call label_4852
     jp   IncrementGameplaySubtypeAndReturn
     call label_6BA8
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $08
     jr   z, label_500E
     ld   a, [$D001]
@@ -2441,7 +2441,7 @@ label_4F45::
     jr   label_5018
 
 label_500E::
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $04
     jr   z, label_501D
     ld   a, [$D001]
@@ -2452,7 +2452,7 @@ label_5018::
     ld   [$D001], a
 
 label_501D::
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $90
     jr   z, label_5055
     ld   a, [$D001]
@@ -2602,7 +2602,7 @@ label_50C7::
     ld   b, h
     ld   a, [hl]
     call label_6BA8
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $08
     jr   z, label_50F1
     ld   a, [$D002]
@@ -2611,7 +2611,7 @@ label_50C7::
     ld   [$D002], a
 
 label_50F1::
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $04
     jr   z, label_5104
     ld   a, [$D002]
@@ -2625,7 +2625,7 @@ label_5101::
 
 label_5104::
     call label_5094
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     bit  5, a
     jr   z, label_5114
     ld   hl, wGameplaySubtype
@@ -2771,7 +2771,7 @@ label_51CE::
     call label_5094
     call label_51CE
     call label_4F0C
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $90
     jr   z, label_5235
     ld   a, [$D000]
@@ -2812,7 +2812,7 @@ label_5224::
     jp   label_4555
 
 label_5235::
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     bit  5, a
     jr   z, label_5249
     ld   hl, wGameplaySubtype
@@ -2874,7 +2874,7 @@ label_5295::
 
 label_52A4::
     xor  a
-    ld   [$FFF9], a
+    ldh  [$FFF9], a
     ld   a, [$DB5A]
     and  a
     jr   nz, label_52BB
@@ -2962,7 +2962,7 @@ label_531D::
     ld   [wGameplaySubtype], a
     xor  a
     ld   [$C11C], a
-    ld   [$FF9C], a
+    ldh  [$FF9C], a
     ld   [$DB93], a
     ld   [$DB94], a
     ld   [$DB90], a
@@ -2987,16 +2987,16 @@ label_5353::
     ld   a, [$DB63]
     ld   [$DB9E], a
     ld   a, [$DB61]
-    ld   [$FFF6], a
+    ldh  [$FFF6], a
     ld   [$DB9C], a
     ld   a, [$DB60]
-    ld   [$FFF7], a
+    ldh  [$FFF7], a
     ld   a, [$DB64]
     ld   [$DBAE], a
     xor  a
-    ld   [$FFF9], a
+    ldh  [$FFF9], a
     ld   a, $03
-    ld   [$FF9E], a
+    ldh  [$FF9E], a
     ld   a, [$DB5F]
     and  $01
     ld   [$DBA5], a
@@ -3004,7 +3004,7 @@ label_5353::
     ld   a, $04
     ldh  [hLinkAnimationState], a
     ld   a, $02
-    ld   [$FF9E], a
+    ldh  [$FF9E], a
 
 label_538E::
     ld   a, $02
@@ -3020,12 +3020,12 @@ label_5394::
     ld   [$DB76], a
     ld   a, $A3
     ld   [$DB9C], a
-    ld   [$FFF6], a
+    ldh  [$FFF6], a
     ld   [$DB54], a
     ld   a, $01
     ld   [$DBA5], a
     ld   a, $10
-    ld   [$FFF7], a
+    ldh  [$FFF7], a
     ld   a, $50
     ld   [$DB9D], a
     ld   a, $60
@@ -3033,7 +3033,7 @@ label_5394::
     xor  a
     ldh  [hLinkAnimationState], a
     ld   a, $03
-    ld   [$FF9E], a
+    ldh  [$FF9E], a
     ld   a, $16
     ld   [$DB6F], a
     ld   a, $50
@@ -3335,10 +3335,10 @@ label_5519::
     jr   nz, label_5519
     push de
     xor  a
-    ld   [$FFD7], a
-    ld   [$FFD8], a
-    ld   [$FFD9], a
-    ld   [$FFDA], a
+    ldh  [$FFD7], a
+    ldh  [$FFD8], a
+    ldh  [$FFD9], a
+    ldh  [$FFDA], a
     ld   c, a
     ld   b, a
     ld   e, a
@@ -3368,19 +3368,19 @@ label_5544::
     ld   hl, label_53D8
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   hl, label_53E8
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     ld   hl, label_53F8
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFD9], a
+    ldh  [$FFD9], a
     ld   hl, label_5408
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFDA], a
+    ldh  [$FFDA], a
     pop  hl
     call label_5619
     push hl
@@ -3395,10 +3395,10 @@ label_5544::
     xor  a
     ld   [hl], a
     xor  a
-    ld   [$FFD7], a
-    ld   [$FFD8], a
-    ld   [$FFD9], a
-    ld   [$FFDA], a
+    ldh  [$FFD7], a
+    ldh  [$FFD8], a
+    ldh  [$FFD9], a
+    ldh  [$FFDA], a
     ld   c, a
     ld   b, a
     ld   e, a
@@ -3452,17 +3452,17 @@ label_55C0::
     ld   hl, label_5418
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   hl, label_545C
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     xor  a
-    ld   [$FFD9], a
+    ldh  [$FFD9], a
     ld   hl, label_54A0
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFDA], a
+    ldh  [$FFDA], a
     pop  hl
     call label_5619
     push hl
@@ -3489,18 +3489,18 @@ label_55F5::
     ld   hl, label_54E4
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   hl, label_54E6
 
 label_5600::
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     ld   a, $01
-    ld   [$FFD9], a
-    ld   a, [$FFF7]
+    ldh  [$FFD9], a
+    ldh  a, [$FFF7]
     add  a, $B1
-    ld   [$FFDA], a
+    ldh  [$FFDA], a
     pop  hl
     call label_5619
     inc  hl
@@ -3511,13 +3511,13 @@ label_5600::
     ret
 
 label_5619::
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     ldi  [hl], a
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     ldi  [hl], a
-    ld   a, [$FFD9]
+    ldh  a, [$FFD9]
     ldi  [hl], a
-    ld   a, [$FFDA]
+    ldh  a, [$FFDA]
     ld   [hl], a
     ret
     xor  a
@@ -3526,8 +3526,8 @@ label_5619::
     cp   $05
     jr   z, label_5639
     xor  a
-    ld   [$FFCB], a
-    ld   [$FFCC], a
+    ldh  [$FFCB], a
+    ldh  [$FFCC], a
     ld   a, [wGameplaySubtype]
 
 label_5639::
@@ -3588,16 +3588,16 @@ label_5678::
     cp   $04
     jr   nz, label_56F3
     ld   a, $03
-    ld   [$FFA9], a
+    ldh  [$FFA9], a
     ld   a, $30
-    ld   [$FFAA], a
+    ldh  [$FFAA], a
     call IncrementGameplaySubtype
     xor  a
     ld   [$C16B], a
     ld   [$C16C], a
     ldh  [hBaseScrollX], a
     ld   [$C1BF], a
-    ld   [$FF97], a
+    ldh  [$FF97], a
     ld   [wInventoryAppearing], a
     ld   [$C1B2], a
     ld   [$C1B3], a
@@ -3663,7 +3663,7 @@ label_571B::
     ld   a, [ROM_DebugTool3]
     and  a
     jr   z, label_5731
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     bit  7, a
     jr   z, label_5731
     xor  a
@@ -3676,7 +3676,7 @@ label_5731::
     ld   a, [$C19F]
     and  a
     jp   nz, label_5818
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $10
     jr   z, label_57B7
     ld   a, [$DBB4]
@@ -3764,7 +3764,7 @@ label_57B7::
     ld   a, [ROM_DebugTool1]
     and  a
     jr   z, label_57FA
-    ld   a, [$FFCB]
+    ldh  a, [$FFCB]
     cp   $60
     jr   nz, label_57FA
     ld   a, GAMEPLAY_OVERWORLD
@@ -3779,11 +3779,11 @@ label_57B7::
     ld   [$D404], a
     ld   a, $52
     ld   [$D405], a
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     swap a
     and  $0F
     ld   e, a
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     sub  a, $08
     and  $F0
     or   e
@@ -3800,7 +3800,7 @@ label_57FA::
     ld   e, $60
 
 label_5804::
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  e
     jr   z, label_5818
     xor  a
@@ -3855,15 +3855,15 @@ label_5854::
     ld   [$C50A], a
     ld   [$C116], a
     ldh  [hBaseScrollX], a
-    ld   [$FF97], a
+    ldh  [$FF97], a
     ld   [$C167], a
     ld   a, $07
-    ld   [$FFA9], a
+    ldh  [$FFA9], a
     ld   a, $70
-    ld   [$FFAA], a
+    ldh  [$FFAA], a
     ld   a, GAMEPLAY_OVERWORLD
     ld   [wGameplayType], a
-    ld   [$FFBC], a
+    ldh  [$FFBC], a
     ld   a, $02
     ld   [wGameplaySubtype], a
     ld   a, [$DBA5]
@@ -3961,7 +3961,7 @@ label_5A31::
     db 0, 0, 0, 0, 0, 0, 0, 0
 
 label_5A59::
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     ld   e, a
     ld   d, $00
     ld   hl, label_5959
@@ -3980,14 +3980,14 @@ label_5A6E::
 
 label_5A71::
     ld   a, [$DBB4]
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   a, [$C1B3]
     ld   hl, $C1B2
     or   [hl]
     ld   hl, $C19F
     or   [hl]
     jp   nz, label_5B3F
-    ld   a, [$FFCB]
+    ldh  a, [$FFCB]
     ld   c, a
     ld   hl, $C182
     and  $0F
@@ -4006,7 +4006,7 @@ label_5A92::
     jr   label_5AA0
 
 label_5A9D::
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     ld   c, a
 
 label_5AA0::
@@ -4053,8 +4053,8 @@ label_5AA0::
     and  a
     jr   nz, label_5AF5
     ld   a, $09
-    ld   [$FFF2], a
-    ld   a, [$FFD7]
+    ldh  [$FFF2], a
+    ldh  a, [$FFD7]
     ld   [$DBB4], a
     jr   label_5B3F
 
@@ -4243,14 +4243,14 @@ label_5C72::
 
 label_5C7B::
     ld   [$C1B0], a
-    ld   [$FFF1], a
+    ldh  [$FFF1], a
     ld   a, $00
     ld   [$C3C0], a
     ld   a, $08
     ld   [$C340], a
     ld   a, $00
     ld   [$C123], a
-    ld   [$FFED], a
+    ldh  [$FFED], a
     ld   e, $00
     ld   a, [$C1B4]
     cp   $70
@@ -4268,11 +4268,11 @@ label_5CA3::
     ld   hl, label_5C41
     add  hl, de
     ld   a, [hl]
-    ld   [$FFEE], a
+    ldh  [$FFEE], a
     ld   hl, label_5C45
     add  hl, de
     ld   a, [hl]
-    ld   [$FFEC], a
+    ldh  [$FFEC], a
     ld   a, [$C1B0]
     rla
     rla
@@ -4291,7 +4291,7 @@ label_5CBD::
     ld   a, $08
     ld   [$C3C0], a
     xor  a
-    ld   [$FFF5], a
+    ldh  [$FFF5], a
     ld   c, $08
     call label_3CE6
     ld   a, [$C1B0]
@@ -4301,15 +4301,15 @@ label_5CBD::
     dec  a
     cp   $80
     jr   nc, label_5D13
-    ld   [$FFF1], a
+    ldh  [$FFF1], a
     ld   de, $C030
-    ld   a, [$FFEC]
+    ldh  a, [$FFEC]
     ld   [de], a
     inc  de
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     ld   [de], a
     inc  de
-    ld   a, [$FFF1]
+    ldh  a, [$FFF1]
     ld   c, a
     ld   b, $00
     sla  c
@@ -4324,10 +4324,10 @@ label_5CBD::
     ld   a, [hli]
     ld   [de], a
     inc  de
-    ld   a, [$FFEC]
+    ldh  a, [$FFEC]
     ld   [de], a
     inc  de
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     add  a, $08
     ld   [de], a
     inc  de
@@ -4413,7 +4413,7 @@ label_5D53::
     add  hl, de
     push de
     ld   bc, label_5D14
-    ld   a, [$FFDB]
+    ldh  a, [$FFDB]
     and  a
     jr   z, label_5D75
     ld   bc, label_5D29
@@ -4434,15 +4434,15 @@ label_5D77::
     ld   hl, $D604
     add  hl, de
     ld   c, $00
-    ld   a, [$FFD9]
+    ldh  a, [$FFD9]
     and  a
     jr   z, label_5DAB
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
 
 label_5D8B::
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     sub  a, $08
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     jr   c, label_5DA2
     ld   a, $AE
     ldi  [hl], a
@@ -4465,7 +4465,7 @@ label_5DA2::
     jr   label_5DB3
 
 label_5DAB::
-    ld   a, [$FFDA]
+    ldh  a, [$FFDA]
     cp   c
     jr   z, label_5DBF
     ld   a, $AE
@@ -4598,7 +4598,7 @@ label_5E3A::
     ld   a, [$DBA5]
     and  a
     jr   z, label_5E95
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_5E79
     ld   hl, $DDDA
@@ -4660,10 +4660,10 @@ label_5EA6::
     nop
     ld   hl, $C460
     add  hl, de
-    ld   a, [$FFE4]
+    ldh  a, [$FFE4]
     ld   [hl], a
     inc  a
-    ld   [$FFE4], a
+    ldh  [$FFE4], a
     push bc
     ld   a, [$C125]
     ld   c, a
@@ -4671,47 +4671,47 @@ label_5EA6::
     ld   hl, label_5E97
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   hl, label_5E9C
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     ld   hl, label_5EA1
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFD9], a
+    ldh  [$FFD9], a
     ld   hl, label_5EA6
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFDA], a
+    ldh  [$FFDA], a
     ld   hl, $C200
     add  hl, de
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     add  a, [hl]
     ld   [hl], a
     rr   c
     ld   hl, $C220
     add  hl, de
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     rl   c
     adc  a, [hl]
     ld   [hl], a
     ld   hl, $C210
     add  hl, de
-    ld   a, [$FFD9]
+    ldh  a, [$FFD9]
     add  a, [hl]
     ld   [hl], a
     rr   c
     ld   hl, $C230
     add  hl, de
-    ld   a, [$FFDA]
+    ldh  a, [$FFDA]
     rl   c
     adc  a, [hl]
     ld   [hl], a
     pop  bc
     ret
     ld   c, $06
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     ld   hl, $CE81
 
 label_5F09::
@@ -4733,7 +4733,7 @@ label_5F19::
     ld   hl, $CE81
     add  hl, de
     ld   e, [hl]
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     ld   [hl], a
     ld   hl, $CF00
     add  hl, de
@@ -4850,10 +4850,10 @@ label_5FB3::
     ld   a, [$DBA5]
     and  a
     jr   z, label_5FD3
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     ret  nz
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $16
     ret  z
     cp   $14
@@ -4862,7 +4862,7 @@ label_5FB3::
     ret  z
     cp   $0A
     ret  c
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $FD
     ret  z
     cp   $B1
@@ -4895,15 +4895,15 @@ label_5FF0::
     jr   nz, label_5FDE
     ld   a, $D5
     call label_3B86
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     ld   hl, $C200
     add  hl, de
     ld   [hl], a
-    ld   a, [$FFA2]
+    ldh  a, [$FFA2]
     ld   hl, $C310
     add  hl, de
     ld   [hl], a
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     ld   hl, $C13B
     add  a, [hl]
     ld   hl, $C210
@@ -4919,7 +4919,7 @@ label_6014::
     ld   a, [$DBA5]
     and  a
     jr   nz, label_607F
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $40
     jr   c, label_607F
     ld   a, [$DB68]
@@ -4962,11 +4962,11 @@ label_6059::
     jr   nz, label_6047
     ld   a, $D4
     call label_3B86
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     ld   hl, $C200
     add  hl, de
     ld   [hl], a
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     ld   hl, $C13B
     add  a, [hl]
     ld   hl, $C210
@@ -4976,7 +4976,7 @@ label_6059::
     add  hl, de
     inc  [hl]
     ld   a, $2D
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
 
 label_607F::
     ld   a, [$DB73]
@@ -5005,13 +5005,13 @@ label_609C::
     jr   nz, label_608A
     ld   a, $C1
     call label_3B86
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     ld   hl, $C200
     add  hl, de
     ld   [hl], a
     ld   hl, $D155
     call label_6118
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     ld   hl, $C13B
     add  a, [hl]
     ld   hl, $C210
@@ -5019,7 +5019,7 @@ label_609C::
     ld   [hl], a
     ld   hl, $D175
     call label_6118
-    ld   a, [$FFA2]
+    ldh  a, [$FFA2]
     ld   hl, $C310
     add  hl, de
     ld   [hl], a
@@ -5031,32 +5031,32 @@ label_609C::
     ld   hl, $C2F0
     add  hl, de
     ld   [hl], $0C
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $A4
     jr   nz, label_60F7
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $11
     jr   nz, label_60F7
     ld   a, $08
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     ld   [$C167], a
     ld   hl, $C300
     add  hl, de
     ld   [hl], $79
 
 label_60F7::
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     ld   hl, $D1B5
     call label_6118
     ld   a, [$DB10]
     and  a
     jr   z, label_6117
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     ld   hl, $C200
     add  hl, de
     add  a, $20
     ld   [hl], a
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     ld   hl, $C210
     add  hl, de
     add  a, $10
@@ -5075,7 +5075,7 @@ label_611A::
     ret
 
 label_611F::
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $A7
     ret  z
     ld   a, [$DB56]
@@ -5104,15 +5104,15 @@ label_6141::
     jr   nz, label_612F
     ld   a, $6D
     call label_3B86
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     ld   hl, $C200
     add  hl, de
     ld   [hl], a
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     ld   hl, $C210
     add  hl, de
     ld   [hl], a
-    ld   a, [$FFA2]
+    ldh  a, [$FFA2]
     ld   hl, $C310
     add  hl, de
     ld   [hl], a
@@ -5132,12 +5132,12 @@ label_6162::
     ld   [rBGP], a
     ld   [rOBP0], a
     ld   [rOBP1], a
-    ld   [$FF97], a
+    ldh  [$FF97], a
     ldh  [hBaseScrollX], a
     ld   [$D6FB], a
     ld   [$D6F8], a
     ld   a, $18
-    ld   [$FFB5], a
+    ldh  [$FFB5], a
     ret
 
 label_618A::
@@ -5187,7 +5187,7 @@ label_61E9::
     ld   a, [wFreeMovementMode]
     and  a
     jr   nz, label_6202
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     add  a, $56
     call label_2385
 
@@ -5261,7 +5261,7 @@ label_6281::
     ld   [$C16B], a
     ld   [$C16C], a
     ld   a, $90
-    ld   [$FF97], a
+    ldh  [$FF97], a
     ld   a, $40
     ld   [$C114], a
     ld   a, $A0
@@ -5420,9 +5420,9 @@ label_6417::
     ldh  a, [hFrameCounter]
     and  $03
     jr   nz, label_642E
-    ld   a, [$FF97]
+    ldh  a, [$FF97]
     inc  a
-    ld   [$FF97], a
+    ldh  [$FF97], a
     cp   $00
     jr   nz, label_642E
     ld   a, $80
@@ -5575,7 +5575,7 @@ label_651E::
     cp   $A0
     jr   nz, label_652E
     ld   a, $0F
-    ld   [$FFF4], a
+    ldh  [$FFF4], a
     xor  a
 
 label_652E::
@@ -5584,7 +5584,7 @@ label_652E::
     and  a
     jr   nz, label_6545
     ld   a, $21
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     call GetRandomByte
     and  $7F
     add  a, $60
@@ -5593,7 +5593,7 @@ label_652E::
 label_6545::
     dec  a
     ld   [$D466], a
-    ld   a, [$FF97]
+    ldh  a, [$FF97]
     dec  a
     cp   $C0
     ret  c
@@ -5607,13 +5607,13 @@ label_6545::
 
 label_655F::
     ld   a, $7C
-    ld   [$FFEC], a
+    ldh  [$FFEC], a
     ld   a, $58
-    ld   [$FFEE], a
+    ldh  [$FFEE], a
     ld   hl, $C030
     call label_658B
     ld   a, $48
-    ld   [$FFEE], a
+    ldh  [$FFEE], a
     ld   de, label_6512
     ld   a, [$DC0F]
     and  a
@@ -5630,13 +5630,13 @@ label_6584::
 
 label_658B::
     push bc
-    ld   a, [$FF97]
+    ldh  a, [$FF97]
     ld   c, a
-    ld   a, [$FFEC]
+    ldh  a, [$FFEC]
     sub  a, c
-    ld   [$FFE8], a
+    ldh  [$FFE8], a
     ldi  [hl], a
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     ldi  [hl], a
     ld   a, [de]
     inc  de
@@ -5644,10 +5644,10 @@ label_658B::
     ld   a, [de]
     inc  de
     ldi  [hl], a
-    ld   a, [$FFEC]
+    ldh  a, [$FFEC]
     sub  a, c
     ldi  [hl], a
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     add  a, $08
     ldi  [hl], a
     ld   a, [de]
@@ -5672,11 +5672,11 @@ label_65B2::
     ld   hl, $C530
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFEE], a
+    ldh  [$FFEE], a
     ld   hl, $C540
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFEC], a
+    ldh  [$FFEC], a
     ld   hl, $C520
     add  hl, bc
     ld   a, [hl]
@@ -5774,7 +5774,7 @@ label_668B::
     dec  [hl]
 
 label_66C4::
-    ld   a, [$FFE8]
+    ldh  a, [$FFE8]
     cp   $F0
     jr   c, label_66D7
     ld   hl, $C560
@@ -5853,7 +5853,7 @@ label_6733::
     ld   e, a
     ldh  a, [hFrameCounter]
     add  a, e
-    ld   [$FFE9], a
+    ldh  [$FFE9], a
 
 label_6745::
     and  $3F
@@ -5870,7 +5870,7 @@ label_6745::
     ld   [hl], a
 
 label_675A::
-    ld   a, [$FFE9]
+    ldh  a, [$FFE9]
     add  a, $40
     and  $3F
     jr   nz, label_6773
@@ -5968,14 +5968,14 @@ label_67D4::
 
 label_67DE::
     ld   e, a
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     push af
     ld   a, $60
-    ld   [$FF99], a
+    ldh  [$FF99], a
     ld   a, e
     call label_2373
     pop  af
-    ld   [$FF99], a
+    ldh  [$FF99], a
     ret
 
 label_67EE::
@@ -6014,13 +6014,13 @@ label_6829::
     cp   $04
     jr   nz, label_6855
     call label_5888
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $06
     jr   z, label_6849
     ld   a, $03
-    ld   [$FFA9], a
+    ldh  [$FFA9], a
     ld   a, $30
-    ld   [$FFAA], a
+    ldh  [$FFAA], a
 
 label_6849::
     call IncrementGameplaySubtype
@@ -6032,10 +6032,10 @@ label_6849::
 label_6855::
     ret
     ld   e, $21
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $06
     jr   z, label_6868
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $DD
     ld   e, $12
     jr   nz, label_6868
@@ -6048,10 +6048,10 @@ label_6868::
     ld   [$C13F], a
     jp   IncrementGameplaySubtypeAndReturn
     ld   e, $24
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $06
     jr   z, label_6885
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $DD
     ld   e, $12
     jr   nz, label_6885
@@ -6064,7 +6064,7 @@ label_6885::
     ld   [wWindowY], a
     xor  a
     ldh  [hBaseScrollX], a
-    ld   [$FF97], a
+    ldh  [$FF97], a
     ld   [$C16B], a
     ld   [$C16C], a
     ld   e, $08
@@ -6088,7 +6088,7 @@ label_689E::
 
 label_68BF::
     ret
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $06
     jr   nz, label_68CF
     call label_6A7C
@@ -6097,11 +6097,11 @@ label_68BF::
     ret
 
 label_68CF::
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $B0
     jr   z, label_68E3
     ld   a, $13
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
 
 label_68D9::
     call IncrementGameplaySubtype
@@ -6287,20 +6287,20 @@ label_6A76::
     ld   l, d
 
 label_6A7C::
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $06
     ret  nz
     xor  a
-    ld   [$FFF1], a
-    ld   [$FFED], a
-    ld   [$FFF5], a
+    ldh  [$FFF1], a
+    ldh  [$FFED], a
+    ldh  [$FFF5], a
     ld   a, $38
-    ld   [$FFEE], a
+    ldh  [$FFEE], a
     ld   a, [wScreenShakeVertical]
     ld   e, a
     ld   a, $20
     sub  a, e
-    ld   [$FFEC], a
+    ldh  [$FFEC], a
     ld   a, [$D214]
     and  a
     jr   z, label_6AC2
@@ -6331,13 +6331,13 @@ label_6AAE::
 
 label_6AC2::
     ld   a, $48
-    ld   [$FFEE], a
+    ldh  [$FFEE], a
     ld   a, [wScreenShakeVertical]
     ld   e, a
     ld   a, [$D211]
     add  a, $20
     sub  a, e
-    ld   [$FFEC], a
+    ldh  [$FFEC], a
     ld   a, [$D213]
     ld   e, a
     ld   d, $00
@@ -6407,9 +6407,9 @@ label_6B2B::
     jr   nz, label_6B51
     call label_5888
     ld   a, $03
-    ld   [$FFA9], a
+    ldh  [$FFA9], a
     ld   a, $30
-    ld   [$FFAA], a
+    ldh  [$FFAA], a
     call IncrementGameplaySubtype
     xor  a
     ld   [$C1BF], a
@@ -6426,7 +6426,7 @@ label_6B52::
     ld   [wWindowY], a
     xor  a
     ldh  [hBaseScrollX], a
-    ld   [$FF97], a
+    ldh  [$FF97], a
     ld   [$C16B], a
     ld   [$C16C], a
     ld   a, $01
@@ -6462,30 +6462,30 @@ label_6B99::
     ret
 
 label_6B9A::
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $B0
     jr   z, label_6BA7
     ld   a, $13
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     call label_68D9
 
 label_6BA7::
     ret
 
 label_6BA8::
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $0C
     jr   z, label_6BB4
 
 label_6BAE::
     push af
     ld   a, $0A
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     pop  af
 
 label_6BB4::
     ret
-    ld   a, [$FF92]
+    ldh  a, [$FF92]
     cp   $08
     jp  c, label_6C77
     jr   nz, label_6BC6
@@ -6498,7 +6498,7 @@ label_6BC6::
     call label_6BEA
     xor  a
     ldh  [hNeedsUpdatingBGTiles], a
-    ld   [$FF92], a
+    ldh  [$FF92], a
     ret
 
 label_6BCF::
@@ -6521,15 +6521,15 @@ label_6BF0::
 
 label_6BF4::
     ld   a, c
-    ld   [$FFE0], a
+    ldh  [$FFE0], a
     ld   d, $00
 
 label_6BF9::
     xor  a
-    ld   [$FFD7], a
-    ld   [$FFD8], a
-    ld   [$FFD9], a
-    ld   [$FFDA], a
+    ldh  [$FFD7], a
+    ldh  [$FFD8], a
+    ldh  [$FFD9], a
+    ldh  [$FFDA], a
     ld   hl, $DB65
     add  hl, de
     ld   a, [hl]
@@ -6544,13 +6544,13 @@ label_6BF9::
     ld   h, $9D
     push hl
     ld   a, $7C
-    ld   [$FFD7], a
-    ld   [$FFD8], a
-    ld   [$FFD9], a
+    ldh  [$FFD7], a
+    ldh  [$FFD8], a
+    ldh  [$FFD9], a
     ld   hl, label_6BD7
     add  hl, de
     ld   a, [hl]
-    ld   [$FFDA], a
+    ldh  [$FFDA], a
     pop  hl
     jr   label_6C48
 
@@ -6566,28 +6566,28 @@ label_6C2A::
     ld   hl, label_6BDF
     add  hl, de
     ld   a, [hl]
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     inc  a
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     add  a, $0F
-    ld   [$FFD9], a
+    ldh  [$FFD9], a
     inc  a
-    ld   [$FFDA], a
+    ldh  [$FFDA], a
     pop  hl
 
 label_6C48::
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     ld   [hl], a
     call label_6C69
-    ld   a, [$FFD8]
-    ld   [hl], a
-    inc  c
-    call label_6C69
-    ld   a, [$FFD9]
+    ldh  a, [$FFD8]
     ld   [hl], a
     inc  c
     call label_6C69
-    ld   a, [$FFDA]
+    ldh  a, [$FFD9]
+    ld   [hl], a
+    inc  c
+    call label_6C69
+    ldh  a, [$FFDA]
     ld   [hl], a
     inc  e
     ld   a, e
@@ -6631,9 +6631,9 @@ label_6C77::
     ld   hl, label_4D00
     add  hl, bc
     call label_C3A
-    ld   a, [$FF92]
+    ldh  a, [$FF92]
     inc  a
-    ld   [$FF92], a
+    ldh  [$FF92], a
     ret
 
 label_6CA5::
@@ -6772,7 +6772,7 @@ label_6DEA::
     ld   a, [$DBA5]
     and  a
     jr   z, label_6E18
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_6DFF
     ld   a, $0F
@@ -6792,7 +6792,7 @@ label_6E03::
     ld   h, [hl]
     ld   l, a
     ld   [hl], $A3
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     jr   z, label_6E18
     ld   [hl], $7F
@@ -6813,7 +6813,7 @@ IntroHandlerEntryPoint::
     jp   RenderIntroFrame
 
 IntroCheckJoypad::
-    ld   a, [$FFCC]  ; unknow joypad-related value
+    ldh  a, [$FFCC]  ; unknow joypad-related value
     and  $80  ; If not pressing Start
     jp   z, RenderIntroFrame
     ; Start button pressed
@@ -6871,7 +6871,7 @@ IntroCheckJoypad::
     xor  a
     ld   [wGameplaySubtype], a
     ldh  [hBaseScrollX], a
-    ld   [$FF97], a
+    ldh  [$FF97], a
     ld   [rBGP], a
     ld   [wBGPalette], a
     ld   hl, wGameplayType
@@ -6991,7 +6991,7 @@ label_6F5F::
     ld   [$C3B0], a
     ld   [$C3B1], a
     ld   [$C3B2], a
-    ld   [$FFED], a
+    ldh  [$FFED], a
     ld   a, $05
     ld   [$C282], a
     ld   a, $C0
@@ -7273,8 +7273,8 @@ label_7148::
     db 0, 0, 0, 0, $40, $40, $40, $40, $90, $90, $90, $90
 
 label_7154::
-    ld   [$FFE0], a
-    ld   [$FFE0], a
+    ldh  [$FFE0], a
+    ldh  [$FFE0], a
 
 label_7158::
     call label_71C7
@@ -7351,7 +7351,7 @@ label_71C7::
     cp   $A0
     jr   nz, label_71DB
     ld   a, $0F
-    ld   [$FFF4], a
+    ldh  [$FFF4], a
     xor  a
 
 label_71DB::
@@ -7588,7 +7588,7 @@ label_7355::
     cp   $10
     jr   c, label_7363
     ld   a, $19
-    ld   [$FFF4], a
+    ldh  [$FFF4], a
     call IncrementGameplaySubtype
 
 label_7363::
@@ -7761,7 +7761,7 @@ label_7447::
     ld   [wOBJ0Palette], a
     xor  a
     ldh  [hBaseScrollX], a
-    ld   [$FF97], a
+    ldh  [$FF97], a
     dec  a
     ld   [$D018], a
     ret
@@ -7770,11 +7770,11 @@ RenderRain::
     call GetRandomByte
     and  $18
     add  a, $10
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     call GetRandomByte
     and  $18
     add  a, $10
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   hl, $C04C
     ; On the sea, limit the rain to the top section of the screen ($10)
     ld   c, $10
@@ -7785,9 +7785,9 @@ RenderRain::
     ld   c, $15
 
 .loop
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     ldi  [hl], a
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     ldi  [hl], a
     call GetRandomByte
     and  $01       ; if random(0,1) == 0
@@ -7801,16 +7801,16 @@ RenderRain::
     ldi  [hl], a
     ld   a, $00
     ldi  [hl], a
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     add  a, $1C
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     cp   $A0
     jr   c, .continue
     sub  a, $98
-    ld   [$FFD7], a
-    ld   a, [$FFD8]
+    ldh  [$FFD7], a
+    ldh  a, [$FFD8]
     add  a, $25
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
 
 .continue
     dec  c
@@ -7849,19 +7849,19 @@ RenderIntroEntities::
     ld   hl, wEntitiesPosXTable
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFEE], a ; EntityOffsetX?
+    ldh  [$FFEE], a ; EntityOffsetX?
     ld   hl, wEntitiesPosYTable
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFEC], a ; EntityOffsetY?
+    ldh  [$FFEC], a ; EntityOffsetY?
     ld   hl, $C3B0
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFF1], a
+    ldh  [$FFF1], a
     ld   hl, $C290
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFF0], a
+    ldh  [$FFF0], a
     call RenderIntroEntity
 .continue
     dec  c
@@ -7938,12 +7938,12 @@ RenderIntroShip::
     ld   c, $06
 
 .loop
-    ld   a, [$FFEC]
+    ldh  a, [$FFEC]
     add  a, [hl]
     inc  hl
     ld   [de], a
     inc  de
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     add  a, [hl]
     inc  hl
     ld   [de], a
@@ -7964,12 +7964,12 @@ RenderIntroShip::
     ld   de, $C018
     ld   c, $04
 .loop2
-    ld   a, [$FFEC]
+    ldh  a, [$FFEC]
     add  a, [hl]
     inc  hl
     ld   [de], a
     inc  de
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     add  a, [hl]
     inc  hl
     ld   [de], a
@@ -8048,7 +8048,7 @@ RenderIntroMarin::
     ld   a, [$C3C0]
     add  a, $08
     ld   [$C3C0], a
-    ld   a, [$FFF0]
+    ldh  a, [$FFF0]
     JP_TABLE
 ._0 dw label_7681
 ._1 dw label_76AB
@@ -8064,7 +8064,7 @@ label_7681::
     rra
     and  $01
     call label_3B0C
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     cp   $48
     jr   nc, label_769C
     call label_C05
@@ -8278,7 +8278,7 @@ label_77ED::
     rra
     rra
     and  $07
-    ld   [$FFF1], a
+    ldh  [$FFF1], a
     xor  a
     ld   [$C340], a
     ld   de, label_77BD
@@ -8386,11 +8386,11 @@ label_7920::
 
 label_7929::
     ld   a, $78
-    ld   [$FFEE], a
+    ldh  [$FFEE], a
     ld   hl, $D018
     ld   a, $59
     add  a, [hl]
-    ld   [$FFEC], a
+    ldh  [$FFEC], a
     ldh  a, [hIsGBC]
     and  a
     jr   nz, label_795D
@@ -8572,7 +8572,7 @@ label_7A27::
     ld   d, $00
 
 RenderIntroInertLink::
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     cp   $F0
     jr   nc, label_7A47
     xor  a
@@ -8586,7 +8586,7 @@ label_7A36::
     ld   [$C3C0], a
 
 label_7A47::
-    ld   a, [$FFF0]
+    ldh  a, [$FFF0]
     JP_TABLE
     dw $7a52
     dw $7a5e
@@ -8635,10 +8635,10 @@ label_7A8B::
     ld   [$C211], a
 
 label_7A96::
-    ld   a, [$FF97]
+    ldh  a, [$FF97]
     push af
     dec  a
-    ld   [$FF97], a
+    ldh  [$FF97], a
     pop  af
     and  $07
     jr   nz, label_7AB2
@@ -8659,9 +8659,9 @@ label_7AB3::
     call label_C05
     ld   [hl], $17
     ld   a, $07
-    ld   [$FFA9], a
+    ldh  [$FFA9], a
     ld   a, $70
-    ld   [$FFAA], a
+    ldh  [$FFAA], a
     ret
     ldh  a, [hFrameCounter]
     and  $03

--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -21,7 +21,7 @@ label_4000::
     dec  h
     ld   e, b
     call IncrementGameplaySubtype
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_4042
     ld   hl, $DC10
@@ -86,7 +86,7 @@ label_4072::
     ld   a, $FF
     ld   [wWindowY], a
     xor  a
-    ld   [hBaseScrollX], a
+    ldh  [hBaseScrollX], a
     ld   [$FF97], a
     ld   [$C16B], a
     ld   [$C16C], a
@@ -339,7 +339,7 @@ label_420D::
     ld   a, $0F
     ld   [$D6FE], a
     ld   a, $FF
-    ld   [hLinkAnimationState], a
+    ldh  [hLinkAnimationState], a
     ld   a, [$DB57]
     add  a, $01
     daa
@@ -377,7 +377,7 @@ label_4259::
     ld   hl, label_41CF
     add  hl, de
     ld   a, [hl]
-    ld   [hLinkAnimationState], a
+    ldh  [hLinkAnimationState], a
     ld   a, [$FFB7]
     rra
     rra
@@ -410,7 +410,7 @@ label_4259::
     ld   a, $FF
     ld   [wWindowY], a
     xor  a
-    ld   [hBaseScrollX], a
+    ldh  [hBaseScrollX], a
     ld   [$FF97], a
     ld   hl, $FF9C
     inc  [hl]
@@ -750,7 +750,7 @@ label_44B0::
 label_44B4::
     ld   a, $0F
     ld   [$FF94], a
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_44C9
     di
@@ -764,8 +764,8 @@ label_44B4::
 label_44C9::
     call label_D1E
     xor  a
-    ld   [hNeedsUpdatingBGTiles], a
-    ld   [hNeedsUpdatingEnnemiesTiles], a
+    ldh  [hNeedsUpdatingBGTiles], a
+    ldh  [hNeedsUpdatingEnnemiesTiles], a
     ld   a, $09
     ld   [$D6FE], a
 
@@ -826,7 +826,7 @@ label_4507::
     ld   [wOBJ0Palette], a
     ld   a, $E4
     ld   [$DB99], a
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   nz, label_4548
     ld   a, $04
@@ -929,7 +929,7 @@ label_4555::
     ld   [wGameplaySubtype], a
     xor  a
     ld   [$FF97], a
-    ld   [hBaseScrollX], a
+    ldh  [hBaseScrollX], a
     ld   a, $00
     ld   [wBGPalette], a
     ld   [wOBJ0Palette], a
@@ -1336,7 +1336,7 @@ label_4920::
     ld   [$D000], a
 
 label_4938::
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $10
     jr   nz, label_4954
     ld   a, [$D000]
@@ -1361,7 +1361,7 @@ label_4954::
     ld   d, $00
     ld   hl, label_48E4
     add  hl, de
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $08
     jr   z, label_497B
     ld   a, [hl]
@@ -1939,7 +1939,7 @@ label_4CB7::
     ld   b, $00
     add  hl, bc
     ld   e, [hl]
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $10
     jr   z, label_4CD9
     ld   hl, $C004
@@ -2005,7 +2005,7 @@ label_4CDA::
     ld   b, $4E
     ld   l, e
     ld   c, [hl]
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_4D53
     ld   a, $01
@@ -2013,20 +2013,20 @@ label_4CDA::
     ld   a, $01
     ld   [$DDD1], a
     jp   IncrementGameplaySubtypeAndReturn
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_4D53
     ld   a, $02
     ld   [$DDD1], a
     jp   IncrementGameplaySubtypeAndReturn
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_4D53
     call label_905
     ld   a, $01
     ld   [$DDD1], a
     jp   IncrementGameplaySubtypeAndReturn
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_4D53
     ld   a, $02
@@ -2261,7 +2261,7 @@ label_4ECF::
 label_4ED9::
     call label_4F0C
     call label_4954
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $10
     jr   z, label_4EEF
 
@@ -2309,7 +2309,7 @@ label_4F0C::
     ld   [$D000], a
 
 label_4F1D::
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $10
     jr   nz, label_4F3A
     ld   a, [$D000]
@@ -2493,7 +2493,7 @@ label_5055::
     ld   d, $00
     ld   hl, label_48E4
     add  hl, de
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $08
     ld   a, [hl]
     ld   hl, $C000
@@ -2646,7 +2646,7 @@ label_5129::
     call label_5175
 
 label_512C::
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $10
     jr   z, label_514F
     ld   a, [$D001]
@@ -2700,7 +2700,7 @@ label_5175::
     ld   a, [$D002]
     cp   $03
     jp   z, label_51C3
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $08
     jr   z, label_51A8
     ld   a, [hl]
@@ -2745,7 +2745,7 @@ label_51A8::
     ret
 
 label_51C3::
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $08
     ld   a, [hl]
     ld   hl, $C008
@@ -2824,7 +2824,7 @@ label_5235::
 
 label_5249::
     call label_512C
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $10
     jr   z, label_526F
     ld   a, [$D002]
@@ -3002,7 +3002,7 @@ label_5353::
     ld   [$DBA5], a
     jr   z, label_538E
     ld   a, $04
-    ld   [hLinkAnimationState], a
+    ldh  [hLinkAnimationState], a
     ld   a, $02
     ld   [$FF9E], a
 
@@ -3031,7 +3031,7 @@ label_5394::
     ld   a, $60
     ld   [$DB9E], a
     xor  a
-    ld   [hLinkAnimationState], a
+    ldh  [hLinkAnimationState], a
     ld   a, $03
     ld   [$FF9E], a
     ld   a, $16
@@ -3548,7 +3548,7 @@ label_5639::
     dec  h
     ld   e, b
     call IncrementGameplaySubtype
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_5678
     ld   hl, $DC10
@@ -3595,7 +3595,7 @@ label_5678::
     xor  a
     ld   [$C16B], a
     ld   [$C16C], a
-    ld   [hBaseScrollX], a
+    ldh  [hBaseScrollX], a
     ld   [$C1BF], a
     ld   [$FF97], a
     ld   [wInventoryAppearing], a
@@ -3822,7 +3822,7 @@ label_5825::
     ld   a, [$C16B]
     cp   $04
     jr   nz, label_58A7
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_5854
     ld   hl, $DC10
@@ -3854,7 +3854,7 @@ label_5854::
     xor  a
     ld   [$C50A], a
     ld   [$C116], a
-    ld   [hBaseScrollX], a
+    ldh  [hBaseScrollX], a
     ld   [$FF97], a
     ld   [$C167], a
     ld   a, $07
@@ -3915,7 +3915,7 @@ label_58A8::
     ldi  [hl], a
     ld   [hl], $3E
     inc  hl
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     rla
     and  $10
     ld   [hl], a
@@ -4132,7 +4132,7 @@ label_5B3F::
     ld   [hl], $F0
     inc  hl
     ld   [hl], $20
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $10
     jr   nz, label_5BAC
     ld   hl, $C088
@@ -4744,7 +4744,7 @@ label_5F2D::
 
 label_5F2E::
     ld   hl, $0000
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_5F3A
     ld   [hl], $00
@@ -5133,7 +5133,7 @@ label_6162::
     ld   [rOBP0], a
     ld   [rOBP1], a
     ld   [$FF97], a
-    ld   [hBaseScrollX], a
+    ldh  [hBaseScrollX], a
     ld   [$D6FB], a
     ld   [$D6F8], a
     ld   a, $18
@@ -5257,7 +5257,7 @@ label_6281::
     ld   a, $FF
     ld   [wWindowY], a
     xor  a
-    ld   [hBaseScrollX], a
+    ldh  [hBaseScrollX], a
     ld   [$C16B], a
     ld   [$C16C], a
     ld   a, $90
@@ -5374,10 +5374,10 @@ label_63BA::
     db 0, 0, 0, 0, 4, 4, 4, 4, $18, $18, $18, $18, $1C, $1C, $1C, $1C
 
 label_6C3A::
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_63E4
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $07
     jr   nz, label_6417
     call label_1A39
@@ -5388,7 +5388,7 @@ label_6C3A::
     jr   label_6417
 
 label_63E4::
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $07
     jr   nz, label_63F8
     ld   a, [$C3C5]
@@ -5399,7 +5399,7 @@ label_63E4::
     call IncrementGameplaySubtype
 
 label_63F8::
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $03
     ld   e, a
     ld   a, [$C3C5]
@@ -5417,7 +5417,7 @@ label_63F8::
     ld   [wOBJ0Palette], a
 
 label_6417::
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $03
     jr   nz, label_642E
     ld   a, [$FF97]
@@ -5763,7 +5763,7 @@ label_668B::
     pop  de
     call label_658B
     call label_67A8
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $07
     jr   nz, label_66C4
     ld   hl, $C560
@@ -5811,7 +5811,7 @@ label_66FD::
     jr   z, label_6718
     ld   hl, $D200
     add  hl, bc
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $07
     jr   nz, label_6717
     ld   a, [hl]
@@ -5851,7 +5851,7 @@ label_6733::
     sla  a
     sla  a
     ld   e, a
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     add  a, e
     ld   [$FFE9], a
 
@@ -5983,7 +5983,7 @@ label_67EE::
     db $25, $58, $E4, $68, 8, $69, $45, $69, $22, $58, $CD, $D6, $44
 
 label_680B::
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_6829
     ld   hl, $DC10
@@ -6063,7 +6063,7 @@ label_6885::
     ld   a, $FF
     ld   [wWindowY], a
     xor  a
-    ld   [hBaseScrollX], a
+    ldh  [hBaseScrollX], a
     ld   [$FF97], a
     ld   [$C16B], a
     ld   [$C16C], a
@@ -6306,7 +6306,7 @@ label_6A7C::
     jr   z, label_6AC2
     dec  a
     ld   [$D214], a
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $07
     ld   a, [$D212]
     jr   nz, label_6AAE
@@ -6342,7 +6342,7 @@ label_6AC2::
     ld   e, a
     ld   d, $00
     ld   hl, label_6976
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_6AE3
     ld   hl, label_697C
@@ -6353,7 +6353,7 @@ label_6AE3::
     xor  a
     ld   [$C3C0], a
     ld   hl, label_6982
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_6AF4
     ld   hl, label_69D2
@@ -6375,7 +6375,7 @@ label_6AF8::
 
 label_6B0A::
     call IncrementGameplaySubtype
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_6B2B
     ld   hl, $DC10
@@ -6425,7 +6425,7 @@ label_6B52::
     ld   a, $FF
     ld   [wWindowY], a
     xor  a
-    ld   [hBaseScrollX], a
+    ldh  [hBaseScrollX], a
     ld   [$FF97], a
     ld   [$C16B], a
     ld   [$C16C], a
@@ -6497,7 +6497,7 @@ label_6BB4::
 label_6BC6::
     call label_6BEA
     xor  a
-    ld   [hNeedsUpdatingBGTiles], a
+    ldh  [hNeedsUpdatingBGTiles], a
     ld   [$FF92], a
     ret
 
@@ -6688,7 +6688,7 @@ label_6D02::
     ld   a, b
     or   c
     jr   nz, label_6CE9
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_6D10
     call label_6D11
@@ -6804,12 +6804,12 @@ IntroSeaPaletteTable::
     db $C6, $C2, $C0, $C2
 
 IntroHandlerEntryPoint::
-    ld   a, [hButtonsInactiveDelay]
+    ldh  a, [hButtonsInactiveDelay]
     and  a  ; if ButtonsInactiveDelay == 0
     jr   z, IntroCheckJoypad
     ; ButtonsInactiveDelay != 0
     dec  a
-    ld   [hButtonsInactiveDelay], a
+    ldh  [hButtonsInactiveDelay], a
     jp   RenderIntroFrame
 
 IntroCheckJoypad::
@@ -6823,10 +6823,10 @@ IntroCheckJoypad::
     jr   z, .transitionToFileMenu
     ; Transition to Title screen
     ld   a, 40  ; Ignore joypad for the next 40 frames
-    ld   [hButtonsInactiveDelay], a
+    ldh  [hButtonsInactiveDelay], a
     ld   a, $11
     ld   [$D6FF], a
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   nz, .isGBC
     ; Not GBC
@@ -6870,7 +6870,7 @@ IntroCheckJoypad::
     ; Jump to End Sequence (dead code, never reached)
     xor  a
     ld   [wGameplaySubtype], a
-    ld   [hBaseScrollX], a
+    ldh  [hBaseScrollX], a
     ld   [$FF97], a
     ld   [rBGP], a
     ld   [wBGPalette], a
@@ -6937,7 +6937,7 @@ label_6EF8::
     ld   a, $02
     ld   [$D6FE], a
     xor  a
-    ld   [hFrameCounter], a
+    ldh  [hFrameCounter], a
     ld   a, $A2
     ld   [$C13D], a
     ld   a, [$FF40]
@@ -6959,7 +6959,7 @@ label_6F2A::
 
 label_6F36::
     call label_7D01
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_6F42
     ld   a, $25
@@ -7068,7 +7068,7 @@ IntroShipOnSeaHandler::
     ld   a, $FF
     ld   [wIntroTimer], a
     xor  a
-    ld   [hBaseScrollX], a
+    ldh  [hBaseScrollX], a
     ld   [wScrollXOffsetForSection], a
     ld   [$C102], a
     ld   [$C103], a
@@ -7095,12 +7095,12 @@ label_7014::
     ld   a, $01
     ld   [rIE], a
     xor  a
-    ld   [hBaseScrollX], a
+    ldh  [hBaseScrollX], a
     ret
 
 label_7031::
     call label_7D01
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $07
     jp   nz, label_70B1
     ld   hl, hBaseScrollX
@@ -7112,7 +7112,7 @@ label_7031::
     inc  hl
     dec  [hl]
     ld   c, $00
-    ld   a, [hBaseScrollX]
+    ldh  a, [hBaseScrollX]
     cp   $10
     jr   z, label_7068
     inc  c
@@ -7209,7 +7209,7 @@ IntroLinkFaceHandler::
     ; Move back to sea sequence
     ld   a, GAMEPLAY_INTRO_SEA
     ld   [wGameplaySubtype], a
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, .notGBC
     ld   a, $25
@@ -7231,7 +7231,7 @@ IntroLinkFaceHandler::
     ret
 
 .continue4
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $7F
     jr   nz, .return
     ; FrameCounter == $7F
@@ -7314,7 +7314,7 @@ label_7188::
     ld   [$D010], a
 
 label_719B::
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $03
     ld   e, a
     ld   a, [$D010]
@@ -7400,7 +7400,7 @@ label_7286::
     dec  c
     jr   nz, label_7286
     ld   [hl], $00
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_7296
     call label_7338
@@ -7623,7 +7623,7 @@ label_737E::
     ldi  [hl], a
     dec  c
     jr   nz, label_737E
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   nz, label_738E
     call label_79AE
@@ -7677,7 +7677,7 @@ label_73C8::
 TitleScreenHandler::
     call RenderIntroEntities
     call label_7920
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $3F
     jr   nz, label_7418
     ld   e, $01
@@ -7760,7 +7760,7 @@ label_7447::
     ld   a, $1C
     ld   [wOBJ0Palette], a
     xor  a
-    ld   [hBaseScrollX], a
+    ldh  [hBaseScrollX], a
     ld   [$FF97], a
     dec  a
     ld   [$D018], a
@@ -7916,7 +7916,7 @@ RenderIntroShip::
     and  a
     ld   a, $00
     jr   nz, .skip
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     add  a, $D0
     rra
     rra
@@ -8058,7 +8058,7 @@ RenderIntroMarin::
 
 label_7681::
     call label_7D9C
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     rra
     rra
     rra
@@ -8100,7 +8100,7 @@ label_76AB::
     xor  a
     ld   [$C291], a
     ld   [$C2E1], a
-    ld   [hFrameCounter], a
+    ldh  [hFrameCounter], a
     ret
 
 label_76D4::
@@ -8112,7 +8112,7 @@ label_76D6::
     ld   a, [$C201]
     dec  a
     ld   [$C201], a
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $01
     jr   nz, label_7707
     ld   hl, hBaseScrollX
@@ -8137,7 +8137,7 @@ label_76FF::
     xor  a
 
 label_7707::
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     rra
     rra
     and  $01
@@ -8148,13 +8148,13 @@ label_7711::
     call label_C05
     jr   nz, label_7778
     call label_7DCF
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $01
     jr   nz, label_776C
     ld   a, [$C201]
     dec  a
     ld   [$C201], a
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $03
     jr   nz, label_776C
     ld   hl, hBaseScrollX
@@ -8173,7 +8173,7 @@ label_7740::
     ld   [hl], $50
 
 label_7745::
-    ld   a, [hBaseScrollX]
+    ldh  a, [hBaseScrollX]
     cp   $56
     jr   nz, label_775C
     ld   a, $A0
@@ -8198,7 +8198,7 @@ label_7764::
     xor  a
 
 label_776C::
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     rra
     rra
     rra
@@ -8215,7 +8215,7 @@ label_7778::
 
 label_7781::
     call label_7D46
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $01
     jr   nz, label_77BC
     ld   a, $02
@@ -8391,7 +8391,7 @@ label_7929::
     ld   a, $59
     add  a, [hl]
     ld   [$FFEC], a
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   nz, label_795D
     ld   a, [$D013]
@@ -8432,7 +8432,7 @@ label_795D::
     jr   label_797D
 
 label_797D::
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_7997
     ld   a, [$D013]
@@ -8601,7 +8601,7 @@ label_7A47::
 
 label_7A5D::
     ret
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $03
     jr   nz, label_7A6A
     call label_C05
@@ -8663,7 +8663,7 @@ label_7AB3::
     ld   a, $70
     ld   [$FFAA], a
     ret
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $03
     jr   nz, label_7AE3
     call label_C05
@@ -8780,7 +8780,7 @@ label_7C9D::
     cp   $14
     jr   nz, label_7C9D
     ld   [hl], $00
-    ld   a, [hIsGBC]
+    ldh  a, [hIsGBC]
     and  a
     jr   z, label_7CB6
     call label_7CCB
@@ -8830,28 +8830,28 @@ IntroBGVerticalOffsetTable::
 
 label_7D01::
     ld   hl, wScrollXOffsetForSection
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $07
     jr   nz, label_7D0B
     inc  [hl]
 
 label_7D0B::
     inc  hl
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $0F
     jr   nz, label_7D13
     inc  [hl]
 
 label_7D13::
     inc  hl
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $1F
     jr   nz, label_7D1B
     inc  [hl]
 
 label_7D1B::
     inc  hl
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $0F
     jr   nz, label_7D23
     inc  [hl]
@@ -8865,7 +8865,7 @@ label_7D23::
     inc  [hl]
 
 label_7D2F::
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     add  a, $FC
     rra
     rra
@@ -8881,13 +8881,13 @@ label_7D2F::
     ld   [wIntroBGYOffset], a
 
 label_7D46::
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $0F
     cp   $04
     jr   c, label_7D9B
 
 label_7D4E::
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     rra
     rra
     rra
@@ -8916,7 +8916,7 @@ label_7D6A::
     ld   de, $9300
 
 label_7D7A::
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $03
     sla  a
     sla  a
@@ -8940,7 +8940,7 @@ label_7D9B::
 
 label_7D9C::
     ld   hl, wScrollXOffsetForSection
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $07
     jr   nz, label_7DA6
     inc  [hl]
@@ -8974,7 +8974,7 @@ label_7DCC::
 
 label_7DCF::
     ld   hl, wScrollXOffsetForSection
-    ld   a, [hFrameCounter]
+    ldh  a, [hFrameCounter]
     and  $0F
     jr   nz, label_7DD9
     inc  [hl]

--- a/src/code/bank3.asm
+++ b/src/code/bank3.asm
@@ -163,7 +163,7 @@ data_C826::     db 2, 6, 1, 3, 3, 3, $D, 8, $A, 2, 7, $B, 0, 4, 0, 8
 
 label_C85B::
     call label_3A0A
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     ld   hl, $C3E0
     add  hl, bc
     ld   [hl], a
@@ -224,16 +224,16 @@ label_C8AD::
     ld   a, [hl]
     and  $80
     jr   z, label_C918
-    ld   a, [$FFF8]
+    ldh  a, [$FFF8]
     and  $30
     jr   z, label_C8C7
     jp   label_3F8D
 
 label_C8C7::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $5F
     jr   nz, label_C8F0
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $95
     jr   z, label_C8F0
     cp   $92
@@ -306,10 +306,10 @@ label_C926::
     call label_C00
     ld   [hl], $30
     ret
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $65
     ret  nz
-    ld   a, [$FFEC]
+    ldh  a, [$FFEC]
     cp   $50
     ret  c
     ld   hl, $C2B0
@@ -360,9 +360,9 @@ label_C995::
 
 label_C99C::
     ld   [$D368], a
-    ld   [$FFB0], a
-    ld   [$FFBD], a
-    ld   [$FFBF], a
+    ldh  [$FFB0], a
+    ldh  [$FFBD], a
+    ldh  [$FFBF], a
     ret
     xor  a
     ld   [$D219], a
@@ -397,19 +397,19 @@ label_C99C::
     ld   [hl], a
     ret
     xor  a
-    ld   [$FFB0], a
+    ldh  [$FFB0], a
     ret
     call label_CA12
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     swap a
     and  $01
     add  a, $04
     jp   label_3B0C
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     swap a
     and  $01
     ld   e, a
-    ld   a, [$FFEF]
+    ldh  a, [$FFEF]
     swap a
     inc  a
     rla
@@ -434,7 +434,7 @@ label_CA12::
     call label_C05
     ld   [hl], $20
     ret
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $D9
     ld   a, $32
     jr   nz, label_CA32
@@ -448,7 +448,7 @@ label_CA32::
     ld   a, [$DBA5]
     and  a
     jr   z, label_CA46
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   z, label_CA4D
 
@@ -465,7 +465,7 @@ label_CA4F::
     ld   de, $C220
     ld   hl, $C200
     jp   label_CF92
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $E2
     jr   nz, label_CA6B
     ld   a, [$DB56]
@@ -480,16 +480,16 @@ label_CA6B::
 
 label_CA72::
     ret
-    ld   a, [$FFF8]
+    ldh  a, [$FFF8]
     rra
     jr   label_CA7A
-    ld   a, [$FFF8]
+    ldh  a, [$FFF8]
 
 label_CA7A::
     and  $10
     jp   nz, label_3F8D
     ret
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $C0
     jr   c, label_CAA3
     ld   a, [$DB74]
@@ -501,9 +501,9 @@ label_CA7A::
     inc  a
     ld   [$C3C8], a
     ld   a, $2F
-    ld   [$FFB1], a
-    ld   [$FFB0], a
-    ld   [$FFBD], a
+    ldh  [$FFB1], a
+    ldh  [$FFB0], a
+    ldh  [$FFBD], a
     call label_27EA
 
 label_CAA3::
@@ -536,7 +536,7 @@ data_CAC6::
     ld   [bc], a
     nop
     nop
-    ld   a, [$FFFE]
+    ldh  a, [$FFFE]
     and  a
     jr   z, label_CB2F
     ld   a, [$DBA5]
@@ -629,7 +629,7 @@ label_CB56::
     ld   a, [$DBA5]
     and  a
     jr   z, label_CB56
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $DA
     jr   nz, label_CB56
     ld   a, [$DB0E]
@@ -645,7 +645,7 @@ label_CB56::
 
 label_CB84::
     ld   hl, $DDE0
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     ld   e, a
     ld   d, $00
     add  hl, de
@@ -700,7 +700,7 @@ label_CBC2::
     add  hl, bc
     ld   [hl], $00
     jp   label_CB56
-    ld   a, [$FFFE]
+    ldh  a, [$FFFE]
     and  a
     jp   z, label_CB56
     call label_CB84
@@ -710,7 +710,7 @@ label_CBC2::
     add  hl, bc
     ld   a, $3C
     jr   label_CC15
-    ld   a, [$FFFE]
+    ldh  a, [$FFFE]
     and  a
     jp   z, label_CB56
     call label_CB84
@@ -759,18 +759,18 @@ data_CC44::
     inc  [hl]
     call label_C05
     jr   z, label_CC77
-    ld   a, [$FFE7]
+    ldh  a, [$FFE7]
     rra
     rra
     rra
     and  $01
-    ld   [$FFF1], a
+    ldh  [$FFF1], a
     ld   de, data_CC44
     call label_3BC0
     ld   hl, $C3B0
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFF1], a
+    ldh  [$FFF1], a
     call label_3A81
     call label_FF7E
     call label_FFA9
@@ -779,7 +779,7 @@ data_CC44::
     ret
 
 label_CC77::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $1F
     jr   nz, label_CC8C
     ld   hl, $C3A0
@@ -816,7 +816,7 @@ data_CCAC::
 data_CCB2::
     ld   e, $01
     ld   e, $61
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_CCDC
     ld   hl, $C3A0
@@ -852,7 +852,7 @@ label_CCDC::
     ld   [hl], $01
 
 label_CCEF::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $A8
     jr   nz, label_CD04
     ld   a, $16
@@ -868,7 +868,7 @@ label_CD04::
 label_CD07::
     cp   $40
     jr   c, label_CD29
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $09
     jr   z, label_CD19
     cp   $0B
@@ -895,19 +895,19 @@ label_CD29::
     ld   hl, $C3B0
     add  hl, bc
     ld   [hl], a
-    ld   [$FFF1], a
+    ldh  [$FFF1], a
     ld   e, a
     ld   d, b
     ld   hl, data_CCA4
     add  hl, de
-    ld   a, [$FFEC]
+    ldh  a, [$FFEC]
     add  a, [hl]
-    ld   [$FFEC], a
+    ldh  [$FFEC], a
     ld   a, e
     cp   $03
     jr   nz, label_CD51
     xor  a
-    ld   [$FFF1], a
+    ldh  [$FFF1], a
     ld   de, data_CCB2
     call label_3BC0
     jr   label_CD57
@@ -935,26 +935,26 @@ label_CD66::
     ld   hl, data_CCA8
     add  hl, de
     ld   e, [hl]
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     push af
     ld   hl, $C4B0
     add  hl, bc
 
 label_CD7A::
     ld   a, [hl]
-    ld   [$FF98], a
-    ld   a, [$FF99]
+    ldh  [$FF98], a
+    ldh  a, [$FF99]
     push af
     ld   hl, $C4C0
     add  hl, bc
     ld   a, [hl]
-    ld   [$FF99], a
+    ldh  [$FF99], a
     ld   a, e
     call label_FEC7
     pop  af
-    ld   [$FF99], a
+    ldh  [$FF99], a
     pop  af
-    ld   [$FF98], a
+    ldh  [$FF98], a
     jp   label_FF25
     call label_3A81
     call label_FF7E
@@ -967,7 +967,7 @@ label_CD7A::
     ld   [hl], b
     call label_E6FA
     call label_D438
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $5C
     jr   nz, label_CDD2
     ld   hl, $C2A0
@@ -1000,7 +1000,7 @@ label_CDD2::
     or   [hl]
     jr   nz, label_CE04
     call label_F267
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $5C
     jr   nz, label_CE04
 
@@ -1030,7 +1030,7 @@ data_CE05::
     ld   a, [$DB00]
     cp   $03
     jr   nz, label_CE28
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $20
     jr   nz, label_CE35
     jr   label_CE72
@@ -1039,7 +1039,7 @@ label_CE28::
     ld   a, [$DB01]
     cp   $03
     jr   nz, label_CE72
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $10
     jr   z, label_CE72
 
@@ -1067,13 +1067,13 @@ label_CE35::
     add  hl, bc
     ld   [hl], $07
     ld   a, $02
-    ld   [$FFF3], a
+    ldh  [$FFF3], a
     ld   hl, $C490
     add  hl, bc
     ld   [hl], b
     call label_C05
     ld   [hl], $02
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     ld   [$C15D], a
     jp   label_D732
 
@@ -1154,7 +1154,7 @@ label_CED0::
     add  hl, bc
     dec  [hl]
     ret
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     and  $10
     ld   a, $00
     jr   nz, label_CEEC
@@ -1174,7 +1174,7 @@ label_CEEC::
     ld   hl, $C2D0
     add  hl, bc
     ld   [hl], $02
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $A4
     jr   z, label_CF0B
     cp   $D2
@@ -1205,10 +1205,10 @@ label_CF24::
     or   $11
     ld   [hl], a
     ret
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $F8
     jr   nz, label_CF44
-    ld   a, [$FFF8]
+    ldh  a, [$FFF8]
     bit  4, a
     jp   nz, label_3F8D
     bit  5, a
@@ -1219,7 +1219,7 @@ label_CF24::
 label_CF44::
     cp   $7A
     jr   nz, label_CF54
-    ld   a, [$FFF8]
+    ldh  a, [$FFF8]
     and  $10
     jp   nz, label_3F8D
     ld   a, $04
@@ -1231,7 +1231,7 @@ label_CF54::
     ld   a, [$D969]
     and  $10
     jp   z, label_3F8D
-    ld   a, [$FFF8]
+    ldh  a, [$FFF8]
     and  $10
     jp   nz, label_3F8D
 
@@ -1283,7 +1283,7 @@ label_CFA9::
     call label_C00
     ld   [hl], $A0
     ret
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $12
     jr   nz, label_CFC8
     ld   hl, $C2D0
@@ -1360,10 +1360,10 @@ data_D03D::
 data_D048::      db $11, $CB, $4F, $CD, $3C
 data_D04D::      db $58, $C9
 
-data_D04F::      
+data_D04F::
     db $62, $70, $63, $71
 
-data_D053::      
+data_D053::
     db $62, $70, $62, $70
 
 data_D057:: db 3, 4, 5, 6, 7, 8, 9, $A, $B, $C, 2, 1, 0, 0, 0, 0
@@ -1378,9 +1378,9 @@ label_D068::
     ld   a, $2A
     ld   [$C111], a
     ld   a, $04
-    ld   [$FFF4], a
+    ldh  [$FFF4], a
     ld   de, data_D04F
-    ld   a, [$FFFE]
+    ldh  a, [$FFFE]
     and  a
     jr   z, label_D081
     ld   de, data_D053
@@ -1399,7 +1399,7 @@ label_D081::
     ld   hl, $C3B0
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFE8], a
+    ldh  [$FFE8], a
     ld   d, b
     cp   $11
     jr   nz, label_D0AC
@@ -1453,7 +1453,7 @@ label_D0D8::
 label_D0EF::
     cp   $0C
     jr   nc, label_D125
-    ld   a, [$FFE8]
+    ldh  a, [$FFE8]
     cp   $01
     jr   nz, label_D0FD
     ld   hl, $DB44
@@ -1469,7 +1469,7 @@ label_D0FD::
     inc  [hl]
 
 label_D10C::
-    ld   a, [$FFE8]
+    ldh  a, [$FFE8]
     cp   $0A
     jr   nz, label_D11A
     ld   hl, $DB4D
@@ -1496,16 +1496,16 @@ label_D12A::
     ld   a, [hl]
     or   $10
     ld   [hl], a
-    ld   [$FFF8], a
+    ldh  [$FFF8], a
     ret
 
 label_D134::
     ld   a, [$DBA5]
     ld   d, a
     ld   hl, $D800
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     ld   e, a
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_D14B
     ld   d, $00
@@ -1526,16 +1526,16 @@ label_D154::
 data_D156::
     db $6A, $7A, $6B, $7B
 
-data_D15A::      
+data_D15A::
     db $10, $12, $11, $13
 
-data_D15E::      
+data_D15E::
     db $F8, $F9, $FA, $FB
 
-data_D162::      
+data_D162::
     db $E, $1E, $F, $1F
 
-data_D166::      
+data_D166::
     db $68, $77, $69, $4B
 
 data_D16A::
@@ -1567,10 +1567,10 @@ label_D16E::
 
 label_D198::
     ld   a, $11
-    ld   [$FFF4], a
+    ldh  [$FFF4], a
     ld   de, data_D166
     ld   b, $C6
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $77
     jr   nz, label_D1B3
     ld   a, [$DDD9]
@@ -1585,7 +1585,7 @@ label_D1B3::
     jr   z, label_D1C9
     ld   de, data_D15A
     ld   b, $0D
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $C7
     jr   nz, label_D1C9
     ld   de, data_D156
@@ -1596,16 +1596,16 @@ label_D1C9::
     ld   a, b
     push af
     ld   b, $00
-    ld   a, [$FFEF]
+    ldh  a, [$FFEF]
     sub  a, $0F
-    ld   [$FFCD], a
-    ld   a, [$FFEE]
+    ldh  [$FFCD], a
+    ldh  a, [$FFEE]
     sub  a, $07
-    ld   [$FFCE], a
+    ldh  [$FFCE], a
     swap a
     and  $0F
     ld   e, a
-    ld   a, [$FFCD]
+    ldh  a, [$FFCD]
     and  $F0
     or   e
     ld   e, a
@@ -1628,9 +1628,9 @@ label_D1F5::
     add  a, $0A
     ld   [$D600], a
     pop  de
-    ld   a, [$FFCF]
+    ldh  a, [$FFCF]
     ldi  [hl], a
-    ld   a, [$FFD0]
+    ldh  a, [$FFD0]
     ldi  [hl], a
     ld   a, $81
     ldi  [hl], a
@@ -1640,9 +1640,9 @@ label_D1F5::
     ld   a, [de]
     inc  de
     ldi  [hl], a
-    ld   a, [$FFCF]
+    ldh  a, [$FFCF]
     ldi  [hl], a
-    ld   a, [$FFD0]
+    ldh  a, [$FFD0]
     inc  a
     ldi  [hl], a
     ld   a, $81
@@ -1654,7 +1654,7 @@ label_D1F5::
     ldi  [hl], a
     xor  a
     ld   [hl], a
-    ld   a, [$FFFE]
+    ldh  a, [$FFFE]
     and  a
     jr   z, label_D234
     push bc
@@ -1670,7 +1670,7 @@ data_D235::
 
 data_D238::
     db $27, $F8, $17, $FA, $17
-    
+
 data_D23D::
     db $F8, 8, 0, 0
 
@@ -1682,11 +1682,11 @@ data_D245::
 
 label_D249::
     ld   a, [$DBA5]
-    ld   [$FFF1], a
+    ldh  [$FFF1], a
     ld   de, data_D235
     and  a
     jr   nz, label_D25D
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $77
     jr   nz, label_D25D
     ld   de, data_D245
@@ -1703,7 +1703,7 @@ label_D25D::
     ld   [$C144], a
 
 label_D276::
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $C7
     jr   z, label_D282
     ld   a, [$DBA5]
@@ -1712,7 +1712,7 @@ label_D276::
 
 label_D282::
     ld   a, $02
-    ld   [$FFA1], a
+    ldh  [$FFA1], a
 
 label_D286::
     ld   hl, $C3D0
@@ -1777,7 +1777,7 @@ label_D2D7::
     jr   nz, label_D31E
     ld   hl, $C200
     add  hl, de
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     sub  a, [hl]
     add  a, $0C
     cp   $18
@@ -1817,7 +1817,7 @@ label_D31E::
     ld   a, c
     ld   [$C50C], a
     call label_C00
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     jp   z, label_D3A8
     cp   $01
     jr   nz, label_D395
@@ -1832,15 +1832,15 @@ label_D31E::
     ld   a, $2F
     call label_E4CA
     jr   c, label_D369
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     ld   hl, $C200
     add  hl, de
     ld   [hl], a
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     ld   hl, $C210
     add  hl, de
     ld   [hl], a
-    ld   a, [$FFDA]
+    ldh  a, [$FFDA]
     ld   hl, $C310
     add  hl, de
     ld   [hl], a
@@ -1849,10 +1849,10 @@ label_D31E::
     ld   [hl], $80
 
 label_D369::
-    ld   a, [$FFF1]
+    ldh  a, [$FFF1]
     and  a
     jr   nz, label_D392
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $1E
     jr   z, label_D378
     cp   $10
@@ -1926,7 +1926,7 @@ label_D3E4::
     ld   hl, $FFF4
     ld   [hl], $05
     ld   e, $1F
-    ld   a, [$FFF1]
+    ldh  a, [$FFF1]
     cp   $FF
     jr   z, label_D3F9
     cp   $01
@@ -1974,11 +1974,11 @@ label_D438::
 
 label_D455::
     ld   a, $30
-    ld   [$FFCE], a
+    ldh  [$FFCE], a
     ld   a, $20
-    ld   [$FFCD], a
+    ldh  [$FFCD], a
     ld   a, $19
-    ld   [$FFDF], a
+    ldh  [$FFDF], a
     call label_3E4D
     jp   label_C60
 
@@ -2075,7 +2075,7 @@ label_D56F::
     cp   $01
     jr   nz, label_D594
     ld   a, $12
-    ld   [$FFF3], a
+    ldh  [$FFF3], a
 
 label_D594::
     ld   hl, $FFF4
@@ -2084,20 +2084,20 @@ label_D594::
 label_D599::
     call label_FFA9
 
-data_D59C::     
+data_D59C::
     db $C9, $2E, $2E, $2D, $2D, $37, $2D, $FF, $FF, $2F, $37, $38, $2E, $2F
 
-data_D5AA::     
+data_D5AA::
     db $2F, 3, 1, 1, 0, 3, 3, 3, 3, 1, 0, 0, 0, 3
 
-data_D5B8::     
+data_D5B8::
     db 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0
 
 data_D5C7::
     db $2E, $2D, $38, $2F, $2E, $2D, $38, $37
 
 label_DC5F::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $23
     jr   nz, label_D5E2
     ld   hl, $C2B0
@@ -2205,11 +2205,11 @@ label_D670::
     ld   hl, $C2B0
     add  hl, de
     ld   [hl], a
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     ld   hl, $C200
     add  hl, de
     ld   [hl], a
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     ld   hl, $C210
     add  hl, de
     ld   [hl], a
@@ -2222,7 +2222,7 @@ label_D670::
     ld   hl, $C480
     add  hl, de
     ld   [hl], $03
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     jr   nz, label_D6D9
     ld   hl, $C3A0
@@ -2230,7 +2230,7 @@ label_D670::
     ld   a, [hl]
     cp   $30
     jr   nz, label_D6B8
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $88
     jr   nz, label_D6B8
     ld   hl, $C3B0
@@ -2240,7 +2240,7 @@ label_D670::
 label_D6B8::
     cp   $3C
     jr   nz, label_D6D1
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $58
     jr   z, label_D6C6
     cp   $5A
@@ -2288,7 +2288,7 @@ data_D6F1::
 data_D701::
     db 1, $10, $10, 8, 0, $F0, $F0, $F8, 0, 0, 0, 0, 0, $FF, $FF, $FF
 
-data_D711::     
+data_D711::
     db $FF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8
 
 data_D721::
@@ -2296,7 +2296,7 @@ data_D721::
     db $E
 
 label_D732::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     ld   [$C5A8], a
     cp   $02
     jr   nz, label_D745
@@ -2318,7 +2318,7 @@ label_D748::
     cp   $04
     jr   z, label_D789
     ld   a, [$C15D]
-    ld   [$FF9E], a
+    ldh  [$FF9E], a
     push hl
     call label_C05
     pop  hl
@@ -2326,7 +2326,7 @@ label_D748::
     jr   nz, label_D789
     inc  [hl]
     ld   hl, data_D6EA
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $02
     jr   z, label_D77F
     ld   a, [$DB43]
@@ -2360,7 +2360,7 @@ label_D78F::
     jp   label_D7E6
 
 label_D795::
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     sla  a
     sla  a
     add  a, e
@@ -2388,7 +2388,7 @@ label_D795::
     ld   hl, $C210
     add  hl, bc
     ld   [hl], a
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     jr   z, label_D7D7
     push hl
@@ -2421,7 +2421,7 @@ label_D7E9::
     cp   $01
     jr   z, label_D7F7
     ld   a, $30
-    ld   [$FFF5], a
+    ldh  [$FFF5], a
 
 label_D7F7::
     call label_D83C
@@ -2450,7 +2450,7 @@ data_D823::
     ld   b, $04
     ld   [bc], a
     nop
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $15
     jr   nz, label_D835
     ld   a, [$DB56]
@@ -2476,14 +2476,14 @@ label_D847::
     add  hl, bc
     ld   a, $01
     ld   [hl], a
-    ld   [$FFF0], a
+    ldh  [$FFF0], a
     call label_C05
     ld   [hl], $40
 
 label_D858::
     call label_FFA9
     call label_EE28
-    ld   a, [$FFF0]
+    ldh  a, [$FFF0]
     and  a
     jr   z, label_D8D7
     call label_C05
@@ -2498,7 +2498,7 @@ label_D858::
     ld   a, e
     cp   [hl]
     jr   nz, label_D889
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $24
     jr   z, label_D889
     cp   $09
@@ -2654,18 +2654,18 @@ label_D947::
     call label_E4CA
     jr   c, label_D98B
     push bc
-    ld   a, [$FFD9]
+    ldh  a, [$FFD9]
     ld   c, a
     ld   hl, data_D937
     add  hl, bc
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     add  a, [hl]
     ld   hl, $C200
     add  hl, de
     ld   [hl], a
     ld   hl, data_D93B
     add  hl, bc
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     add  a, [hl]
     ld   hl, $C210
     add  hl, de
@@ -2684,7 +2684,7 @@ label_D974::
     ld   hl, $C250
     add  hl, de
     ld   [hl], a
-    ld   a, [$FFD9]
+    ldh  a, [$FFD9]
     ld   hl, $C3B0
     add  hl, de
     ld   [hl], a
@@ -2715,21 +2715,21 @@ label_D998::
     call label_E4CA
     jr   c, label_D9D6
     push bc
-    ld   a, [$FFD9]
+    ldh  a, [$FFD9]
     ld   hl, $C380
     add  hl, de
     ld   [hl], a
     ld   c, a
     ld   hl, data_D98C
     add  hl, bc
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     add  a, [hl]
     ld   hl, $C200
     add  hl, de
     ld   [hl], a
     ld   hl, data_D98E
     add  hl, bc
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     add  a, [hl]
     ld   hl, $C210
     add  hl, de
@@ -2774,8 +2774,8 @@ data_D9D8::
     ld   a, [hl]
     or   $20
     ld   [hl], a
-    ld   [$FFF8], a
-    ld   a, [$FFF7]
+    ldh  [$FFF8], a
+    ldh  a, [$FFF7]
     ld   hl, $DA2E
     cp   $06
     jr   z, label_DA12
@@ -2790,23 +2790,23 @@ label_DA14::
     jp   label_3F8D
 
 label_DA17::
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     ld   hl, $C200
     add  hl, bc
     ld   [hl], a
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     ld   hl, $C210
     add  hl, bc
     sub  a, $0C
     ld   [hl], a
-    ld   a, [$FFA2]
+    ldh  a, [$FFA2]
     ld   hl, $C310
     add  hl, bc
     ld   [hl], a
     ld   a, $6C
-    ld   [$FF9D], a
+    ldh  [$FF9D], a
     ld   a, $03
-    ld   [$FF9E], a
+    ldh  [$FF9E], a
     xor  a
     ld   [$C137], a
     ld   [$C16A], a
@@ -2816,7 +2816,7 @@ label_DA17::
     add  hl, bc
     ld   [hl], a
     ld   a, $02
-    ld   [$FFA1], a
+    ldh  [$FFA1], a
     ret
 
 data_DA4D::
@@ -2824,10 +2824,10 @@ data_DA4D::
     ld   [bc], a
     xor  h
     ldi  [hl], a
-    ld   a, [$FFF8]
+    ldh  a, [$FFF8]
     and  $10
     jp   nz, label_3F8D
-    ld   a, [$FFF0]
+    ldh  a, [$FFF0]
     rst  0
     ld   d, d
     ld   e, e
@@ -2853,10 +2853,10 @@ data_DA4D::
     ld   [$C167], a
     jp   label_3B12
     ld   a, $03
-    ld   [$FF90], a
+    ldh  [$FF90], a
     jp   label_3B12
     ld   a, $04
-    ld   [$FF90], a
+    ldh  [$FF90], a
     jp   label_3B12
     ld   a, $4F
     call label_2385
@@ -2895,7 +2895,7 @@ label_DABA::
     cp   $04
     jr   nz, label_DAED
     ld   a, $19
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     xor  a
     ld   [$DB5C], a
     ld   hl, $DB93
@@ -2914,13 +2914,13 @@ label_DAED::
     and  a
     ret  nz
     ld   a, $05
-    ld   [$FF90], a
+    ldh  [$FF90], a
     jp   label_3B12
     ld   a, $06
-    ld   [$FF90], a
+    ldh  [$FF90], a
     call label_3F8D
     ld   a, $0D
-    ld   [$FFA5], a
+    ldh  [$FFA5], a
     xor  a
     ld   [$C167], a
     jp   label_D12A
@@ -2961,11 +2961,11 @@ label_DB2B::
     ld   a, $6B
 
 label_DB41::
-    ld   [$FFEC], a
+    ldh  [$FFEC], a
     ld   a, [$DB5C]
-    ld   [$FFF1], a
+    ldh  [$FFF1], a
     ld   a, $8E
-    ld   [$FFEE], a
+    ldh  [$FFEE], a
     ld   de, data_DB17
     jp   label_3BC0
     ld   de, data_DA4D
@@ -2992,7 +2992,7 @@ data_DB6B::
 label_DB6D::
     ld   de, data_DB65
     call label_3BC0
-    ld   a, [$FFE7]
+    ldh  a, [$FFE7]
     rra
     rra
     rra
@@ -3001,14 +3001,14 @@ label_DB6D::
 
 label_DB7D::
     jp   label_E0AA
-    
+
 data_DB80::
     db $74, 0, $76, 0, $76, $20, $74, $20, $11, $80, $5B, $CD, $C0, $3B, $CD, $78
     db $7F, $CD, $AF, $62, $C9
-    
+
 data_DB95::
     db $86, $17
-    
+
 data_DB97::
     db $84, $17
 
@@ -3017,14 +3017,14 @@ label_DB99::
     ld   a, [$DB4E]
     and  a
     jr   nz, label_DBAC
-    ld   a, [$FFF8]
+    ldh  a, [$FFF8]
     and  $10
     jp   nz, label_3F8D
     ld   de, data_DB97
 
 label_DBAC::
     call label_3C77
-    ld   a, [$FFF0]
+    ldh  a, [$FFF0]
     rst  0
 
 label_DBB2::
@@ -3046,8 +3046,8 @@ label_DBCB::
     ld   a, $31
     ld   [$D368], a
     ld   a, $05
-    ld   [$FFB0], a
-    ld   [$FFBF], a
+    ldh  [$FFB0], a
+    ldh  [$FFBF], a
     call label_BFB
     ld   [hl], $52
     call label_3B12
@@ -3064,7 +3064,7 @@ label_DBE1::
     ld   a, $20
     ld   [$C121], a
     ld   a, $03
-    ld   [$FFF4], a
+    ldh  [$FFF4], a
     jp   label_3B12
     call label_C05
     ret  nz
@@ -3074,10 +3074,10 @@ label_DBE1::
     jp   label_3B12
     call label_DA17
     ld   a, $6B
-    ld   [$FF9D], a
+    ldh  [$FF9D], a
     ld   hl, $C200
     add  hl, bc
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     sub  a, $04
     ld   [hl], a
     call label_C05
@@ -3093,11 +3093,11 @@ label_DBE1::
 label_DC37::
     cp   $1A
     jr   nz, label_DC46
-    ld   a, [$FFEF]
+    ldh  a, [$FFEF]
     sub  a, $0C
     call label_EC36
     ld   a, $07
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
 
 label_DC46::
     ret
@@ -3106,7 +3106,7 @@ data_DC47::
     db $8A, $14
 
 label_DC49::
-    ld   a, [$FFF8]
+    ldh  a, [$FFF8]
     and  $10
     jp   nz, label_3F8D
     ld   de, data_DC47
@@ -3136,7 +3136,7 @@ data_DC78::
 
 data_DC84::
     db 0, $A3, $A4, $A5, 0
-    
+
 label_DC89::
     call label_DCEA
     jr   nc, label_DC99
@@ -3147,7 +3147,7 @@ label_DC89::
     ret
 
 label_DC99::
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $80
     jp   z, label_DC49
     ld   de, data_DC78
@@ -3157,7 +3157,7 @@ label_DC99::
     cp   $10
     jr   nz, label_DCCD
     dec  [hl]
-    ld   a, [$FFF1]
+    ldh  a, [$FFF1]
     dec  a
     ld   e, a
     ld   d, b
@@ -3165,7 +3165,7 @@ label_DC99::
     add  hl, de
     ld   a, [hl]
     call label_2385
-    ld   a, [$FFF1]
+    ldh  a, [$FFF1]
     dec  a
     ld   e, a
     ld   d, b
@@ -3200,15 +3200,15 @@ label_DCEA::
     ld   a, [$DBA5]
     and  a
     jr   nz, label_DD34
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $CE
     jr   nz, label_DD34
-    ld   a, [$FFEF]
+    ldh  a, [$FFEF]
     sub  a, $48
     add  a, $03
     cp   $06
     jr   nc, label_DD34
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     sub  a, $50
     add  a, $03
     cp   $06
@@ -3233,7 +3233,7 @@ label_DCEA::
     call label_C05
     ld   [hl], $2F
     ld   a, $18
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     scf
     ret
 
@@ -3274,7 +3274,7 @@ label_DD6C::
     dec  a
     jr   nz, label_DD80
     ld   a, $0A
-    ld   [$FFA5], a
+    ldh  [$FFA5], a
     ld   d, $0C
     call label_E472
     ld   a, $01
@@ -3337,14 +3337,14 @@ label_DE29::
     ld   a, [hl]
     cp   $19
     jr   nc, label_DE8A
-    ld   a, [$FFE7]
+    ldh  a, [$FFE7]
     and  $07
     jr   nz, label_DE5B
     ld   a, [hl]
     and  a
     jr   nz, label_DE45
     ld   a, $2C
-    ld   [$FFF4], a
+    ldh  [$FFF4], a
     xor  a
 
 label_DE45::
@@ -3361,14 +3361,14 @@ label_DE45::
     ld   [hl], $60
 
 label_DE5B::
-    ld   a, [$FFE7]
+    ldh  a, [$FFE7]
     and  $03
     ld   hl, $C2C0
     add  hl, bc
     add  a, [hl]
     ld   e, a
     ld   d, b
-    ld   a, [$FFFE]
+    ldh  a, [$FFFE]
     and  a
     jr   z, label_DE76
     push bc
@@ -3402,16 +3402,16 @@ label_DE8B::
 label_DEAE::
     ld   a, c
     ld   [$D201], a
-    ld   a, [$FFF8]
+    ldh  a, [$FFF8]
     and  $10
     jp   nz, label_3F8D
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     and  $03
-    ld   [$FFF1], a
+    ldh  [$FFF1], a
     call label_394D
     ld   de, data_DD83
     call label_3BC0
-    ld   a, [$FFF0]
+    ldh  a, [$FFF0]
     rst  0
     push de
     ld   e, [hl]
@@ -3429,10 +3429,10 @@ label_DEAE::
     jr   nz, label_DEFE
     dec  [hl]
     call label_3B12
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     add  a, $00
     call label_2373
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     ld   e, a
     ld   d, b
     ld   hl, $DB65
@@ -3471,15 +3471,15 @@ label_DF33::
     call label_C05
     jr   nz, label_DF5F
     ld   a, $2B
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     ld   a, $39
     call label_E4CA
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     dec  a
     ld   hl, $C200
     add  hl, de
     ld   [hl], a
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     ld   hl, $C210
     add  hl, de
     ld   [hl], a
@@ -3504,18 +3504,18 @@ label_DF5F::
     inc  [hl]
     ld   a, [hl]
     and  $01
-    ld   [$FFE8], a
+    ldh  [$FFE8], a
     ld   a, $39
     call label_E4CA
     push bc
     ld   hl, $C2B0
     add  hl, de
     inc  [hl]
-    ld   a, [$FFE8]
+    ldh  a, [$FFE8]
     ld   c, a
     ld   hl, data_DF2F
     add  hl, bc
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     add  a, [hl]
     ld   hl, $C200
     add  hl, de
@@ -3526,7 +3526,7 @@ label_DF5F::
     ld   hl, $C240
     add  hl, de
     ld   [hl], a
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     ld   hl, $C210
     add  hl, de
     add  a, $F8
@@ -3585,7 +3585,7 @@ label_E001::
     ld   a, [$DBA5]
     and  a
     jr   nz, label_E029
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $C6
     jr   nz, label_E029
     ld   a, $05
@@ -3626,7 +3626,7 @@ label_E055::
     db   $DB
     and  a
     jr   z, label_E063
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   z, label_E06A
 
@@ -3680,7 +3680,7 @@ label_E0B3::
     call label_FF25
     call label_EB7B
     call label_F893
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     jr   z, label_E0E3
     ld   hl, $C2A0
@@ -3739,11 +3739,11 @@ label_E103::
 label_E112::
     push af
     push hl
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $30
     jr   nz, label_E120
     ld   a, $17
-    ld   [$FFF4], a
+    ldh  [$FFF4], a
     jr   label_E134
 
 label_E120::
@@ -3759,7 +3759,7 @@ label_E120::
     ld   a, $09
 
 label_E132::
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
 
 label_E134::
     pop  hl
@@ -3777,7 +3777,7 @@ label_E136::
 
 label_E143::
     ld   [hl], a
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     jr   nz, label_E156
     ld   hl, $C250
@@ -3838,7 +3838,7 @@ label_E1BB::
     jp   label_FEC7
 
 label_E1C0::
-    ld   a, [$FFE7]
+    ldh  a, [$FFE7]
     and  $03
     jr   nz, label_E1DD
     ld   hl, $C310
@@ -3875,7 +3875,7 @@ label_E1DE::
     ld   a, [hl]
     cp   $02
     jr   nz, label_E243
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $3D
     jr   z, label_E200
     ld   a, [$DBA5]
@@ -3884,12 +3884,12 @@ label_E1DE::
 
 label_E200::
     call label_FE0E
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $2D
     jr   z, label_E227
     cp   $3D
     jr   nz, label_E22F
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $DA
     jr   z, label_E22F
     cp   $A5
@@ -3904,7 +3904,7 @@ label_E200::
     jr   z, label_E22F
 
 label_E227::
-    ld   a, [$FFAF]
+    ldh  a, [$FFAF]
     cp   $04
     jr   z, label_E23B
     jr   label_E235
@@ -3915,7 +3915,7 @@ label_E22F::
     ld   [hl], $01
 
 label_E235::
-    ld   a, [$FFAF]
+    ldh  a, [$FFAF]
     cp   $CC
     jr   nz, label_E29C
 
@@ -3932,14 +3932,14 @@ label_E243::
     ld   a, [$C178]
     and  a
     jr   z, label_E29C
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     add  a, $08
     ld   hl, $C179
     sub  a, [hl]
     add  a, $10
     cp   $20
     jr   nc, label_E29C
-    ld   a, [$FFEF]
+    ldh  a, [$FFEF]
     add  a, $08
     ld   hl, $C17A
     sub  a, [hl]
@@ -3958,13 +3958,13 @@ label_E26B::
     ld   [hl], $18
     ld   a, $0C
     call label_FE45
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     cpl
     inc  a
     ld   hl, $C240
     add  hl, bc
     ld   [hl], a
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     cpl
     inc  a
     ld   hl, $C250
@@ -4033,7 +4033,7 @@ label_E2EA::
 label_E2EB::
     call label_C00
     jr   nz, label_E2EA
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     sub  a, $2D
     ld   e, a
     ld   d, b
@@ -4062,7 +4062,7 @@ label_E311::
     add  hl, bc
     ld   a, [hl]
     call label_3F78
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     sub  a, $2D
     cp   $02
     jr   nc, label_E328
@@ -4109,7 +4109,7 @@ label_E32D::
     ld   l, b
     ld   h, e
     ld   a, $0B
-    ld   [$FFA5], a
+    ldh  [$FFA5], a
     ld   d, $0C
     call label_E472
     ld   hl, $DB76
@@ -4158,13 +4158,13 @@ label_E37C::
     ld   [$C167], a
 
 label_E3A1::
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     push af
     add  a, $04
-    ld   [$FF98], a
+    ldh  [$FF98], a
     call label_E41E
     pop  af
-    ld   [$FF98], a
+    ldh  [$FF98], a
     jr   label_E3D2
     xor  a
     ld   [$D47C], a
@@ -4180,7 +4180,7 @@ label_E3A1::
     ld   [$D368], a
     jr   label_E3D2
     ld   a, $01
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
 
 label_E3D2::
     call label_C05
@@ -4214,14 +4214,14 @@ label_E422::
     push de
     ld   hl, data_E3EE
     add  hl, de
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     add  a, [hl]
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   hl, data_E3F2
     add  hl, de
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     add  a, [hl]
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     ld   a, $07
     call label_CC7
     ld   hl, $C520
@@ -4246,7 +4246,7 @@ label_E422::
     call label_C05
     ld   [hl], $A0
     ld   a, $FF
-    ld   [$FFBF], a
+    ldh  [$FFBF], a
     ret
 
 label_E468::
@@ -4284,17 +4284,17 @@ label_E487::
 
 label_E48E::
     ret
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $80
     jr   z, label_E4A5
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     cp   $7C
     jr   nz, label_E4A0
     ld   hl, $D969
     set  4, [hl]
 
 label_E4A0::
-    ld   a, [$FFF1]
+    ldh  a, [$FFF1]
     and  a
     jr   z, label_E4AD
 
@@ -4351,19 +4351,19 @@ label_E4E0::
     ld   hl, $C200
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   hl, $C210
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     ld   hl, $C380
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFD9], a
+    ldh  [$FFD9], a
     ld   hl, $C310
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFDA], a
+    ldh  [$FFDA], a
     call label_E524
     ld   hl, $C410
     add  hl, de
@@ -4491,13 +4491,13 @@ label_E614::
     jr   label_E64A
 
 label_E625::
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     ld   hl, $FF98
     sub  a, [hl]
     add  a, $18
     cp   $30
     jr   nc, label_E64A
-    ld   a, [$FFEF]
+    ldh  a, [$FFEF]
     ld   hl, $FF99
     sub  a, [hl]
     add  a, $18
@@ -4558,7 +4558,7 @@ label_E68C::
     call label_3BC0
     call label_FF78
     ret
-    ld   a, [$FFEC]
+    ldh  a, [$FFEC]
     add  a, $10
     cp   $A0
     jp   nc, label_3F8D
@@ -4596,7 +4596,7 @@ label_E6BF::
     ld   a, [$DB00]
     cp   $02
     jr   nz, label_E6EA
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $20
     jr   nz, label_E6F7
     jr   label_E6FA
@@ -4605,7 +4605,7 @@ label_E6EA::
     ld   a, [$DB01]
     cp   $02
     jr   nz, label_E6FA
-    ld   a, [$FFCC]
+    ldh  a, [$FFCC]
     and  $10
     jr   z, label_E6FA
 
@@ -4621,7 +4621,7 @@ label_E6FA::
     call label_EB34
 
 label_E706::
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     ret  nz
     ld   a, [hl]
@@ -4667,18 +4667,18 @@ data_E759::
 
 data_E75D::
     db $F8, 8, $FF, 1
-    
+
 data_E761::
     db $72, $73, $73, $72, 0, 0, 0, 0
 
 data_E769::
     db 0, $10, $F0, $10
-    
+
 data_E76D::
     db 0, 0, $10, 0
 
 label_E771::
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     jp   nz, label_E8E5
     push bc
@@ -4690,7 +4690,7 @@ label_E771::
     add  hl, de
     add  a, [hl]
     and  $F0
-    ld   [$FFCE], a
+    ldh  [$FFCE], a
     swap a
     ld   hl, $C210
     add  hl, bc
@@ -4701,7 +4701,7 @@ label_E771::
     add  hl, de
     add  a, [hl]
     and  $F0
-    ld   [$FFCD], a
+    ldh  [$FFCD], a
     or   c
     ld   c, a
     ld   b, $00
@@ -4710,9 +4710,9 @@ label_E771::
     add  hl, bc
     ld   h, a
     ld   a, c
-    ld   [$FFE9], a
+    ldh  [$FFE9], a
     ld   a, [hl]
-    ld   [$FFAF], a
+    ldh  [$FFAF], a
     ld   e, a
     cp   $BB
     jr   c, label_E828
@@ -4722,13 +4722,13 @@ label_E771::
     and  a
     jr   nz, label_E828
     ld   a, $02
-    ld   [$FFF2], a
-    ld   a, [$FFCD]
+    ldh  [$FFF2], a
+    ldh  a, [$FFCD]
     and  $E0
-    ld   [$FFCD], a
-    ld   a, [$FFCE]
+    ldh  [$FFCD], a
+    ldh  a, [$FFCE]
     and  $E0
-    ld   [$FFCE], a
+    ldh  [$FFCE], a
     ld   a, $03
     call label_AA7
     ld   a, c
@@ -4795,12 +4795,12 @@ label_E828::
     jp   nc, label_E8E4
     ld   c, a
     ld   a, $02
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     ld   a, [$DBA5]
     and  a
     jr   nz, label_E878
     pop  bc
-    ld   a, [$FFE9]
+    ldh  a, [$FFE9]
     ld   e, a
     ld   d, b
     ld   hl, $D711
@@ -4810,7 +4810,7 @@ label_E828::
     ld   [$DDD8], a
     ld   a, $83
     call label_B2F
-    ld   a, [$FFFE]
+    ldh  a, [$FFFE]
     and  a
     jr   z, label_E862
     ld   de, data_E751
@@ -4822,22 +4822,22 @@ label_E862::
 label_E865::
     push de
     ld   hl, $D800
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     ld   e, a
     ld   d, $00
     add  hl, de
     ld   a, [hl]
     or   $04
     ld   [hl], a
-    ld   [$FFF8], a
+    ldh  [$FFF8], a
     jp   label_D1F5
 
 label_E878::
     ld   hl, $D900
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     ld   e, a
     ld   d, $00
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_E88B
     ld   hl, $DDE0
@@ -4859,7 +4859,7 @@ label_E894::
     ld   a, [de]
     or   [hl]
     ld   [de], a
-    ld   [$FFF8], a
+    ldh  [$FFF8], a
     ld   hl, data_E75D
     add  hl, bc
     ld   a, [$DBAE]
@@ -4874,13 +4874,13 @@ label_E894::
     ld   a, [de]
     or   [hl]
     ld   [de], a
-    ld   a, [$FFCE]
+    ldh  a, [$FFCE]
     swap a
     and  $0F
     ld   e, a
 
 label_E8BE::
-    ld   a, [$FFCD]
+    ldh  a, [$FFCD]
     and  $F0
     or   e
     ld   e, a
@@ -4921,22 +4921,22 @@ label_E8F8::
     push bc
     ld   hl, data_E8E6
     add  hl, de
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     add  a, [hl]
     sub  a, $08
     and  $F0
-    ld   [$FFCE], a
+    ldh  [$FFCE], a
     swap a
     ld   c, a
     ld   hl, data_E8EF
     add  hl, de
-    ld   a, [$FFEC]
+    ldh  a, [$FFEC]
 
 label_E90F::
     add  a, [hl]
     sub  a, $10
     and  $F0
-    ld   [$FFCD], a
+    ldh  [$FFCD], a
     or   c
     ld   e, a
     ld   hl, $D711
@@ -4947,9 +4947,9 @@ label_E90F::
     ld   a, [$DBA5]
     and  a
     ld   a, [hl]
-    ld   [$FFAF], a
+    ldh  [$FFAF], a
     jr   nz, label_E93C
-    ld   [$FFE9], a
+    ldh  [$FFE9], a
     cp   $0A
     jr   z, label_E964
     cp   $D3
@@ -4962,10 +4962,10 @@ label_E93C::
     cp   $A9
     jp   nz, label_E9A0
     ld   hl, $D900
-    ld   a, [$FFF6]
+    ldh  a, [$FFF6]
     ld   c, a
     ld   b, $00
-    ld   a, [$FFF7]
+    ldh  a, [$FFF7]
     cp   $FF
     jr   nz, label_E954
     ld   hl, $DDE0
@@ -4983,7 +4983,7 @@ label_E95D::
     ld   a, [hl]
     or   $40
     ld   [hl], a
-    ld   [$FFF8], a
+    ldh  [$FFF8], a
 
 label_E964::
     call label_2178
@@ -4994,12 +4994,12 @@ label_E964::
     ld   [$C19B], a
     ld   hl, $C200
     add  hl, de
-    ld   a, [$FFCE]
+    ldh  a, [$FFCE]
     add  a, $08
     ld   [hl], a
     ld   hl, $C210
     add  hl, de
-    ld   a, [$FFCD]
+    ldh  a, [$FFCD]
     add  a, $10
     ld   [hl], a
     ld   hl, $C3B0
@@ -5007,13 +5007,13 @@ label_E964::
     ld   a, [$DBA5]
     xor  $01
     ld   [hl], a
-    ld   [$FFF1], a
-    ld   a, [$FFE9]
+    ldh  [$FFF1], a
+    ldh  a, [$FFE9]
     cp   $0A
     jr   nz, label_E99B
     ld   a, $FF
     ld   [hl], a
-    ld   [$FFF1], a
+    ldh  [$FFF1], a
 
 label_E99B::
     ld   c, e
@@ -5042,7 +5042,7 @@ label_E9D9::
     call label_FF78
     ld   a, [$DBA5]
     and  a
-    ld   a, [$FFAF]
+    ldh  a, [$FFAF]
     jr   z, label_E9F0
     cp   $8A
     jr   z, label_E9F8
@@ -5060,20 +5060,20 @@ label_E9F8::
     ld   [hl], b
     call label_C00
     ld   [hl], b
-    ld   a, [$FFE9]
+    ldh  a, [$FFE9]
     ld   e, a
     ld   d, b
     call label_2178
-    ld   a, [$FFCE]
+    ldh  a, [$FFCE]
     add  a, $08
-    ld   [$FFD7], a
-    ld   a, [$FFCD]
+    ldh  [$FFD7], a
+    ldh  a, [$FFCD]
     add  a, $10
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     ld   a, $08
     call label_CC7
     ld   a, $13
-    ld   [$FFF4], a
+    ldh  [$FFF4], a
 
 label_EA1D::
     ret
@@ -5086,7 +5086,7 @@ label_EA2E::
     jp   label_EAD7
     ld   hl, $C14D
     inc  [hl]
-    ld   a, [$FFF0]
+    ldh  a, [$FFF0]
     and  a
     jr   nz, label_EA70
     call label_C05
@@ -5095,14 +5095,14 @@ label_EA2E::
     ld   [$C19E], a
     call label_F5A2
     call label_EAD4
-    ld   a, [$FFF1]
+    ldh  a, [$FFF1]
     cp   $02
     ret  nz
     ld   a, [$C18E]
     and  $1F
     cp   $0F
     ret  nz
-    ld   a, [$FFAF]
+    ldh  a, [$FFAF]
     cp   $C0
     ret  nz
     call label_C60
@@ -5124,11 +5124,11 @@ label_EA70::
     ld   a, $02
     call label_E4CA
     jr   c, label_EA93
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     ld   hl, $C200
     add  hl, de
     ld   [hl], a
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     ld   hl, $C210
     add  hl, de
     ld   [hl], a
@@ -5141,27 +5141,27 @@ label_EA93::
     jp   label_3F8D
 
 label_EA96::
-    ld   a, [$FFF1]
+    ldh  a, [$FFF1]
     push af
     ld   e, a
     ld   d, b
     xor  a
-    ld   [$FFF1], a
+    ldh  [$FFF1], a
     ld   hl, data_EA68
     add  hl, de
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     add  a, [hl]
-    ld   [$FFEE], a
+    ldh  [$FFEE], a
     ld   hl, data_EA6C
     add  hl, de
-    ld   a, [$FFEC]
+    ldh  a, [$FFEC]
     add  a, [hl]
-    ld   [$FFEC], a
+    ldh  [$FFEC], a
     ld   de, data_EA66
     call label_3C77
     call label_3D8A
     pop  af
-    ld   [$FFF1], a
+    ldh  [$FFF1], a
     ld   de, data_EBC6
     call label_3BC0
     ld   a, $0C
@@ -5190,7 +5190,7 @@ label_EADA::
     and  a
     jr   z, label_EB42
     call label_C05
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $04
     jr   nz, label_EAFF
     call label_C00
@@ -5208,11 +5208,11 @@ label_EAFF::
     inc  a
     jr   z, label_EB13
     ld   a, $07
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
 
 label_EB13::
     call label_C50
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $00
     jr   nz, label_EB31
     call label_EB2C
@@ -5264,7 +5264,7 @@ label_EB4C::
     jp   label_3F8D
 
 label_EB53::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $0A
     jr   z, label_EB6E
     call label_C05
@@ -5290,7 +5290,7 @@ data_EB77::
     db $40, 8, $40, $40
 
 label_EB7B::
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     jr   nz, label_EB8C
     call label_FF5E
@@ -5309,7 +5309,7 @@ label_EB8C::
     ld   d, b
     and  a
     jr   z, label_EBAB
-    ld   a, [$FFE7]
+    ldh  a, [$FFE7]
     and  $07
     jr   nz, label_EBAB
     ld   hl, $C240
@@ -5359,17 +5359,17 @@ label_EBDE::
     ld   a, [$C11C]
     cp   $02
     jr   nc, label_EC5A
-    ld   a, [$FFA2]
+    ldh  a, [$FFA2]
     and  a
     jr   nz, label_EC5A
     ld   hl, $FFEE
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     sub  a, [hl]
     add  a, $06
     cp   $0C
     jr   nc, label_EC5A
     ld   hl, $FFEC
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     sub  a, [hl]
     add  a, $06
     cp   $0C
@@ -5377,13 +5377,13 @@ label_EBDE::
     ld   a, [$C15B]
     and  a
     jr   z, label_EC5B
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $2B
     jr   nz, label_EC41
     ld   a, [$DB44]
     cp   $02
     jr   c, label_EC5B
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     ld   e, a
     ld   d, b
     ld   hl, data_EBDA
@@ -5400,13 +5400,13 @@ label_EBDE::
     add  hl, bc
     ld   [hl], $02
     ld   a, $07
-    ld   [$FFF2], a
-    ld   a, [$FFEF]
+    ldh  [$FFF2], a
+    ldh  a, [$FFEF]
 
 label_EC36::
-    ld   [$FFD8], a
-    ld   a, [$FFEE]
-    ld   [$FFD7], a
+    ldh  [$FFD8], a
+    ldh  a, [$FFEE]
+    ldh  [$FFD7], a
     ld   a, $05
     jp   label_CC7
 
@@ -5417,11 +5417,11 @@ label_EC41::
     ld   d, b
     ld   hl, data_EBD6
     add  hl, de
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     cp   [hl]
     jr   nz, label_EC5B
     ld   a, $16
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
 
 label_EC54::
     ld   hl, $C2A0
@@ -5433,7 +5433,7 @@ label_EC5A::
 
 label_EC5B::
     call label_ECC0
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $2B
     jr   z, label_EC68
     cp   $0C
@@ -5443,13 +5443,13 @@ label_EC68::
     jp   label_3F8D
 
 label_EC6B::
-    ld   a, [$FFE7]
+    ldh  a, [$FFE7]
     xor  c
     rra
     jp   nc, label_ECCB
 
 label_EC72::
-    ld   a, [$FFA2]
+    ldh  a, [$FFA2]
     and  a
     jr   nz, label_EC5A
 
@@ -5463,7 +5463,7 @@ label_EC77::
     ld   hl, $D580
     add  hl, bc
     pop  bc
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     add  a, [hl]
     push hl
     ld   hl, $FF98
@@ -5485,7 +5485,7 @@ label_EC98::
     cp   e
     jp   nc, label_ECCB
     inc  hl
-    ld   a, [$FFEC]
+    ldh  a, [$FFEC]
     add  a, [hl]
     push hl
     ld   hl, $FF99
@@ -5523,13 +5523,13 @@ label_ECCB::
     ret
 
 label_ECCD::
-    ld   a, [$FF9D]
+    ldh  a, [$FF9D]
     sub  a, $4E
     cp   $02
     jr   c, label_ECC9
 
 label_ECD5::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $AC
     jr   nz, label_ECF9
     call label_FEE9
@@ -5541,31 +5541,31 @@ label_ECD5::
     ld   a, $02
     ld   [$C146], a
     ld   a, $F0
-    ld   [$FF9B], a
+    ldh  [$FF9B], a
     call label_3D7F
     ld   a, $0E
-    ld   [$FFF3], a
+    ldh  [$FFF3], a
     ret
 
 label_ECF9::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $9F
     jr   nz, label_ED3D
     ld   a, [$C146]
     and  a
     jr   z, label_ED3D
-    ld   a, [$FFB7]
+    ldh  a, [$FFB7]
     and  a
     jr   nz, label_ED1B
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     jr   nz, label_ED15
-    ld   a, [$FFA3]
+    ldh  a, [$FFA3]
     xor  $80
     jr   label_ED17
 
 label_ED15::
-    ld   a, [$FF9B]
+    ldh  a, [$FF9B]
 
 label_ED17::
     and  $80
@@ -5573,28 +5573,28 @@ label_ED17::
 
 label_ED1B::
     ld   a, $02
-    ld   [$FFB7], a
+    ldh  [$FFB7], a
     ld   hl, $C290
     add  hl, bc
     ld   [hl], $02
     call label_C05
     ld   [hl], $30
     ld   a, $0E
-    ld   [$FFF3], a
-    ld   a, [$FFF9]
+    ldh  [$FFF3], a
+    ldh  a, [$FFF9]
     and  a
     jr   nz, label_ED38
     ld   a, $10
-    ld   [$FFA3], a
+    ldh  [$FFA3], a
     ret
 
 label_ED38::
     ld   a, $F0
-    ld   [$FF9B], a
+    ldh  [$FF9B], a
     ret
 
 label_ED3D::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $1C
     jr   nz, label_ED4E
     call label_C05
@@ -5613,16 +5613,16 @@ label_ED4E::
     jp   nz, label_EE0A
 
 label_ED5D::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $E4
     jr   nz, label_ED73
-    ld   a, [$FFF0]
+    ldh  a, [$FFF0]
     cp   $04
     jr   nz, label_ED73
     call label_3B12
     ld   [hl], $08
     ld   a, $03
-    ld   [$FFF3], a
+    ldh  [$FFF3], a
     ret
 
 label_ED73::
@@ -5635,7 +5635,7 @@ label_ED73::
     or   [hl]
     jp   nz, label_EE0A
     ld   a, $03
-    ld   [$FFF3], a
+    ldh  [$FFF3], a
     ld   hl, $C4D0
     add  hl, bc
     ld   d, b
@@ -5678,19 +5678,19 @@ label_EDAB::
     ld   a, [$C1BE]
     and  a
     jr   nz, label_EDDF
-    ld   a, [$FFB0]
+    ldh  a, [$FFB0]
     cp   $22
     jr   z, label_EDDD
     ld   [$D368], a
 
 label_EDDD::
-    ld   [$FFBF], a
+    ldh  [$FFBF], a
 
 label_EDDF::
     call label_CB6
     ld   a, $10
     ld   [$C13E], a
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     ld   e, $18
     cp   $82
     jp   z, label_EFA7
@@ -5708,7 +5708,7 @@ label_EDFA::
 
 label_EE02::
     call label_F565
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     jr   nz, label_EE0E
 
@@ -5720,7 +5720,7 @@ data_EE0C::
     db $C, $F4
 
 label_EE0E::
-    ld   a, [$FF9C]
+    ldh  a, [$FF9C]
     cp   $02
     jr   z, label_EE0A
     call label_FED9
@@ -5728,11 +5728,11 @@ label_EE0E::
     ld   hl, data_EE0C
     add  hl, de
     ld   a, [hl]
-    ld   [$FF9A], a
+    ldh  [$FF9A], a
     ld   a, $F4
-    ld   [$FF9B], a
+    ldh  [$FF9B], a
     xor  a
-    ld   [$FF9C], a
+    ldh  [$FF9C], a
     scf
     ret
 
@@ -5825,19 +5825,19 @@ label_EE8E::
     and  a
     jp   nz, label_EFE8
     ld   a, [$C14A]
-    ld   [$FFE9], a
+    ldh  [$FFE9], a
     call label_CB6
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $E2
     jr   nz, label_EED1
     ld   a, [$DB44]
     cp   $02
     ret  nz
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     cp   $02
     ret  nz
     ld   a, $04
-    ld   [$FF9B], a
+    ldh  [$FF9B], a
     ld   a, $08
     ld   [$C13E], a
     jp   label_3B12
@@ -5845,7 +5845,7 @@ label_EE8E::
 label_EED1::
     cp   $55
     jr   nz, label_EEF7
-    ld   a, [$FFF0]
+    ldh  a, [$FFF0]
     cp   $02
     jp   nz, label_EF93
     ld   hl, $C240
@@ -5912,7 +5912,7 @@ label_EF2A::
     ld   [hl], $20
     call label_C05
     ld   [hl], $FF
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     ld   e, a
     ld   d, b
     ld   hl, data_EF65
@@ -5943,7 +5943,7 @@ data_EF67::
 
 data_EF69::
     db 0, 0
-    
+
 label_EF6B::
     ld   a, [$FF10]
 
@@ -5954,7 +5954,7 @@ label_EF6D::
     jr   nz, label_EF8E
 
 label_EF75::
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     and  $02
     jr   nz, label_EF81
     ld   hl, $C240
@@ -5980,11 +5980,11 @@ label_EF8E::
 
 label_EF93::
     ld   a, $09
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     call label_CB6
     ld   a, $0C
     ld   [$C13E], a
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $82
     jr   nz, label_EFB9
     ld   e, $10
@@ -6001,16 +6001,16 @@ label_EFA7::
     inc  a
 
 label_EFB3::
-    ld   [$FF9A], a
+    ldh  [$FF9A], a
     xor  a
-    ld   [$FF9B], a
+    ldh  [$FF9B], a
     ret
 
 label_EFB9::
     ld   a, $12
     call label_F565
     ld   hl, $FFE9
-    ld   a, [$FFCB]
+    ldh  a, [$FFCB]
     and  $0F
     ld   a, $08
     or   [hl]
@@ -6019,13 +6019,13 @@ label_EFB9::
 
 label_EFCC::
     call label_FE45
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     cpl
     inc  a
     ld   hl, $C400
     add  hl, bc
     ld   [hl], a
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     cpl
     inc  a
     ld   hl, $C3F0
@@ -6037,7 +6037,7 @@ data_EFE4::
     db 0, 1, 2, 3
 
 label_EFE8::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $E2
     ret  z
     cp   $E6
@@ -6066,12 +6066,12 @@ label_F007::
 
 label_F013::
     jp   label_3B12
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
 
 label_F018::
     cp   $B9
     jr   nz, label_F042
-    ld   a, [$FFEA]
+    ldh  a, [$FFEA]
     cp   $05
     jr   nz, label_F042
     call label_3B12
@@ -6085,22 +6085,22 @@ label_F018::
     ld   [$C16A], a
     ld   [$C121], a
     ld   a, $1C
-    ld   [$FFF4], a
+    ldh  [$FFF4], a
     jp   label_ECD5
 
 label_F042::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $55
     jr   nz, label_F06F
     ld   a, $30
     call label_FE45
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     cpl
     inc  a
     ld   hl, $C250
     add  hl, bc
     ld   [hl], a
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     cpl
     inc  a
     ld   hl, $C240
@@ -6125,7 +6125,7 @@ label_F06F::
 label_F07D::
     cp   $5B
     jr   nz, label_F0B9
-    ld   a, [$FFE8]
+    ldh  a, [$FFE8]
     and  a
     jr   nz, label_F0A9
     ld   hl, $C2B0
@@ -6164,7 +6164,7 @@ label_F0B9::
     ld   a, [hl]
     and  $40
     jr   z, label_F102
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $51
     jp   z, label_EF04
     cp   $5C
@@ -6203,7 +6203,7 @@ label_F0E7::
     jp   label_EDDF
 
 label_F102::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $8E
     jr   nz, label_F10D
     call label_CB6
@@ -6217,7 +6217,7 @@ label_F10D::
     ld   a, [hl]
     and  a
     jr   nz, label_F146
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     ld   e, a
     ld   d, b
     ld   hl, data_EFE4
@@ -6236,14 +6236,14 @@ label_F10D::
     call label_EFCC
 
 label_F13B::
-    ld   a, [$FFEE]
-    ld   [$FFD7], a
-    ld   a, [$FFEC]
-    ld   [$FFD8], a
+    ldh  a, [$FFEE]
+    ldh  [$FFD7], a
+    ldh  a, [$FFEC]
+    ldh  [$FFD8], a
     jp   label_D15
 
 label_F146::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $15
     jp   z, label_F3E6
 
@@ -6279,7 +6279,7 @@ label_F17A::
     add  hl, bc
     ld   [hl], $01
     ld   a, $11
-    ld   [$FFF3], a
+    ldh  [$FFF3], a
     ld   hl, $C280
     add  hl, bc
     ld   a, [hl]
@@ -6350,7 +6350,7 @@ label_F1C0::
     and  a
     ret  z
     push af
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $E6
     jr   nz, label_F215
     ld   a, [$D219]
@@ -6386,7 +6386,7 @@ label_F228::
     cp   $6C
     jr   nz, label_F235
     ld   a, $13
-    ld   [$FFF3], a
+    ldh  [$FFF3], a
 
 label_F235::
     pop  af
@@ -6460,14 +6460,14 @@ label_F29D::
     ld   hl, $C200
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   hl, $C210
     add  hl, bc
     ld   a, [hl]
     ld   hl, $C310
     add  hl, bc
     sub  a, [hl]
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     ld   a, $02
     jp   label_CC7
 
@@ -6550,14 +6550,14 @@ label_F325::
     jr   label_F33E
 
 label_F330::
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     push af
     ld   a, $10
-    ld   [$FF99], a
+    ldh  [$FF99], a
     ld   a, e
     call label_2385
     pop  af
-    ld   [$FF99], a
+    ldh  [$FF99], a
 
 label_F33E::
     call label_3B12
@@ -6694,7 +6694,7 @@ label_F3E7::
     jp   z, label_F4E1
     ld   hl, $C380
     add  hl, bc
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     cp   [hl]
     jp   z, label_F4E1
     ld   de, $FFEE
@@ -6748,13 +6748,13 @@ label_F440::
     call label_F565
     ld   a, $18
     call label_FE45
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     cpl
     inc  a
     ld   hl, $C400
     add  hl, bc
     ld   [hl], a
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     cpl
     inc  a
     ld   hl, $C3F0
@@ -6773,11 +6773,11 @@ label_F440::
     ld   [$C16D], a
 
 label_F48B::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $BE
     jr   nz, label_F4C1
     ld   a, $09
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     ld   a, [$D205]
     cp   $00
     jr   z, label_F4BF
@@ -6803,24 +6803,24 @@ label_F4BF::
     jr   label_F4DC
 
 label_F4C1::
-    ld   a, [$FF9E]
+    ldh  a, [$FF9E]
     ld   e, a
     ld   d, b
     ld   hl, data_F4E4
     add  hl, de
     ld   a, [$C140]
     add  a, [hl]
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   hl, data_F4E8
     add  hl, de
     ld   a, [$C142]
     add  a, [hl]
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     call label_D15
 
 label_F4DC::
     ld   a, $0C
-    ld   [$FFB6], a
+    ldh  [$FFB6], a
     ret
 
 label_F4E1::
@@ -6833,16 +6833,16 @@ data_F4E8::
     db $FC, $FC, $F0, 0
 
 label_F4EC::
-    ld   a, [$FFE7]
+    ldh  a, [$FFE7]
     xor  c
     rra
     jr   nc, label_F570
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     add  a, $08
-    ld   [$FFD7], a
-    ld   a, [$FF99]
+    ldh  [$FFD7], a
+    ldh  a, [$FF99]
     add  a, $08
-    ld   [$FFD9], a
+    ldh  [$FFD9], a
     ld   de, $FFEE
     ld   hl, $D5C0
     ld   a, [de]
@@ -6891,7 +6891,7 @@ label_F52D::
     and  a
     jr   nz, label_F570
     call label_ECD5
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $BE
     jr   nz, label_F570
     ld   a, [$D205]
@@ -6911,10 +6911,10 @@ label_F52D::
 
 label_F565::
     call label_FE45
-    ld   a, [$FFD7]
-    ld   [$FF9B], a
-    ld   a, [$FFD8]
-    ld   [$FF9A], a
+    ldh  a, [$FFD7]
+    ldh  [$FF9B], a
+    ldh  a, [$FFD8]
+    ldh  [$FF9A], a
 
 label_F570::
     ret
@@ -6936,13 +6936,13 @@ label_F571::
     ld   a, $D0
 
 label_F58B::
-    ld   [$FF9A], a
+    ldh  [$FF9A], a
     xor  a
-    ld   [$FF9B], a
+    ldh  [$FF9B], a
     ld   a, $30
-    ld   [$FFA3], a
+    ldh  [$FFA3], a
     ld   a, $0B
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     ret
     ld   a, $20
     ld   [$C13E], a
@@ -6957,7 +6957,7 @@ label_F5A6::
     ld   a, e
     cp   c
     jp   z, label_F79F
-    ld   a, [$FFE7]
+    ldh  a, [$FFE7]
     xor  e
     and  $01
     jp   nz, label_F79F
@@ -6973,7 +6973,7 @@ label_F5A6::
     jp   nz, label_F79F
     ld   hl, $C200
     add  hl, de
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     sub  a, [hl]
     add  a, $0C
     cp   $18
@@ -6994,7 +6994,7 @@ label_F5A6::
     ld   a, [hl]
     cp   $FF
     jp   z, label_F79F
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $55
     jr   nz, label_F5FE
     call label_C05
@@ -7035,7 +7035,7 @@ label_F630::
     ld   a, [hl]
     and  $20
     jp   nz, label_F715
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $08
     jr   z, label_F668
     ld   hl, $C3A0
@@ -7046,7 +7046,7 @@ label_F630::
     ld   a, [$D219]
     cp   $05
     jr   nz, label_F656
-    ld   a, [$FFF1]
+    ldh  a, [$FFF1]
     cp   $02
     jr   nz, label_F65F
 
@@ -7064,7 +7064,7 @@ label_F65F::
     jp   label_F737
 
 label_F668::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $08
     jr   nz, label_F6AC
     ld   hl, $C3A0
@@ -7132,7 +7132,7 @@ label_F6AC::
     ld   a, [hl]
     and  a
     jr   nz, label_F710
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $03
     jp   nz, label_F65F
     ld   [hl], $01
@@ -7140,11 +7140,11 @@ label_F6AC::
     ld   a, $32
     call label_E4CA
     jr   c, label_F70D
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     ld   hl, $C200
     add  hl, de
     ld   [hl], a
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     ld   hl, $C210
     add  hl, de
     ld   [hl], a
@@ -7153,7 +7153,7 @@ label_F6AC::
     ld   a, c
     inc  a
     ld   [hl], a
-    ld   a, [$FFD9]
+    ldh  a, [$FFD9]
     and  $01
     ld   hl, $C3B0
     add  hl, de
@@ -7168,7 +7168,7 @@ label_F710::
     jr   label_F737
 
 label_F715::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $01
     jr   z, label_F71F
     cp   $03
@@ -7193,7 +7193,7 @@ label_F734::
     jp   label_F79F
 
 label_F737::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $A8
     jr   z, label_F75A
     cp   $01
@@ -7246,10 +7246,10 @@ label_F782::
     ld   a, [hl]
     and  a
     jr   nz, label_F79A
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $00
     jr   nz, label_F795
-    ld   a, [$FFF0]
+    ldh  a, [$FFF0]
     and  a
     jr   nz, label_F798
 
@@ -7272,10 +7272,10 @@ label_F79F::
     ret
 
 label_F7A7::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $00
     jr   nz, label_F7B8
-    ld   a, [$FFF0]
+    ldh  a, [$FFF0]
     and  a
     jr   z, label_F7B8
     call label_C05
@@ -7329,7 +7329,7 @@ label_F7DD::
     jr   nz, label_F834
     ld   hl, $C200
     add  hl, de
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     sub  a, [hl]
     add  a, $18
     cp   $30
@@ -7352,11 +7352,11 @@ label_F7DD::
     call label_F83B
     ld   hl, $C400
     add  hl, de
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     ld   [hl], a
     ld   hl, $C3F0
     add  hl, de
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     ld   [hl], a
 
 label_F834::
@@ -7367,27 +7367,27 @@ label_F834::
     ret
 
 label_F83B::
-    ld   [$FFD7], a
-    ld   a, [$FF98]
+    ldh  [$FFD7], a
+    ldh  a, [$FF98]
     push af
     ld   hl, $C200
     add  hl, de
     ld   a, [hl]
-    ld   [$FF98], a
-    ld   a, [$FF99]
+    ldh  [$FF98], a
+    ldh  a, [$FF99]
     push af
     ld   hl, $C210
     add  hl, de
     ld   a, [hl]
-    ld   [$FF99], a
+    ldh  [$FF99], a
     push de
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     call label_FE45
     pop  de
     pop  af
-    ld   [$FF99], a
+    ldh  [$FF99], a
     pop  af
-    ld   [$FF98], a
+    ldh  [$FF98], a
     ret
 
 data_F85F::
@@ -7409,10 +7409,10 @@ label_F893::
     ld   hl, $C470
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     xor  a
     ld   [hl], a
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     ld   [$C503], a
     ld   [$C50D], a
     ld   hl, $C310
@@ -7437,7 +7437,7 @@ label_F8B1::
 
 label_F8C5::
     ld   e, $02
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $CC
     jr   z, label_F907
     cp   $A0
@@ -7453,10 +7453,10 @@ label_F8C5::
 
 label_F8E3::
     ld   e, $01
-    ld   a, [$FFAF]
+    ldh  a, [$FFAF]
     cp   $67
     jr   z, label_F907
-    ld   a, [$FFDA]
+    ldh  a, [$FFDA]
     and  a
     jp   z, label_FA18
     cp   $0B
@@ -7485,16 +7485,16 @@ label_F90C::
     jr   z, label_F973
     ld   hl, $C470
     add  hl, bc
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     cp   [hl]
     jr   z, label_F973
     ld   a, [hl]
     cp   $03
     jr   z, label_F973
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     cp   $03
     jr   z, label_F973
-    ld   a, [$FFF9]
+    ldh  a, [$FFF9]
     and  a
     jr   nz, label_F93D
     ld   hl, $C320
@@ -7507,7 +7507,7 @@ label_F90C::
     jr   label_F954
 
 label_F93D::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $AC
     jr   z, label_F954
     ld   hl, $C250
@@ -7531,25 +7531,25 @@ label_F95C::
     ld   hl, $C200
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   hl, $C210
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     ld   a, $0E
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
     ld   a, $01
     call label_CC7
 
 label_F973::
-    ld   a, [$FFDA]
+    ldh  a, [$FFDA]
     inc  a
     cp   $F1
     jr   c, label_F99C
     sub  a, $F1
     ld   e, a
     ld   d, b
-    ld   a, [$FFE7]
+    ldh  a, [$FFE7]
     and  $03
     jr   nz, label_F99A
     ld   hl, data_F883
@@ -7571,17 +7571,17 @@ label_F99A::
     jr   label_FA18
 
 label_F99C::
-    ld   a, [$FFAF]
+    ldh  a, [$FFAF]
     cp   $61
     jr   z, label_F9AC
-    ld   a, [$FFDA]
+    ldh  a, [$FFDA]
     cp   $50
     jr   z, label_F9AC
     cp   $51
     jr   nz, label_FA18
 
 label_F9AC::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $6D
     jr   z, label_FA18
     cp   $D5
@@ -7593,7 +7593,7 @@ label_F9AC::
     ld   a, [$C11C]
     cp   $06
     jr   nz, label_FA18
-    ld   a, [$FFAF]
+    ldh  a, [$FFAF]
     cp   $61
     jr   nz, label_FA18
 
@@ -7610,19 +7610,19 @@ label_F9CB::
     ld   hl, $C280
     add  hl, bc
     ld   [hl], $02
-    ld   a, [$FFCE]
+    ldh  a, [$FFCE]
     add  a, $08
     ld   hl, $C4B0
     add  hl, bc
     ld   [hl], a
-    ld   a, [$FFCD]
+    ldh  a, [$FFCD]
     add  a, $10
     ld   hl, $C4C0
     add  hl, bc
     ld   [hl], a
     call label_C05
     ld   [hl], $6F
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $14
     jr   z, label_FA18
     cp   $0B
@@ -7638,10 +7638,10 @@ label_F9CB::
     call label_C05
     ld   [hl], $2F
     ld   a, $18
-    ld   [$FFF2], a
+    ldh  [$FFF2], a
 
 label_FA18::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $6D
     jp   z, label_FA84
     xor  a
@@ -7652,7 +7652,7 @@ label_FA18::
     and  $03
     sla  a
     sla  a
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   hl, $C2A0
     add  hl, bc
     xor  a
@@ -7670,14 +7670,14 @@ label_FA18::
 label_FA47::
     call label_FACD
     jr   c, label_FA5D
-    ld   a, [$FFAF]
+    ldh  a, [$FFAF]
     ld   [$C503], a
-    ld   a, [$FFBE]
+    ldh  a, [$FFBE]
     and  a
     jr   nz, label_FA5D
     ld   hl, $C200
     add  hl, bc
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     ld   [hl], a
 
 label_FA5D::
@@ -7694,14 +7694,14 @@ label_FA5D::
 label_FA6E::
     call label_FACD
     jr   c, label_FA84
-    ld   a, [$FFAF]
+    ldh  a, [$FFAF]
     ld   [$C50D], a
-    ld   a, [$FFBE]
+    ldh  a, [$FFBE]
     and  a
     jr   nz, label_FA84
     ld   hl, $C210
     add  hl, bc
-    ld   a, [$FFEF]
+    ldh  a, [$FFEF]
     ld   [hl], a
 
 label_FA84::
@@ -7721,23 +7721,23 @@ label_FACD::
     ld   a, [hl]
     sub  a, $08
     push af
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     ld   c, a
     pop  af
     ld   hl, data_F85F
     add  hl, bc
     add  hl, de
     add  a, [hl]
-    ld   [$FFDB], a
+    ldh  [$FFDB], a
     swap a
     and  $0F
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     pop  bc
     push bc
     ld   a, e
     cp   $03
     jr   nz, label_FB0E
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $A8
     jr   z, label_FAF9
     cp   $05
@@ -7767,14 +7767,14 @@ label_FB0E::
 label_FB13::
     sub  a, $10
     push af
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     ld   c, a
     pop  af
     ld   hl, data_F86F
     add  hl, bc
     add  hl, de
     add  a, [hl]
-    ld   [$FFDC], a
+    ldh  [$FFDC], a
     and  $F0
     ld   hl, $FFD8
     or   [hl]
@@ -7785,7 +7785,7 @@ label_FB13::
     ld   h, a
     pop  bc
     ld   a, [hl]
-    ld   [$FFAF], a
+    ldh  [$FFAF], a
     cp   $20
     jp   z, label_FC7B
     push de
@@ -7794,15 +7794,15 @@ label_FB13::
     ld   d, a
     call label_2A2C
     pop  de
-    ld   [$FFDA], a
-    ld   a, [$FFEB]
+    ldh  [$FFDA], a
+    ldh  a, [$FFEB]
     cp   $CC
     jr   z, label_FB4E
     cp   $99
     jr   nz, label_FB5D
 
 label_FB4E::
-    ld   a, [$FFDA]
+    ldh  a, [$FFDA]
     cp   $05
     jp   z, label_FCA7
     cp   $07
@@ -7810,7 +7810,7 @@ label_FB4E::
     jp   label_FC75
 
 label_FB5D::
-    ld   a, [$FFDA]
+    ldh  a, [$FFDA]
     and  a
     jp   z, label_FCA7
     cp   $0B
@@ -7831,7 +7831,7 @@ label_FB6F::
     ld   a, [hl]
     and  a
     jp   z, label_FC75
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $59
     jp   z, label_FC75
     jp   label_FCA7
@@ -7842,7 +7842,7 @@ label_FB8B::
     cp   $90
     jp   nc, label_FBE4
     cp   $80
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     jr   c, label_FBA7
     cp   $A8
     jp   z, label_FCA7
@@ -7863,7 +7863,7 @@ label_FBA7::
 
 label_FBBB::
     push de
-    ld   a, [$FFDA]
+    ldh  a, [$FFDA]
     sub  a, $7C
     sla  a
     sla  a
@@ -7871,13 +7871,13 @@ label_FBBB::
     ld   d, $00
     ld   hl, data_FA85
     add  hl, de
-    ld   a, [$FFDB]
+    ldh  a, [$FFDB]
     rra
     rra
     rra
     and  $01
     ld   e, a
-    ld   a, [$FFDC]
+    ldh  a, [$FFDC]
     rra
     rra
     and  $02
@@ -7891,7 +7891,7 @@ label_FBBB::
     jp   z, label_FCA7
 
 label_FBE4::
-    ld   a, [$FFDA]
+    ldh  a, [$FFDA]
     cp   $D0
     jr   c, label_FC2B
     cp   $D4
@@ -7901,7 +7901,7 @@ label_FBE4::
     add  hl, bc
     cp   [hl]
     jr   z, label_FC1A
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $A8
     jr   z, label_FC75
     ld   hl, $C4F0
@@ -7909,13 +7909,13 @@ label_FBE4::
     ld   a, [hl]
     and  a
     jr   z, label_FC75
-    ld   a, [$FFE7]
+    ldh  a, [$FFE7]
     and  $03
     jr   z, label_FC28
     ld   a, [$DBA5]
     and  a
     jr   nz, label_FC17
-    ld   a, [$FFE7]
+    ldh  a, [$FFE7]
     and  $01
     jr   z, label_FC28
 
@@ -7949,7 +7949,7 @@ label_FC2B::
     jr   z, label_FC91
     cp   $04
     jr   nz, label_FCA7
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $A8
     jp   z, label_FCA7
     cp   $02
@@ -7961,7 +7961,7 @@ label_FC2B::
     jp   nz, label_FCA7
 
 label_FC5A::
-    ld   a, [$FFAF]
+    ldh  a, [$FFAF]
     cp   $DB
     jr   c, label_FC9A
     cp   $DD
@@ -7978,12 +7978,12 @@ label_FC5A::
     jr   z, label_FCA7
 
 label_FC75::
-    ld   a, [$FFDA]
+    ldh  a, [$FFDA]
     cp   $60
     jr   nz, label_FC91
 
 label_FC7B::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $03
     jr   nz, label_FC91
     call label_C05
@@ -8027,21 +8027,21 @@ label_FCAB::
     ld   hl, $C200
     add  hl, bc
     ld   a, [hl]
-    ld   [$FFDB], a
+    ldh  [$FFDB], a
     and  $F0
-    ld   [$FFCE], a
+    ldh  [$FFCE], a
     swap a
     ld   hl, $C210
     add  hl, bc
     ld   c, a
     ld   a, [hl]
     sub  a, $08
-    ld   [$FFDC], a
+    ldh  [$FFDC], a
     and  $F0
-    ld   [$FFCD], a
+    ldh  [$FFCD], a
     or   c
     ld   c, a
-    ld   [$FFE9], a
+    ldh  [$FFE9], a
     ld   b, $00
     ld   hl, $D711
     ld   a, h
@@ -8049,12 +8049,12 @@ label_FCAB::
     ld   h, a
     pop  bc
     ld   a, [hl]
-    ld   [$FFAF], a
+    ldh  [$FFAF], a
     cp   $AC
     jp   z, label_FE03
     cp   $AB
     jp   nz, label_FD6B
-    ld   a, [$FFFE]
+    ldh  a, [$FFFE]
     and  a
     jr   z, label_FCFD
     ld   a, [$C11C]
@@ -8068,7 +8068,7 @@ label_FCAB::
     jp   nz, label_FE03
 
 label_FCFD::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $04
     jr   nz, label_FD6B
     ld   a, [$DBA5]
@@ -8076,7 +8076,7 @@ label_FCFD::
     jr   z, label_FD6B
     push hl
     ld   a, $12
-    ld   [$FFF4], a
+    ldh  [$FFF4], a
     ld   a, $08
     call label_E4CA
     jr   c, label_FD6A
@@ -8095,11 +8095,11 @@ label_FCFD::
     ld   hl, $C2C0
     add  hl, bc
     ld   [hl], e
-    ld   a, [$FFCE]
+    ldh  a, [$FFCE]
     ld   hl, $C200
     add  hl, bc
     ld   [hl], a
-    ld   a, [$FFCD]
+    ldh  a, [$FFCD]
     ld   hl, $C210
     add  hl, bc
     ld   [hl], a
@@ -8116,7 +8116,7 @@ label_FCFD::
     jr   z, label_FD63
     sub  a, $04
     ld   [$C3CD], a
-    ld   a, [$FFFE]
+    ldh  a, [$FFFE]
     and  a
     jr   z, label_FD63
     ld   a, $40
@@ -8138,10 +8138,10 @@ label_FD6B::
     ld   a, [$DBA5]
     ld   d, a
     call label_2A2C
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     and  a
     jp   z, label_FE03
-    ld   [$FFDA], a
+    ldh  [$FFDA], a
     cp   $FF
     jp   z, label_FE05
     cp   $D0
@@ -8158,13 +8158,13 @@ label_FD6B::
     ld   a, [hl]
     and  a
     jr   z, label_FDE3
-    ld   a, [$FFE7]
+    ldh  a, [$FFE7]
     and  $03
     jr   z, label_FE03
     ld   a, [$DBA5]
     and  a
     jr   nz, label_FDAC
-    ld   a, [$FFE7]
+    ldh  a, [$FFE7]
     and  $01
     jr   z, label_FE03
 
@@ -8191,7 +8191,7 @@ label_FDC0::
     jp   label_FE03
 
 label_FDCD::
-    ld   a, [$FFDA]
+    ldh  a, [$FFDA]
     cp   $A0
     jr   nc, label_FE03
     cp   $50
@@ -8207,7 +8207,7 @@ label_FDE3::
     ld   hl, $C2A0
     add  hl, bc
     ld   [hl], $01
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $01
     jr   nz, label_FDF3
     call label_C05
@@ -8216,11 +8216,11 @@ label_FDE3::
 label_FDF3::
     ld   hl, $C200
     add  hl, bc
-    ld   a, [$FFEE]
+    ldh  a, [$FFEE]
     ld   [hl], a
     ld   hl, $C210
     add  hl, bc
-    ld   a, [$FFEF]
+    ldh  a, [$FFEF]
     ld   [hl], a
     scf
     ret
@@ -8230,7 +8230,7 @@ label_FE03::
     ret
 
 label_FE05::
-    ld   a, [$FFEB]
+    ldh  a, [$FFEB]
     cp   $01
 
 label_FE09::
@@ -8243,18 +8243,18 @@ label_FE0E::
     add  hl, bc
     ld   a, [hl]
     sub  a, $01
-    ld   [$FFDB], a
+    ldh  [$FFDB], a
     and  $F0
-    ld   [$FFCE], a
+    ldh  [$FFCE], a
     swap a
     ld   hl, $C210
     add  hl, bc
     ld   c, a
     ld   a, [hl]
     sub  a, $07
-    ld   [$FFDC], a
+    ldh  [$FFDC], a
     and  $F0
-    ld   [$FFCD], a
+    ldh  [$FFCD], a
     or   c
     ld   c, a
     ld   b, $00
@@ -8264,23 +8264,23 @@ label_FE0E::
     ld   h, a
     pop  bc
     ld   a, [hl]
-    ld   [$FFAF], a
+    ldh  [$FFAF], a
     ld   e, a
     ld   a, [$DBA5]
     ld   d, a
     call label_2A2C
-    ld   [$FFDA], a
+    ldh  [$FFDA], a
     ret
 
 label_FE45::
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     and  a
     jp   z, label_FEC3
     call label_FEE9
     dec  e
     dec  e
     ld   a, e
-    ld   [$FFD9], a
+    ldh  [$FFD9], a
     ld   a, d
     bit  7, a
     jr   z, label_FE5A
@@ -8288,10 +8288,10 @@ label_FE45::
     inc  a
 
 label_FE5A::
-    ld   [$FFE3], a
+    ldh  [$FFE3], a
     call label_FED9
     ld   a, e
-    ld   [$FFDA], a
+    ldh  [$FFDA], a
     ld   a, d
     bit  7, a
     jr   z, label_FE69
@@ -8299,28 +8299,28 @@ label_FE5A::
     inc  a
 
 label_FE69::
-    ld   [$FFE4], a
+    ldh  [$FFE4], a
     ld   e, $00
     ld   hl, $FFE3
-    ld   a, [$FFE4]
+    ldh  a, [$FFE4]
     cp   [hl]
     jr   nc, label_FE7E
     inc  e
     push af
-    ld   a, [$FFE3]
-    ld   [$FFE4], a
+    ldh  a, [$FFE3]
+    ldh  [$FFE4], a
     pop  af
-    ld   [$FFE3], a
+    ldh  [$FFE3], a
 
 label_FE7E::
     xor  a
-    ld   [$FFE2], a
-    ld   [$FFD7], a
-    ld   a, [$FFD8]
+    ldh  [$FFE2], a
+    ldh  [$FFD7], a
+    ldh  a, [$FFD8]
     ld   d, a
 
 label_FE86::
-    ld   a, [$FFE2]
+    ldh  a, [$FFE2]
     ld   hl, $FFE3
     add  a, [hl]
     jr   c, label_FE94
@@ -8334,52 +8334,52 @@ label_FE94::
     inc  [hl]
 
 label_FE99::
-    ld   [$FFE2], a
+    ldh  [$FFE2], a
     dec  d
     jr   nz, label_FE86
     ld   a, e
     and  a
     jr   z, label_FEAC
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     push af
-    ld   a, [$FFD8]
-    ld   [$FFD7], a
+    ldh  a, [$FFD8]
+    ldh  [$FFD7], a
     pop  af
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
 
 label_FEAC::
-    ld   a, [$FFD9]
+    ldh  a, [$FFD9]
     and  a
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     jr   nz, label_FEB7
     cpl
     inc  a
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
 
 label_FEB7::
-    ld   a, [$FFDA]
+    ldh  a, [$FFDA]
     and  a
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     jr   z, label_FEC2
     cpl
     inc  a
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
 
 label_FEC2::
     ret
 
 label_FEC3::
     xor  a
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ret
 
 label_FEC7::
     call label_FE45
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     ld   hl, $C250
     add  hl, bc
     ld   [hl], a
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
     ld   hl, $C240
     add  hl, bc
     ld   [hl], a
@@ -8387,7 +8387,7 @@ label_FEC7::
 
 label_FED9::
     ld   e, $00
-    ld   a, [$FF98]
+    ldh  a, [$FF98]
     ld   hl, $C200
     add  hl, bc
     sub  a, [hl]
@@ -8401,7 +8401,7 @@ label_FEE7::
 
 label_FEE9::
     ld   e, $02
-    ld   a, [$FF99]
+    ldh  a, [$FF99]
     ld   hl, $C210
     add  hl, bc
     sub  a, [hl]
@@ -8419,7 +8419,7 @@ label_FEFC::
 label_FEFE::
     call label_FED9
     ld   a, e
-    ld   [$FFD7], a
+    ldh  [$FFD7], a
     ld   a, d
     bit  7, a
     jr   z, label_FF0B
@@ -8430,7 +8430,7 @@ label_FF0B::
     push af
     call label_FEE9
     ld   a, e
-    ld   [$FFD8], a
+    ldh  [$FFD8], a
     ld   a, d
     bit  7, a
     jr   z, label_FF19
@@ -8441,11 +8441,11 @@ label_FF19::
     pop  de
     cp   d
     jr   nc, label_FF21
-    ld   a, [$FFD7]
+    ldh  a, [$FFD7]
     jr   label_FF23
 
 label_FF21::
-    ld   a, [$FFD8]
+    ldh  a, [$FFD8]
 
 label_FF23::
     ld   e, a
@@ -8514,7 +8514,7 @@ label_FF5E::
     jr   label_FF4A
 
 label_FF78::
-    ld   a, [$FFEA]
+    ldh  a, [$FFEA]
     cp   $05
     jr   nz, label_FFA7
 

--- a/src/code/header.asm
+++ b/src/code/header.asm
@@ -22,8 +22,8 @@ Copy48BytesAndClearFlags::
     ld   bc, $0030
     call CopyData
     xor  a
-    ld   [$FF90], a
-    ld   [$FF92], a
+    ldh  [$FF90], a
+    ldh  [$FF92], a
     ld   a, $0C
     ld   [$2100], a
     ret

--- a/src/constants/gbhw.asm
+++ b/src/constants/gbhw.asm
@@ -1,6 +1,8 @@
 ; Constants for GameBoy hardware
 ; Graciously aped from http://nocash.emubase.de/pandocs.htm.
 
+GBC EQU $11
+
 ; MBC3
 MBC3SRamEnable EQU $0000
 MBC3RomBank    EQU $2000

--- a/src/constants/hram.asm
+++ b/src/constants/hram.asm
@@ -1,23 +1,96 @@
+section "HRAM", HRAM
 
-hRomBank                    equ $FF80
-hTemp                       equ $FF81
-hCodeTemp                   equ $FF82
-hNeedsUpdatingBGTiles       equ $FF90
-hNeedsUpdatingEnnemiesTiles equ $FF91
-hBaseScrollX                equ $FF96
-hBaseScrollY                equ $FF97
-hLinkPositionX              equ $FF98
-hLinkPositionY              equ $FF99
-hLinkAnimationState         equ $FF9D
+hRomBank:: ; FF80
+ ds 1
 
-hButtonsInactiveDelay       equ $FFB5 ; Number of frames during which joypad is ignored
-hPressedButtonsMask         equ $FFCB
-;unknow                         $FFCC ; joypad-related?
-hNeedsRenderingFrame        equ $FFD1
-hFrameCounter               equ $FFE7 ; wraps around 00-FF
-;hSpriteYOffset?            equ $FFEC 
-;hSpriteXOffset?            equ $FFEE
-hMapIndex                   equ $FFF6 ; currently loaded map
-hMapTileset                 equ $FFF7 ; tileset index for the current map
-hDidRenderFrame             equ $FFFD
-hIsGBC                      equ $FFFE ; 0 = GB, 1 = GBC
+hTemp:: ; FF81
+ ds 1
+
+hCodeTemp:: ; FF82
+ ds 1
+
+; Unlabeled
+hFF83:: ; FF83
+ ds $D
+
+hNeedsUpdatingBGTiles:: ; FF90
+ ds 1
+
+hNeedsUpdatingEnnemiesTiles:: ; FF91
+ ds 1
+
+; Unlabeled
+hFF92:: ; hFF92
+  ds 4
+
+hBaseScrollX:: ; FF96
+ ds 1
+
+hBaseScrollY:: ; FF97
+ ds 1
+
+hLinkPositionX:: ; FF98
+ ds 1
+
+hLinkPositionY:: ; FF99
+ ds 1
+
+; Unlabeled
+hFF9A:: ; hFF9A
+  ds 3
+
+hLinkAnimationState:: ; FF9D
+ ds 1
+
+; Unlabeled
+hFF9E:: ; hFF9E
+  ds $17
+
+hButtonsInactiveDelay:: ; FFB5
+  ; Number of frames during which joypad is ignored
+  ds 1
+
+; Unlabeled
+hFFB6:: ; hFFB6
+  ds $15
+
+hPressedButtonsMask:: ; FFCB
+ ds 1
+
+; Unlabeled
+hFFCC:: ; hFFCC
+  ds $5
+
+hNeedsRenderingFrame:: ; FFD1
+ ds 1
+
+; Unlabeled
+hFFD2:: ; hFFD2
+  ds $15
+
+hFrameCounter:: ; FFE7
+  ; wraps around 00-FF
+  ds 1
+
+; Unlabeled
+hFFE8:: ; hFFE8
+  ds $E
+
+hMapIndex:: ; FFF6
+  ; currently loaded map
+  ds 1
+
+hMapTileset:: ; FFF7
+  ; tileset index for the current map
+  ds 1
+
+; Unlabeled
+hFFF8:: ; hFFF8
+  ds $5
+
+hDidRenderFrame:: ; FFFD
+ ds 1
+
+hIsGBC:: ; FFFE
+  ; 0 = GB, 1 = GBC
+  ds 1


### PR DESCRIPTION
This allow the HRAM constants to be exported into the debug symbols.

The High-RAM, or addresses located between `$FF80` and `$FFFF`, can be accessed faster using special shorter opcodes.

However, if we want HRAM constants to be exported into the debug symbols, we need to turn them from constants into labels. For this, we need to define a custom `section` in the assembly code, to tell the linker where our symbols have to be exported in the final binary. And if we use a custom `section`, we hit a **know limitation of the `rgbds` toolchain**: 

> If you use this method of allocating HRAM, the assembler will NOT choose the short addressing mode in the LD instructions `LD [$FF00+n8],A` and `LD A,[$FF00+n8]` because the actual address calculation is done by the linker.
> 
> If you find this undesirable you can use the `LDH [$FF00+n8],A` and `LDH A,[$FF00+n8]` syntax instead. This forces the assembler to emit the correct instruction and the linker to check if the value is in the correct range.

_(From the [RGBDS documentation](https://rednex.github.io/rgbds/rgbasm.5.html))_

This means we have to **convert every load instruction referencing HRAM variables from `ld` instructions to `ldh` instructions**. Fortunately this is easily done with a simple regular expression, which is what this PR does.