### PR TITLE
Label clear-memory functions

### DIFF
--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -6528,53 +6528,7 @@ UpdateNextBGColumnWithTiles::
     jr   nz, UpdateNextBGColumnWithTiles
     ret
 
-; Clear $1600 bytes of WRAM (from $C000 to $D600)
-ClearLowerAndMiddleWRAM::
-    ld   bc, $1600
-    jr   ClearWRAMBytes
-
-; Clear $1300 bytes of WRAM (from $C000 to $D300)
-ClearLowerWRAM::
-    ld   bc, $1300
-    jr   ClearWRAMBytes
-
-; Clear lower values of HRAM (from $FF90 to $FFBF) and all WRAM
-ClearWRAMAndLowerHRAM::
-    ld   bc, $002F
-    jr   ClearHRAMBytesAndWRAM
-
-; Clear all values from HRAM and WRAM
-; (only `hIsGBC` is kept)
-ClearHRAMAndWRAM::
-    ; Set all bytes of HRAM (from $FF90 to $FFFD) to zero
-    ld   bc, $006D
-
-ClearHRAMBytesAndWRAM
-    ; Set BC bytes of HRAM (starting from $FF90) to zero
-    ld   hl, hGameValuesSection
-    call ClearBytes
-    ; Set all bytes of WRAM (from $C000 to $DF00) to zero
-    ld   bc, $1F00
-
-; Set BC bytes of WRAM (starting from $C000) to zero
-ClearWRAMBytes::
-    ld   hl, wram0Section
-
-; Set BC bytes of memory starting from HL to zero
-ClearBytes::
-    ldh  a, [hIsGBC]
-    push af
-
-.ClearBytes_loop
-    xor  a
-    ldi  [hl], a
-    dec  bc
-    ld   a, b
-    or   c
-    jr   nz, .ClearBytes_loop
-    pop  af
-    ldh  [hIsGBC], a
-    ret
+include "src/code/home/clear_memory.asm"
 
 label_29ED::
     ld   a, $14

--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -142,7 +142,7 @@ label_40D5::
 label_40F9::
     call label_27F2
     call label_5DE6
-    call label_29CB
+    call ClearWRAMAndLowerHRAM
     xor  a
     ldh  [$FFF5], a
     ld   a, $01
@@ -671,7 +671,7 @@ label_4425::
     ret
 
 label_442B::
-    call label_29C6
+    call ClearLowerWRAM
     xor  a
     ld   [$C11C], a
     call IncrementGameplaySubtype
@@ -6928,7 +6928,7 @@ IntroSceneJumpTable::
 ._D dw $7448
 
 label_6EF8::
-    call label_29C1
+    call ClearLowerAndMiddleWRAM
     call label_27F2
     ld   a, $01
     call label_8FA

--- a/src/code/home/clear_memory.asm
+++ b/src/code/home/clear_memory.asm
@@ -1,0 +1,51 @@
+;
+; Memory-clearing functions
+;
+
+; Clear $1600 bytes of WRAM (from $C000 to $D600)
+ClearLowerAndMiddleWRAM::
+    ld   bc, $1600
+    jr   ClearWRAMBytes
+
+; Clear $1300 bytes of WRAM (from $C000 to $D300)
+ClearLowerWRAM::
+    ld   bc, $1300
+    jr   ClearWRAMBytes
+
+; Clear lower values of HRAM (from $FF90 to $FFBF) and all WRAM
+ClearWRAMAndLowerHRAM::
+    ld   bc, $002F
+    jr   ClearHRAMBytesAndWRAM
+
+; Clear all values from HRAM and WRAM
+; (only `hIsGBC` is kept)
+ClearHRAMAndWRAM::
+    ; Set all bytes of HRAM (from $FF90 to $FFFD) to zero
+    ld   bc, $006D
+
+ClearHRAMBytesAndWRAM
+    ; Set BC bytes of HRAM (starting from $FF90) to zero
+    ld   hl, hGameValuesSection
+    call ClearBytes
+    ; Set all bytes of WRAM (from $C000 to $DF00) to zero
+    ld   bc, $1F00
+
+; Set BC bytes of WRAM (starting from $C000) to zero
+ClearWRAMBytes::
+    ld   hl, wram0Section
+
+; Set BC bytes of memory starting from HL to zero
+ClearBytes::
+    ldh  a, [hIsGBC]
+    push af
+
+.loop
+    xor  a
+    ldi  [hl], a
+    dec  bc
+    ld   a, b
+    or   c
+    jr   nz, .loop
+    pop  af
+    ldh  [hIsGBC], a
+    ret

--- a/src/constants/hram.asm
+++ b/src/constants/hram.asm
@@ -13,6 +13,9 @@ hCodeTemp:: ; FF82
 hFF83:: ; FF83
  ds $D
 
+; Beginning of the game-variables section of the HRAM
+hGameValuesSection EQU $FF90
+
 hNeedsUpdatingBGTiles:: ; FF90
  ds 1
 

--- a/src/constants/wram.asm
+++ b/src/constants/wram.asm
@@ -1,6 +1,9 @@
 section "WRAM Bank0", wram0
 
-wC000 equ $C000
+wram0Section EQU $C000
+
+; Unlabeled
+wC000 EQU $C000
   ds $100
 
 wScrollXOffsetForSection:: ; C100


### PR DESCRIPTION
- Label more memory-clearing functions
- Rename functions from `ZeroMemory`, `ZeroWRAM` to `ClearBytes`, `ClearWRAMBytes`
- Move the functions to their own file