### PR TITLE
Export all labels to debug symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 # If your default python is 3, you may want to change this to python27.
 PYTHON := python
 2BPP   := $(PYTHON) tools/gfx.py 2bpp
+ASM    := rgbasm -E
 
 .SUFFIXES: .asm .o .gbc .png .2bpp
 
@@ -39,7 +40,7 @@ gfx_files = $(shell find src/gfx -type f -name '*.png')
 src/main.o: $(asm_files) $(gfx_files:.png=.2bpp) bin/banks/bank_00_0.bin
 
 .asm.o:
-	rgbasm -i src/ -o $@ $<
+	$(ASM) -i src/ -o $@ $<
 
 # Then we link them to create a playable image.
 # This also spits out game.sym, which lets you use labels in bgb.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ MD5 - 07C211479386825042EFB4AD31BB525F
 
 ## Usage
 
-1. Install [rbgds](https://github.com/rednex/rgbds#1-installing-rgbds).
+1. Install [rbgds](https://github.com/rednex/rgbds#1-installing-rgbds) (version >= 0.2.5 required).
 2. `make all`
 
 ## Overview
@@ -35,7 +35,7 @@ Here is how to use BGB for reverse-engineering the game:
 1. Compile the game (`make all`).
 
     It produces `game.gbc` (a compiled rom identical to the original) and more importantly `game.map`, the debug symbols.
-  
+
 2. Open `game.gbc` in the [BGB emulator](http://bgb.bircd.org/).
 3. Open the debugger, and jump to the `0000:0150` address. You'll see a function named `Start`. Notice how BGB knows the name of this function from the debug symbols.
 4. You can now trace the execution of the code, set breakpoints, watchers, edit the memory, etc.

--- a/src/code/bank0.asm
+++ b/src/code/bank0.asm
@@ -576,7 +576,7 @@ LoadMapData::
     ;   09  $2E73
     ;   ...
     call label_4657
-    jp   [hl]
+    jp   hl
 
     ;
     ; $D6FE == 0: common case
@@ -1797,7 +1797,7 @@ label_BE7::
     ld   h, a
     ld   a, [$DE03]
     ld   l, a
-    jp   [hl]
+    jp   hl
     ld   a, $02
     ld   [MBC3SelectBank], a
     call label_1A50
@@ -6374,7 +6374,7 @@ TableJump::
     ld   d, [hl] ; Load the high byte of the target address
     ld   l, e
     ld   h, d
-    jp   [hl]    ; Jump to the target address
+    jp   hl    ; Jump to the target address
 
 ; Turn off LCD at next vertical blanking
 LCDOff::
@@ -9025,7 +9025,7 @@ label_3A8D::
     ld   h, d
     ld   [wCurrentBank], a
     ld   [MBC3SelectBank], a
-    jp   [hl]
+    jp   hl
 
 data_3AAA::
     db   8, 5, 8, 5, 8, $A, 8, $A, 8, $A, 8, $A, 8, $10, 4, $A

--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -1133,7 +1133,7 @@ label_47CD::
     ld   a, [wGameplaySubtype]
     JP_TABLE
     ; Code below is actually data for the jump table
-    jp   [hl]
+    jp   hl
     ld   b, a
     push af
     ld   b, a
@@ -3096,7 +3096,7 @@ label_53E8::
     rst  $38
     adc  a, d
     ldd  [hl], a
-    jp   [hl]
+    jp   hl
     rst  $38
     adc  a, d
     ld   l, $E9
@@ -3286,7 +3286,7 @@ label_54A0::
     nop
     rst  $38
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     rst  $38
     nop
     db   $E8 ; add  sp, d
@@ -3294,7 +3294,7 @@ label_54A0::
     db   $E8 ; add  sp, d
     rst  $38
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     rst  $38
     nop
     db   $E8 ; add  sp, d
@@ -3324,7 +3324,7 @@ label_54A0::
     db   $EC ; Undefined instruction
     db   $E8 ; add  sp, d
     db   $EC ; Undefined instruction
-    jp   [hl]
+    jp   hl
     rst  $38
     nop
     nop

--- a/src/code/bank3.asm
+++ b/src/code/bank3.asm
@@ -283,7 +283,7 @@ label_C918::
     ld   [hl], $05
     ld   a, $03
     call label_9D3
-    jp   [hl]
+    jp   hl
 
 data_C924::
     db 1, 4

--- a/tools/Z80Dis.c
+++ b/tools/Z80Dis.c
@@ -277,7 +277,7 @@ global_variable instruction InstructionTable[] = {
     {0xE6, 2, "and  $N"},
     {0xE7, 1, "rst  $20"},
     {0xE8, 1, "add  sp, d"},
-    {0xE9, 1, "jp   [hl]"},
+    {0xE9, 1, "jp   hl"},
     {0xEA, 3, "ld   [$NN], a"},
     {0xEB, 1, "db   $EB"},
     {0xEC, 1, "db   $EC"},
@@ -1953,7 +1953,7 @@ DisassembleBank(u16 BankNum) {
                 break;
             }
             case 0xE9: {
-                fprintf(Output, "jp   [hl]\n");
+                fprintf(Output, "jp   hl\n");
                 break;
             }
             case 0xEA: {


### PR DESCRIPTION
This PR enables the `rgbasm -E` option, which exports all labels to debug symbols, including unreferenced and local labels.

This allows us to see local labels in our debug tools. For instance, in the following code:

```asm
RenderLoop::
    ; Set DidRenderFrame
    ld   a, 1
    ldh  [hDidRenderFrame], a

.applyRegularScrollYOffset
    ; Compose the base offset and the screen shake offset
    ld   hl, wScreenShakeVertical
    ldh  a, [hBaseScrollY]
    add  a, [hl]

.setScrollY
    ld   [rSCY], a ; scrollY
```

The `RenderLoop` label (which is global) would be exported and visible in our debugger—but `applyRegularScrollYOffset` (which is a local label) wouldn't show.

### Note about `rgbds` version

This option requires at least rgbds v0.2.5.