### PR TITLE
Improve the built-in disassembler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ bin/banks/*
 *.sln
 *.suo
 *.DS_Store
+Z80Dis

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ clean:
 	rm -f game.{gbc,sym,map}
 	find . -iname '*.2bpp' -exec rm {} +
 
+Z80Dis: tools/Z80Dis.c
+	gcc -std=c99 -o Z80Dis tools/Z80Dis.c
+	chmod a+x Z80Dis
+
 DumpBanks: tools/DumpBanks.c
 	gcc -std=c99 -o DumpBanks tools/DumpBanks.c
 	chmod a+x DumpBanks

--- a/src/disassembled-banks/Bank0.asm
+++ b/src/disassembled-banks/Bank0.asm
@@ -4854,7 +4854,8 @@ label_1F49::
     ld   [label_A08], sp
     ld   a, [bc]
     dec  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $36
     jr   c, label_1F8E
     inc  a
 
@@ -5278,7 +5279,8 @@ label_21FB::
     ret
 
 label_2205::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   bc, label_3E01
     ld   [$00EA], sp
     ld   hl, label_34CD
@@ -8671,7 +8673,8 @@ label_377A::
 label_3789::
     nop
     ld   bc, label_302
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
     jr   nz, label_37B4
@@ -8727,7 +8730,8 @@ label_37CF::
 label_37E1::
     nop
     ld   bc, $00FF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
 
 label_37E7::
     ld   [$FFE9], a
@@ -9184,7 +9188,8 @@ label_3AC8::
     rlca
     db   $FC ; Undefined instruction
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     inc  c
     ld   [de], a
     ld   [label_208], sp

--- a/src/disassembled-banks/Bank0.asm
+++ b/src/disassembled-banks/Bank0.asm
@@ -724,7 +724,7 @@ label_430::
     ld   a, $20
     ld   [label_2100], a
     call label_4657
-    jp   [hl]
+    jp   hl
 
 label_43A::
     call label_28CF
@@ -1871,7 +1871,7 @@ label_BE7::
     ld   h, a
     ld   a, [$DE03]
     ld   l, a
-    jp   [hl]
+    jp   hl
     ld   a, $02
     ld   [label_2100], a
     call label_1A50
@@ -6404,7 +6404,7 @@ label_289F::
     ld   d, [hl]
     ld   l, e
     ld   h, d
-    jp   [hl]
+    jp   hl
 
 label_28CF::
     ld   a, [$FFFF]
@@ -9155,7 +9155,7 @@ label_3A8D::
     ld   h, d
     ld   [$DBAF], a
     ld   [label_2100], a
-    jp   [hl]
+    jp   hl
 
 label_3AAA::
     ld   [label_805], sp

--- a/src/disassembled-banks/Bank1.asm
+++ b/src/disassembled-banks/Bank1.asm
@@ -1137,7 +1137,7 @@ label_47CD::
     call label_5DC0
     ld   a, [$DB96]
     rst  0
-    jp   [hl]
+    jp   hl
     ld   b, a
     push af
     ld   b, a
@@ -2520,7 +2520,7 @@ label_4F45::
     ld   c, a
     rst  $18
     ld   d, b
-    jp   [hl]
+    jp   hl
     ld   d, c
     ld   a, $08
     ld   [$D6FE], a
@@ -3198,7 +3198,7 @@ label_53E8::
     rst  $38
     adc  a, d
     ldd  [hl], a
-    jp   [hl]
+    jp   hl
     rst  $38
     adc  a, d
     ld   l, $E9
@@ -3379,7 +3379,7 @@ label_54A0::
     nop
     rst  $38
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     rst  $38
     nop
     db   $E8 ; add  sp, d
@@ -3387,7 +3387,7 @@ label_54A0::
     db   $E8 ; add  sp, d
     rst  $38
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     rst  $38
     nop
     db   $E8 ; add  sp, d
@@ -3417,7 +3417,7 @@ label_54A0::
     db   $EC ; Undefined instruction
     db   $E8 ; add  sp, d
     db   $EC ; Undefined instruction
-    jp   [hl]
+    jp   hl
     rst  $38
     nop
     nop
@@ -3467,7 +3467,7 @@ label_54E6::
     ld   c, c
     ld   a, a
     sbc  a, l
-    jp   [hl]
+    jp   hl
     ld   c, c
     ld   a, a
     sbc  a, [hl]
@@ -8593,7 +8593,7 @@ label_71DE::
     push hl
     and  $E7
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     ld   [$ECEB], a
     db   $ED ; Undefined instruction
     xor  $EF

--- a/src/disassembled-banks/Bank1.asm
+++ b/src/disassembled-banks/Bank1.asm
@@ -339,9 +339,12 @@ label_41CF::
     inc  de
     ld   [de], a
     ld   de, label_1010
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $AF
     ld   [$C155], a
     ld   [$C156], a
     ld   a, [$FFB7]
@@ -2264,7 +2267,8 @@ label_4E43::
     dec  c
     ld   a, [hl]
     ld   a, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
     ld   [label_7E13], sp
     ld   a, [hl]
     ld   a, [hl]
@@ -5729,7 +5733,8 @@ label_6162::
 label_618A::
     nop
     ld   d, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $57
     jr   nz, label_61E7
     jr   nc, label_61E9
     ld   b, b
@@ -5746,7 +5751,8 @@ label_618A::
     ld   d, a
     nop
     ld   e, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $58
     jr   nz, label_61FC
     jr   nc, label_61FE
     ld   b, b
@@ -7007,7 +7013,8 @@ label_6975::
 label_6976::
     inc  d
     inc  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     inc  c
     inc  c
 
@@ -7027,28 +7034,34 @@ label_6982::
     call z, label_10
     ld   [label_10CE], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DC
     stop
     jr   label_695D
     jr   nc, label_69A3
     nop
     sbc  a, $10
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   [rNR10], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld  [$FF00+C], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   label_697F
     jr   nc, label_69C3
 
 label_69A3::
     nop
     db   $E4 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     ld   [label_10E6], sp
     jr   nz, label_69BC
     db   $E8 ; add  sp, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
 
 label_69AF::
     jr   label_6995
@@ -7073,17 +7086,21 @@ label_69C3::
     ld   b, b
     ld   [label_10E0], sp
     ld   b, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     jr   nc, label_6A0F
     jr   label_69AF
     jr   nc, label_69D3
 
 label_69D3::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DC
     ld   d, $10
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E2
     ld   d, $20
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E8
     ld   d, $00
     nop
     call z, label_15
@@ -7091,18 +7108,22 @@ label_69D3::
 label_69E3::
     ld   [label_15CE], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CE
     dec  [hl]
     nop
     jr   label_69B9
     dec  [hl]
     stop
     sbc  a, $15
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   [$FF15], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [$FF35], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     sbc  a, $35
     jr   nz, label_6A00
 
@@ -7138,7 +7159,8 @@ label_6A1C::
     ld   b, b
     ld   [label_15E0], sp
     ld   b, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     dec  [hl]
     ld   b, b
     jr   label_6A0B
@@ -7150,7 +7172,8 @@ label_6A2D::
     ld   c, b
 
 label_6A33::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F2
 
 label_6A35::
     rlca
@@ -7171,7 +7194,8 @@ label_6A35::
     ld   c, b
 
 label_6A4B::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     rlca
     ld   c, b
 
@@ -7198,7 +7222,8 @@ label_6A5B::
     ld   c, b
     ld   [label_7FC], sp
     ld   c, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     rlca
     ld   c, b
     jr   label_6A57
@@ -7597,7 +7622,8 @@ label_6CA5::
     ld   b, $07
     ld   [label_A09], sp
     dec  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1B
     jr   nz, label_6CE0
     jr   nc, label_6CF2
     ld   b, b
@@ -7729,7 +7755,8 @@ label_6D46::
     ld   b, b
     ld   b, b
     jr   nz, label_6D70
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [label_408], sp
     inc  b
     ld   [bc], a
@@ -7757,7 +7784,8 @@ label_6D46::
     jr   nz, label_6D90
 
 label_6D70::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [label_408], sp
     inc  b
     nop
@@ -7787,7 +7815,8 @@ label_6D70::
     jr   nz, label_6DB0
 
 label_6D90::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     nop
@@ -7819,7 +7848,8 @@ label_6D90::
     jr   nz, label_6DD0
 
 label_6DB0::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [label_408], sp
     inc  b
     ld   [bc], a
@@ -9151,17 +9181,20 @@ label_7538::
     ld   [bc], a
     nop
     ld   [label_21E], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     jr   nz, label_7546
     stop
 
 label_7546::
     ldi  [hl], a
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     inc  h
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   h, $02
 
 label_7550::
@@ -9290,7 +9323,8 @@ label_75F9::
     nop
     nop
     ld   [hl], $21
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     inc  l
     ld   hl, label_1020
 
@@ -9613,22 +9647,26 @@ label_77ED::
     ret
 
 label_7808::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   l, $05
     nop
     jr   label_783B
     dec  b
 
 label_7810::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
 
 label_7812::
     ld   a, [hli]
     dec  b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
     dec  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   h, $05
     nop
     ld   [label_524], sp
@@ -9651,11 +9689,13 @@ label_782D::
     ld   d, $00
     jr   label_7883
     ld   d, $10
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $4A
 
 label_783B::
     ld   d, $00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $48
     ld   d, $10
     ld   [label_1646], sp
     nop
@@ -9671,13 +9711,16 @@ label_783B::
     nop
     jr   label_7883
     dec  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   a, [hli]
     dec  b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
     dec  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   h, $05
     nop
     ld   [label_524], sp
@@ -9706,11 +9749,13 @@ label_787F::
     ld   d, $10
 
 label_7881::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $4A
 
 label_7883::
     ld   d, $00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $48
     ld   d, $10
     ld   [label_1646], sp
     nop

--- a/src/disassembled-banks/Bank10.asm
+++ b/src/disassembled-banks/Bank10.asm
@@ -535,7 +535,8 @@ label_281EA::
     ld  [$FF00+C], a
     nop
     jr   label_28268
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  b
     dec  c
     ld   [hl], h
@@ -635,7 +636,8 @@ label_28284::
     nop
     add  hl, de
     ld   a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  b
     dec  c
     jr   nz, label_282A9
@@ -643,7 +645,8 @@ label_28284::
     rst  $30
     ld   [hl], h
     db   $ED ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C9
     ld   b, b
     ret
     ld   [hl], e
@@ -766,7 +769,8 @@ label_28323::
     add  a, d
     nop
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     ld   [bc], a
     dec  h
     rlca
@@ -915,7 +919,8 @@ label_283CE::
     ld   h, $0A
     ld   h, $C2
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $82
     jr   nc, label_2841B
     inc  sp
     inc  d
@@ -992,7 +997,8 @@ label_28428::
     nop
     dec  de
     ld   a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  b
     rrca
     add  hl, sp
@@ -1157,7 +1163,8 @@ label_2850A::
     inc  hl
     and  [hl]
     jp   nz, label_D40
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     ld   h, b
     dec  hl
     cp   $04
@@ -1891,7 +1898,8 @@ label_28884::
     inc  bc
     ld   bc, label_525
     rst  0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_2029
     ret
     ld   d, b
@@ -2154,7 +2162,8 @@ label_28994::
     cp   a
     ld  [$FF00+C], a
     ld   bc, $883B
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  b
     dec  c
     inc  b
@@ -2461,7 +2470,8 @@ label_28B36::
     cp   [hl]
     ld  [$FF00+C], a
     ld   bc, label_183E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  b
     dec  c
 
@@ -2504,7 +2514,8 @@ label_28B6C::
     inc  bc
     nop
     dec  h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $23
     jr   nz, label_28BA0
     ld   hl, $C42B
     ld   sp, $C523
@@ -2516,7 +2527,8 @@ label_28B83::
     jr   label_28B43
     ld  [$FF00+C], a
     ld   bc, label_183A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  b
     rlca
     ld   [hl], h
@@ -2527,7 +2539,8 @@ label_28B83::
 
 label_28B92::
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
 
 label_28B95::
     ld   [bc], a
@@ -2615,7 +2628,8 @@ label_28BD6::
     jr   label_28BB1
     ld  [$FF00+C], a
     ld   bc, $883F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  b
     rlca
     inc  b
@@ -2705,7 +2719,8 @@ label_28C5B::
     nop
     inc  bc
     add  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     add  a, d
     ld   [$8203], sp
     jr   label_28C74
@@ -2847,7 +2862,8 @@ label_28D14::
     add  a, e
 
 label_28D16::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
 
 label_28D18::
     add  a, e
@@ -3189,7 +3205,8 @@ label_28E68::
     ld   l, l
     rst  0
     ld   bc, $C363
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6C
     add  a, e
     inc  d
     ld   l, e
@@ -3280,7 +3297,8 @@ label_28F15::
     nop
     ld   d, h
     add  a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $54
     add  a, e
 
 label_28F20::
@@ -3373,7 +3391,8 @@ label_28F76::
     ld   [hl], c
     ld   c, b
     ld   [hl], c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $70
     ld   [de], a
     ld   [hl], b
     inc  d
@@ -3441,7 +3460,8 @@ label_28FD9::
     nop
     ld   l, l
     add  a, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $54
     add  a, l
     jr   nz, label_2903F
     ld   d, $5E
@@ -3671,7 +3691,8 @@ label_290D0::
     rrca
     ld   a, c
     inc  l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C9
     ld   b, b
     ret
     cp   $04
@@ -3692,7 +3713,8 @@ label_290D0::
 
 label_290F7::
     ld   de, label_19C6
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $77
     ld   d, $78
     dec  c
     ld   a, c
@@ -3856,7 +3878,8 @@ label_29197::
     rlca
     ld   h, $09
     inc  h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     add  a, $17
     inc  h
     ret  z
@@ -3989,7 +4012,8 @@ label_29246::
     dec  c
     inc  b
     dec  h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     ld   de, label_120D
     dec  h
     inc  de
@@ -4221,7 +4245,8 @@ label_29342::
     ld   bc, label_825
     ld   h, $09
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_1329
     xor  h
     ld   d, $AC
@@ -4434,7 +4459,8 @@ label_29443::
     add  a, e
     rlca
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     add  a, d
     ld   de, label_1221
     rst  0
@@ -4699,7 +4725,8 @@ label_29569::
 label_29574::
     ld   [hl], b
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     adc  a, b
     ld   de, label_1921
     ld   h, $60
@@ -5460,7 +5487,8 @@ label_298C4::
 label_29907::
     rra
     adc  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  c
     dec  e
     inc  b
@@ -5468,7 +5496,8 @@ label_29907::
     jr   nc, label_29907
     ld   e, c
     rst  $30
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C9
     ld   h, b
     ret
     jr   nz, label_29942
@@ -5538,7 +5567,8 @@ label_29942::
     ld   b, a
     ld   [de], a
     ld   sp, label_3610
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $33
     ld   de, label_1138
     ldd  [hl], a
     inc  e
@@ -5627,7 +5657,8 @@ label_299AC::
     inc  bc
     ld   a, l
     adc  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  c
     ld   a, $04
     db   $F4 ; Undefined instruction
@@ -5748,7 +5779,8 @@ label_29A4E::
     push bc
     inc  b
     inc  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     jp   nz, label_2412
     add  a, d
     jr   nc, label_29A97
@@ -5861,12 +5893,14 @@ label_29AB6::
     inc  bc
     ld   e, a
     adc  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  c
     sbc  a, l
     rlca
     db   $F4 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F6
     add  hl, hl
     rst  $30
     ld   [hl], l
@@ -5883,7 +5917,8 @@ label_29AB6::
     add  hl, de
     sub  a, [hl]
     add  a, $29
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     dec  de
     add  a, a
     jr   nz, label_29B3B
@@ -5920,7 +5955,8 @@ label_29B3B::
     dec  e
     ld   [bc], a
     db   $F4 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F6
     add  hl, hl
     rst  $30
     ld   [hl], e
@@ -5928,11 +5964,13 @@ label_29B3B::
     nop
     sub  a, e
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C2
     inc  bc
     inc  hl
     jp   nz, label_2409
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     ld   [de], a
     inc  d
     jr   nz, label_29B88
@@ -5983,7 +6021,8 @@ label_29B92::
     ld   e, $04
     db   $F4 ; Undefined instruction
     jr   nc, label_29B92
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C9
     ld   d, b
     ret
     jr   nz, label_29BCB
@@ -6046,7 +6085,8 @@ label_29BD4::
     ld   sp, label_3522
     dec  hl
     jp   label_2345
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C9
     ldd  [hl], a
     ret  z
     ld   b, b
@@ -6100,7 +6140,8 @@ label_29C12::
     ld  [$FF00+C], a
     inc  bc
     ld   e, $18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C2
     ld   de, $FE20
     inc  c
     sbc  a, [hl]
@@ -6120,7 +6161,8 @@ label_29C4A::
     jp   nz, label_2305
     add  hl, bc
     dec  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $23
     add  a, d
     ld   de, label_130D
     inc  h
@@ -6171,7 +6213,8 @@ label_29C8A::
     sbc  a, l
     dec  b
     db   $F4 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F6
     ld   [hl], h
     push af
     add  a, d
@@ -6183,8 +6226,10 @@ label_29C9B::
     inc  h
     add  a, $08
     ld   de, label_9C8
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $83
+    db   $10
+    db   $0E
     ld   d, $0E
     add  a, a
     jr   nz, label_29CBB
@@ -6280,14 +6325,16 @@ label_29D01::
     dec  l
     inc  bc
     db   $F4 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
     jp   label_1100
     add  a, e
     ld   bc, $830F
     ld   de, $830F
     ld   hl, $C30F
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $85
     dec  b
     ld   [de], a
     jr   nc, label_29D44
@@ -6361,7 +6408,8 @@ label_29D67::
     rlca
     dec  c
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     dec  d
     dec  c
     adc  a, c
@@ -6425,7 +6473,8 @@ label_29DAA::
     add  hl, bc
     sub  a, h
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     jr   nz, label_29DEB
     adc  a, b
     ld   hl, label_2921
@@ -6468,7 +6517,8 @@ label_29DEB::
     ld   [bc], a
     ld   d, $03
     dec  h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     ld   [de], a
     inc  d
     inc  de
@@ -7195,7 +7245,8 @@ label_2A184::
 
 label_2A185::
     ld   c, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  c
     dec  e
     rlca
@@ -7474,7 +7525,8 @@ label_2A2A6::
     ldi  [hl], a
     cp   $0C
     dec  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F2
     ld   [hl], d
     push af
     add  a, e
@@ -7522,7 +7574,8 @@ label_2A2EB::
     inc  b
     and  l
     adc  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $82
     inc  [hl]
 
 label_2A2F7::
@@ -7608,7 +7661,8 @@ label_2A351::
     inc  b
     and  a
     adc  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $15
 
 label_2A358::
     ld   a, [hli]
@@ -7874,7 +7928,8 @@ label_2A483::
 label_2A488::
     rlca
     and  [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A6
 
 label_2A48C::
     ld   h, b
@@ -7958,7 +8013,8 @@ label_2A4DA::
     inc  b
     xor  c
     adc  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  c
     dec  c
     inc  b
@@ -8042,7 +8098,8 @@ label_2A538::
     ld   d, [hl]
     ret  nz
     add  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
 
 label_2A540::
     ld   hl, $FE0F
@@ -8153,7 +8210,8 @@ label_2A5B6::
     ld   [$C36D], sp
     ld   de, $C66C
     jr   label_2A632
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $54
     add  hl, de
     ld   d, h
     jr   nz, label_2A620
@@ -8212,7 +8270,8 @@ label_2A5B6::
     nop
     ld   l, l
     push bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6C
     add  a, l
     jr   nc, label_2A67D
     jp   label_2AC17
@@ -8605,10 +8664,12 @@ label_2A7D3::
     ld   bc, label_825
     ld   h, $09
     rst  $18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, $C329
     ld   [de], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     dec  h
     add  a, d
     inc  d
@@ -8832,7 +8893,8 @@ label_2A8AB::
     ld   bc, label_912
     ld   d, $C7
     add  hl, de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     dec  d
     add  a, a
     ld   de, label_1713
@@ -8908,7 +8970,8 @@ label_2A924::
     ld   [hl], b
     ld   de, label_D71
     ld   [hl], d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $86
     ld   [hl], e
     and  [hl]
     add  a, d
@@ -9047,7 +9110,8 @@ label_2A9CF::
     rst  0
     ld   [label_926], sp
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     add  a, d
     ld   de, label_1321
     add  hl, hl
@@ -9121,7 +9185,8 @@ label_2AA2E::
     rst  $30
     db   $76 ; Halt
     push af
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     jr   nz, label_2AA4A
     jr   nc, label_2AA6A
     rst  0
@@ -9191,7 +9256,8 @@ label_2AA7A::
     ld   h, b
     ld   [de], a
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     adc  a, d
     ld   [hl], b
     inc  de
@@ -9232,10 +9298,12 @@ label_2AABD::
     nop
     sub  a, e
     ld   bc, label_20D
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     dec  h
     add  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
 
 label_2AAC8::
     ld   [de], a
@@ -9277,7 +9345,8 @@ label_2AAE5::
     ld   h, [hl]
 
 label_2AAF1::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $78
     dec  c
 
 label_2AAF4::
@@ -9335,7 +9404,8 @@ label_2AB33::
     dec  b
     db   $DB
     adc  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  c
     sbc  a, l
     inc  bc
@@ -9349,7 +9419,8 @@ label_2AB3C::
     inc  hl
     push bc
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C4
     inc  bc
     inc  hl
     add  a, h
@@ -9374,7 +9445,8 @@ label_2AB3C::
     ld   [de], a
     ld   d, h
     ld   d, $64
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $43
     daa
     ld   b, h
     ldi  [hl], a
@@ -9407,7 +9479,8 @@ label_2AB83::
     ldi  [hl], a
     ld   [hl], h
     dec  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C9
     ld   b, b
     ret
     add  hl, de
@@ -9456,7 +9529,8 @@ label_2AB93::
 
 label_2ABC8::
     adc  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  b
     dec  c
     inc  b
@@ -9503,7 +9577,8 @@ label_2AC00::
 
 label_2AC09::
     add  hl, bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $19
     inc  d
     ld   [bc], a
     rst  0
@@ -9599,7 +9674,8 @@ label_2AC57::
     adc  a, b
 
 label_2AC58::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  b
     dec  c
     inc  bc
@@ -9712,7 +9788,8 @@ label_2ACD6::
     inc  h
     ld   [$C22A], sp
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $04
     add  hl, hl
     dec  b
     inc  hl
@@ -9848,8 +9925,10 @@ label_2AD3A::
     add  hl, sp
     jp   z, label_4FE
     dec  c
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DB
+    db   $10
+    db   $F6
     ld   [hl], a
     pop  af
     ld   [bc], a
@@ -9941,7 +10020,8 @@ label_2ADD6::
     dec  h
     ld   [label_926], sp
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     add  a, h
     ld   de, label_1521
     add  hl, hl
@@ -10053,7 +10133,8 @@ label_2AE5F::
     rla
     ld   [label_912], sp
     ld   d, $C2
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     jp   nz, label_1012
     jp   label_2313
     jp   label_2416
@@ -10190,7 +10271,8 @@ label_2AEF6::
     inc  bc
     ld   [bc], a
     dec  h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_1221
     add  hl, hl
     add  a, d
@@ -10312,7 +10394,8 @@ label_2AFE2::
     rlca
     ld   h, $82
     ld   [$8203], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     ld   [de], a
     inc  hl
     inc  d
@@ -10580,7 +10663,8 @@ label_2B123::
     ld   l, b
     push bc
     ld   bc, $C663
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     call nz, label_2A513
     call nz, label_2A515
     push bc
@@ -10713,8 +10797,10 @@ label_2B1DB::
 
 label_2B1E1::
     add  a, a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
+    db   $10
+    db   $60
     ld   d, $60
     add  a, a
     jr   nz, label_2B253
@@ -10764,7 +10850,8 @@ label_2B20D::
     ld   b, $C7
     ld   [label_926], sp
     rst  $18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_1829
     ld   a, [hli]
     add  hl, de
@@ -10828,7 +10915,8 @@ label_2B25D::
     ld   [bc], a
     rst  0
     ld   b, $C7
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     ld   [de], a
     rrca
     ld   d, $25
@@ -10897,7 +10985,8 @@ label_2B2BF::
     ld   [bc], a
     rst  0
     ld   b, $C7
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     ld   [de], a
     rrca
     ld   d, $25
@@ -11007,7 +11096,8 @@ label_2B32F::
     ld   bc, label_825
     ld   h, $09
     rst  $18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, $8629
 
 label_2B355::
@@ -11173,7 +11263,8 @@ label_2B3FF::
     rst  $18
     jp   label_DF09
     add  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0D
     inc  de
     rst  $18
     ld   d, $DF
@@ -11244,7 +11335,8 @@ label_2B420::
     ld   [$C826], sp
     add  hl, bc
     rst  $18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_1229
     dec  h
     inc  de
@@ -11312,7 +11404,8 @@ label_2B420::
     ld   bc, label_825
     ld   h, $09
     rst  $18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_1829
     ld   a, [hli]
     add  hl, de
@@ -11492,7 +11585,8 @@ label_2B577::
     jp   nz, label_2AC08
     jp   nz, label_2A809
     adc  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $69
     jr   nz, label_2B5F5
     ld   hl, label_2264
     ld   e, a
@@ -11624,7 +11718,8 @@ label_2B622::
     add  a, h
     dec  b
     ld   hl, label_2609
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $05
     add  a, d
     ld   de, label_13DF
 
@@ -11750,7 +11845,8 @@ label_2B6B6::
     ld   b, $DF
     add  hl, bc
     rst  $18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_1529
     ld   a, [hli]
     ld   d, $26
@@ -11810,7 +11906,8 @@ label_2B700::
     ld   [rJOYP], a
     sbc  a, h
     ld   e, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  c
     sbc  a, l
     add  a, e
@@ -11872,7 +11969,8 @@ label_2B742::
     ld   bc, label_825
     ld   h, $09
     rst  $18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_1829
     ld   a, [hli]
     add  hl, de
@@ -11911,10 +12009,12 @@ label_2B783::
     ld   bc, label_825
     ld   h, $09
     rst  $18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, $C329
     ld   [de], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     dec  h
     add  a, d
     inc  d
@@ -12031,7 +12131,8 @@ label_2B7F4::
     ld   bc, label_825
     ld   h, $09
     rst  $18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_1829
     ld   a, [hli]
     add  hl, de
@@ -12082,7 +12183,8 @@ label_2B841::
     ld   bc, label_825
     ld   h, $09
     rst  $18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_1829
     ld   a, [hli]
     add  hl, de
@@ -12334,7 +12436,8 @@ label_2B96F::
     ld   bc, label_825
     ld   h, $09
     rst  $18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_1829
     ld   a, [hli]
     add  hl, de
@@ -12380,7 +12483,8 @@ label_2B96F::
     ld   bc, label_825
     ld   h, $09
     rst  $18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_1829
     ld   a, [hli]
     add  hl, de
@@ -12420,7 +12524,8 @@ label_2B9E5::
     nop
     rst  8
     ld   e, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  b
     dec  c
     adc  a, b
@@ -12449,10 +12554,12 @@ label_2BA24::
     ld   bc, label_825
     ld   h, $09
     rst  $18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, $C329
     ld   [de], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     dec  h
     add  a, d
     inc  d
@@ -12544,7 +12651,8 @@ label_2BA96::
     nop
     rst  $18
     add  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     add  a, d
     jr   label_2BA82
     add  a, d
@@ -12683,14 +12791,16 @@ label_2BB30::
     ld   [rJOYP], a
     inc  de
     ld   e, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     dec  b
     sub  a, h
     adc  a, d
     nop
     add  a, h
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $84
     adc  a, d
     jr   nz, label_2BAC6
     adc  a, d

--- a/src/disassembled-banks/Bank11.asm
+++ b/src/disassembled-banks/Bank11.asm
@@ -506,7 +506,8 @@ label_2C1D8::
     ld   de, $FEA0
     inc  b
     ld   c, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F6
     add  hl, de
     rst  $30
     ld   [hl], d
@@ -545,7 +546,8 @@ label_2C256::
     jr   nc, label_2C256
     inc  b
     dec  l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F6
     add  hl, de
 
 label_2C25D::
@@ -568,11 +570,13 @@ label_2C272::
     jr   nc, label_2C272
     inc  b
     ld   a, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F6
     ld   [hl], h
     push af
     adc  a, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     add  a, $28
     rrca
     add  a, a
@@ -678,7 +682,8 @@ label_2C2DF::
     push bc
     rlca
     call c, label_2A08
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     add  hl, de
     ld   a, [hli]
     adc  a, d
@@ -719,14 +724,16 @@ label_2C31A::
 
 label_2C32D::
     dec  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F6
     add  hl, de
 
 label_2C331::
     rst  $30
     ld   [hl], h
     push af
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     ld   de, label_18AC
     xor  h
     add  hl, de
@@ -851,7 +858,8 @@ label_2C3B1::
     pop  hl
     ld   b, $17
     ld   a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     ld   a, [hli]
     add  hl, sp
     dec  c
@@ -926,7 +934,8 @@ label_2C432::
     ld   [$C226], sp
     add  hl, bc
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   de, label_1225
     sbc  a, b
     inc  de
@@ -1113,7 +1122,8 @@ label_2C517::
     xor  h
     ld   l, b
     xor  h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     add  hl, de
     ld   a, [hli]
 
@@ -1170,7 +1180,8 @@ label_2C54D::
     inc  b
     dec  c
     ld   b, $2A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     add  hl, de
     ld   a, [hli]
     adc  a, d
@@ -1542,10 +1553,12 @@ label_2C708::
     pop  hl
     ld   b, $09
     ld   a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  b
     ld   c, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F6
     ld   [hl], l
     db   $ED ; Undefined instruction
     ld   [bc], a
@@ -1651,7 +1664,8 @@ label_2C79D::
     add  hl, hl
     ld   [label_90D], sp
     inc  h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $24
     ld   de, $C623
 
 label_2C7A8::
@@ -1698,7 +1712,8 @@ label_2C7D2::
     pop  hl
     ld   b, $0C
     ld   e, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     db   $DB
     cp   $04
     dec  c
@@ -1821,7 +1836,8 @@ label_2C857::
     ld   [de], a
 
 label_2C871::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $83
     inc  de
     rrca
     jp   label_1116
@@ -1883,7 +1899,8 @@ label_2C8A1::
 label_2C8B0::
     ld   a, [hli]
     ld   [$82C7], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [de], a
     inc  hl
     add  a, d
@@ -2060,7 +2077,8 @@ label_2C976::
     add  hl, hl
     inc  bc
     inc  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     ld   de, label_1225
     ld   hl, label_2913
     jr   nz, label_2C9AC
@@ -2143,7 +2161,8 @@ label_2C9C7::
     dec  c
     inc  b
     ld   a, [hli]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_1221
     add  hl, hl
     jr   label_2C999
@@ -2208,7 +2227,8 @@ label_2CA35::
     ld   d, $C2
     ld   d, d
     ld   de, label_2D5C2
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $82
     ld   d, e
     ld   e, $82
     ld   h, e
@@ -2240,7 +2260,8 @@ label_2CA5F::
     rra
     push bc
     ldi  [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $86
     inc  hl
     ld   [de], a
     inc  [hl]
@@ -2331,7 +2352,8 @@ label_2CA7F::
     pop  hl
     ld   b, $1D
     ld   a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  b
     sbc  a, l
     ld   [bc], a
@@ -2349,7 +2371,8 @@ label_2CA7F::
     ld   a, [hli]
     ld   [label_9C7], sp
     add  hl, hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A6
     jr   label_2CAAD
     add  hl, de
     ld   d, $83
@@ -2357,7 +2380,8 @@ label_2CA7F::
     ld   hl, label_2398
     add  hl, hl
     add  a, $29
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $30
     call c, label_2240
     ld   b, c
     dec  hl
@@ -2474,7 +2498,8 @@ label_2CB2D::
     ld   a, [hli]
 
 label_2CBA6::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     ld   de, $C323
     inc  d
     inc  h
@@ -2591,8 +2616,10 @@ label_2CC2A::
     ld   l, b
     xor  h
     ld   [rJOYP], a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $58
+    db   $10
+    db   $FE
     ld   b, $93
     db   $76 ; Halt
     push af
@@ -2723,7 +2750,8 @@ label_2CC7A::
     ld   bc, label_825
     ld   h, $09
     ret  nz
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, $8629
     ld   [de], a
     rrca
@@ -2792,7 +2820,8 @@ label_2CD36::
     rlca
     ld   h, l
     adc  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     ld   b, $06
     ld   bc, label_2D9F0
     di
@@ -2820,7 +2849,8 @@ label_2CD5C::
     ld   d, $06
     dec  h
     ld   de, label_1511
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     inc  hl
     jr   nz, label_2CD99
     add  a, l
@@ -2887,12 +2917,14 @@ label_2CD5C::
     rla
     ld   [label_912], sp
     ld   d, $83
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0D
     inc  de
     inc  hl
     jp   nz, label_2416
     add  hl, de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     dec  h
     add  a, d
     ld   hl, label_2321
@@ -2937,7 +2969,8 @@ label_2CD5C::
     ld    hl, sp+$C3
     inc  d
     ld   de, label_15C3
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $30
     add  hl, hl
     ld   hl, label_2212
     xor  h
@@ -3047,7 +3080,8 @@ label_2CE78::
     dec  l
     dec  b
     and  e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F6
     add  hl, de
     rst  $30
     nop
@@ -3055,7 +3089,8 @@ label_2CE78::
     add  hl, bc
     add  hl, hl
     add  a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     rla
     sub  a, l
     add  hl, de
@@ -3095,7 +3130,8 @@ label_2CED9::
     jr   c, label_2CF2C
     cp   $06
     ld   c, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F6
     ld   [hl], h
     pop  af
     add  a, a
@@ -3167,7 +3203,8 @@ label_2CF2C::
     dec  b
     ld   hl, label_2909
     rst  0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     rst  0
     ld   de, label_1210
     dec  h
@@ -3229,7 +3266,8 @@ label_2CF2C::
     ld   [label_906], sp
     inc  h
     ld   [de], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $83
     inc  de
     ld   b, $14
     ret  nz
@@ -3255,7 +3293,8 @@ label_2CFA0::
     inc  h
 
 label_2CFA6::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     jr   nz, label_2CFB7
     jr   nc, label_2CFD7
     ldd  [hl], a
@@ -3317,7 +3356,8 @@ label_2CFD7::
     nop
     dec  c
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0D
 
 label_2CFED::
     nop
@@ -3463,7 +3503,8 @@ label_2D078::
     dec  b
     ld   d, $06
     dec  h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $15
     ld   d, $23
     jr   nz, label_2D0BE
     add  a, l
@@ -3521,7 +3562,8 @@ label_2D0D8::
     ld   b, $2D
     inc  b
     ld   b, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F6
     add  hl, hl
     rst  $30
     ld   [hl], a
@@ -3574,7 +3616,8 @@ label_2D109::
 
 label_2D11D::
     dec  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
 
 label_2D120::
     adc  a, b
@@ -3644,7 +3687,8 @@ label_2D159::
     dec  h
 
 label_2D167::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     jr   nz, label_2D178
     jr   nc, label_2D198
     ld   b, b
@@ -3888,7 +3932,8 @@ label_2D275::
     add  hl, bc
     ld   a, [hli]
     add  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0D
     inc  d
     and  a
     ld   d, $A7
@@ -3956,7 +4001,8 @@ label_2D296::
     ld   h, $83
     ld   bc, label_40D
     dec  h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2A
     ld   de, label_1298
     ld   h, $14
     inc  hl
@@ -4087,7 +4133,8 @@ label_2D339::
     rlca
     ld   l, c
     adc  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  b
     dec  c
     ld   bc, label_39F0
@@ -4183,7 +4230,8 @@ label_2D3C2::
     dec  c
     ld   b, $2A
     adc  a, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $06
     add  a, d
 
 label_2D3D6::
@@ -4272,7 +4320,8 @@ label_2D434::
     add  a, e
     rlca
     ret  nz
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     add  a, [hl]
     ld   de, label_1721
     ld   h, $82
@@ -4426,7 +4475,8 @@ label_2D4D0::
     ld   b, e
     rrca
     ld   b, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     ld   [de], a
     ld   d, e
     dec  d
@@ -4457,7 +4507,8 @@ label_2D4D0::
     rlca
     inc  bc
     add  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     add  a, e
     rla
     inc  bc
@@ -4504,8 +4555,10 @@ label_2D527::
     jr   z, label_2D588
     db   $FC ; Undefined instruction
     ld   [rJOYP], a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $58
+    db   $10
+    db   $FE
     ld   b, $0D
     inc  b
     db   $F4 ; Undefined instruction
@@ -4610,7 +4663,8 @@ label_2D58F::
     rlca
     ld   l, e
     adc  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     ld   c, $94
     add  a, d
     nop
@@ -4669,7 +4723,8 @@ label_2D5ED::
     nop
     ld   d, h
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $54
     adc  a, d
     jr   nz, label_2D64E
     adc  a, d
@@ -4723,7 +4778,8 @@ label_2D626::
     rlca
     ld   d, h
     rst  0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $57
     add  a, d
     dec  d
     adc  a, d
@@ -4787,7 +4843,8 @@ label_2D626::
 label_2D683::
     rlca
     ld   d, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5C
     ld   de, $8554
     ld   [de], a
     adc  a, d
@@ -4953,7 +5010,8 @@ label_2D741::
     add  a, h
     ld   b, $5C
     add  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $54
     inc  de
     ld   [hl], b
     add  a, d
@@ -5329,7 +5387,8 @@ label_2D879::
     rlca
     ld   h, $82
     ld   [$C203], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     ld   de, label_1225
     add  hl, hl
     rla
@@ -5387,7 +5446,8 @@ label_2D937::
     ld   b, $2A
     ld   [label_926], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_1829
     ld   a, [hli]
     add  hl, de
@@ -5452,7 +5512,8 @@ label_2D95F::
     ld   b, $2A
     ld   [label_926], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_1829
     ld   a, [hli]
     add  hl, de
@@ -5567,7 +5628,8 @@ label_2DA23::
     ld   bc, label_825
     ld   h, $09
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_1829
     ld   a, [hli]
     add  hl, de
@@ -5608,7 +5670,8 @@ label_2DA32::
     nop
 
 label_2DA5B::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_1829
     ld   a, [hli]
     add  hl, de
@@ -5755,7 +5818,8 @@ label_2DAEB::
     ld   b, $C7
     ld   [label_926], sp
     rst  $18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_1829
     ld   a, [hli]
     add  hl, de
@@ -5822,7 +5886,8 @@ label_2DB66::
 label_2DB68::
     ld   [label_900], sp
     rst  $18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C9
     inc  de
     ld   a, [hli]
     inc  d
@@ -5994,7 +6059,8 @@ label_2DBE5::
     dec  c
     add  hl, bc
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     ld   de, $8425
     ld   [de], a
     ld   hl, label_2616
@@ -6180,7 +6246,8 @@ label_2DD10::
     db   $FD ; Undefined instruction
     ld   [rJOYP], a
     ld   e, $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  c
     sub  a, l
     adc  a, d
@@ -6395,7 +6462,8 @@ label_2DE06::
 label_2DE13::
     ld   [rJOYP], a
     ld   e, $78
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  c
     sub  a, l
     adc  a, d
@@ -6456,7 +6524,8 @@ label_2DE46::
     ld   b, $26
     rlca
     ld   a, [hli]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0D
     ld   de, label_12DF
     dec  h
     inc  de
@@ -6757,7 +6826,8 @@ label_2DFA6::
     add  a, d
 
 label_2DFC6::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     jp   nz, label_2314
     add  a, d
     dec  d
@@ -6917,7 +6987,8 @@ label_2E065::
     cp   $0C
     sbc  a, l
     jp   nz, label_DF02
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     add  a, d
     jr   nz, label_2E065
     ld   sp, label_2C0DF
@@ -6975,7 +7046,8 @@ label_2E0B6::
     jp   label_2405
     jp   label_DF06
     jp   nz, label_D09
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0D
     ld   de, $C2DF
     rla
     dec  c
@@ -7028,7 +7100,8 @@ label_2E0EA::
     ld   [rJOYP], a
     rra
     ld   a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  c
     sbc  a, l
     add  a, d
@@ -7039,7 +7112,8 @@ label_2E0EA::
     rst  $18
     add  a, d
     ld   [$C3DF], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     jp   label_DF12
     jp   nz, label_DF13
     jp   nz, label_DF15
@@ -7291,7 +7365,8 @@ label_2E234::
     nop
     rst  $18
     add  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     inc  de
     dec  h
     add  a, [hl]
@@ -7350,7 +7425,8 @@ label_2E283::
     add  hl, bc
     nop
     add  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $21
     inc  de
     ld   h, $14
     rst  $18
@@ -7394,7 +7470,8 @@ label_2E2B7::
     add  hl, hl
     call nz, label_2408
     jp   nz, label_DF09
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, $C229
     add  hl, hl
     dec  c
@@ -7574,7 +7651,8 @@ label_2E384::
     dec  b
     dec  c
     add  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $05
     inc  de
     inc  h
     call nz, label_DF15
@@ -7751,7 +7829,8 @@ label_2E437::
     sub  a, b
     nop
     ld   hl, label_2601
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $05
     ld   de, label_122A
     ld   hl, label_2613
     jr   nz, label_2E425
@@ -7908,7 +7987,8 @@ label_2E525::
     ld   de, label_21C5
     add  a, $C2
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $85
     inc  d
     dec  de
     add  a, l
@@ -8181,7 +8261,8 @@ label_2E63C::
     cp   $04
     ld   c, l
     push bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  bc
     sbc  a, c
     add  a, h
@@ -8464,7 +8545,8 @@ label_2E7B4::
     rlca
     rst  $18
     add  a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $21
     inc  d
     ld   h, $15
     rst  $18
@@ -8661,7 +8743,8 @@ label_2E882::
     ld   d, d
     or   b
     add  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0D
     jr   nz, label_2E8B0
     inc  [hl]
 
@@ -8768,7 +8851,8 @@ label_2E903::
     adc  a, d
 
 label_2E91C::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     add  a, d
     jr   label_2E99D
     adc  a, b
@@ -8838,7 +8922,8 @@ label_2E961::
     ldi  [hl], a
     ld   [hl], c
     jr   z, label_2E92C
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     ld   [hl], d
     daa
     add  a, h
@@ -8995,7 +9080,8 @@ label_2EA11::
     nop
     rst  $18
     add  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     jr   nz, label_2EA11
     inc  bc
     dec  h
@@ -9138,7 +9224,8 @@ label_2EAB7::
     nop
     rst  $18
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     adc  a, d
     ld   h, b
     rst  $18
@@ -9183,7 +9270,8 @@ label_2EAFB::
     nop
     rst  $18
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     adc  a, d
 
 label_2EB05::
@@ -9248,7 +9336,8 @@ label_2EB3A::
     rst  $18
     rlca
     dec  h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_1229
     rrca
     inc  d
@@ -9319,7 +9408,8 @@ label_2EB78::
     ld   [hl], d
     daa
     push bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0D
     ld   de, label_2D20D
     dec  c
     ld   h, e
@@ -9545,7 +9635,8 @@ label_2EC92::
     ld   c, c
     ld   d, $C3
     ld   e, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  b
     ld   a, l
     add  a, [hl]
@@ -9600,7 +9691,8 @@ label_2ECDD::
     nop
     add  a, b
     add  a, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $81
     add  a, [hl]
     jr   nz, label_2EC72
     add  a, [hl]
@@ -9800,13 +9892,15 @@ label_2EDC6::
     inc  d
     push bc
     ld   c, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  b
     ld   c, l
     rlca
     ld   h, $82
     ld   [$8703], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     rla
     ld   a, [hli]
     jr   label_2EE08
@@ -10010,9 +10104,11 @@ label_2EEC2::
     sbc  a, c
     inc  bc
     ld   d, $C2
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $23
     inc  d
     ld   [de], a
     sbc  a, d
@@ -10054,7 +10150,8 @@ label_2EF0A::
     inc  b
     ld   h, $05
     dec  h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, $C329
     inc  d
     inc  h
@@ -10459,7 +10556,8 @@ label_2F0E1::
     add  hl, sp
 
 label_2F0F1::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $44
     sub  a, l
     ld   b, l
     sub  a, [hl]
@@ -10482,7 +10580,8 @@ label_2F0F1::
     nop
     rrca
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C2
 
 label_2F10C::
     inc  b
@@ -10511,7 +10610,8 @@ label_2F10C::
     add  a, h
     jr   nz, label_2F14D
     add  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     ld   de, $000D
     ld   de, label_1510
     ld   hl, label_3098
@@ -10977,7 +11077,8 @@ label_2F34E::
     rrca
     ld   l, b
     set  4, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C7
     ld   l, b
     ldd  [hl], a
     cp   $0C
@@ -11170,7 +11271,8 @@ label_2F45F::
     ld   h, $83
     rlca
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, label_1229
     xor  a
     add  a, e
@@ -11224,7 +11326,8 @@ label_2F47A::
     ld   [label_926], sp
     nop
     add  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $21
     ld   [de], a
     add  hl, hl
     add  a, d
@@ -11336,7 +11439,8 @@ label_2F514::
     nop
     ld   a, c
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   de, $0129
     dec  h
     ld   [label_1826], sp
@@ -11655,7 +11759,8 @@ label_2F65F::
     dec  b
     dec  c
     add  a, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $21
     ld   d, $26
     rla
     dec  c
@@ -11714,7 +11819,8 @@ label_2F6D3::
     nop
     inc  bc
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     adc  a, d
     jr   nz, label_2F6FD
     adc  a, d
@@ -11770,7 +11876,8 @@ label_2F700::
     adc  a, d
     nop
     ld   h, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $61
     jr   nz, label_2F795
     adc  a, d
     ld   [hl], b
@@ -12374,7 +12481,8 @@ label_2F990::
     dec  b
     add  hl, hl
     ld   b, $25
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     ld   de, label_1225
     add  hl, hl
 
@@ -12445,7 +12553,8 @@ label_2FA29::
     ld   bc, label_825
     ld   h, $09
     rst  $18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     ld   de, label_1823
     inc  h
     add  hl, de
@@ -12633,7 +12742,8 @@ label_2FAE8::
     cp   $05
     sub  a, b
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7B
     adc  a, b
     ldi  [hl], a
     ld   a, b
@@ -12775,7 +12885,8 @@ label_2FB91::
     add  hl, bc
     nop
     add  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $21
     ld   [de], a
     add  hl, hl
     add  a, d
@@ -12891,7 +13002,8 @@ label_2FBFF::
     dec  c
     inc  bc
     rst  $18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0D
     ld   de, label_12DF
     dec  h
     inc  de
@@ -12981,7 +13093,8 @@ label_2FC88::
     jr   c, label_2FCC4
     call nz, label_2448
     add  a, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $05
     add  a, e
     jr   nz, label_2FCC2
     add  a, h
@@ -13112,7 +13225,8 @@ label_2FD2A::
 
 label_2FD2C::
     ld   [$82DF], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     ld   [de], a
     dec  h
     add  a, e

--- a/src/disassembled-banks/Bank11.asm
+++ b/src/disassembled-banks/Bank11.asm
@@ -163,7 +163,7 @@ label_2C083::
     ld   d, e
     cp   e
     ld   d, e
-    jp   [hl]
+    jp   hl
     ld   d, e
     inc  h
     ld   d, h
@@ -394,7 +394,7 @@ label_2C186::
     ld   [hl], d
     and  b
     ld   [hl], d
-    jp   [hl]
+    jp   hl
     ld   [hl], d
     ld   a, [de]
     ld   [hl], e
@@ -464,7 +464,7 @@ label_2C1D8::
     ld   h, $7C
     adc  a, e
     ld   a, h
-    jp   [hl]
+    jp   hl
     ld   a, h
     inc  e
     ld   a, l
@@ -5592,7 +5592,7 @@ label_2DA32::
     dec  [hl]
     db   $E8 ; add  sp, d
     ld   b, h
-    jp   [hl]
+    jp   hl
     ld   b, l
     ld   [label_4FE], a
     rrca
@@ -7708,7 +7708,7 @@ label_2E431::
     ld   d, [hl]
     set  4, b
     nop
-    jp   [hl]
+    jp   hl
     ld   l, b
 
 label_2E437::

--- a/src/disassembled-banks/Bank12.asm
+++ b/src/disassembled-banks/Bank12.asm
@@ -14,7 +14,8 @@ label_30007::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
     jr   label_3002E
     dec  c
     rla
@@ -355,7 +356,8 @@ label_3012F::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     nop
@@ -663,7 +665,8 @@ label_302CA::
     ld   e, e
     ld   a, a
     jr   nz, label_3030D
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     nop
     nop
     nop
@@ -880,7 +883,8 @@ label_303BD::
     ld   [rLCDC], a
     ld   [hl], b
     jr   nz, label_303EF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     nop
     nop
     nop
@@ -1001,7 +1005,8 @@ label_303EF::
     rrca
     rrca
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     daa
     ccf
     jr   z, label_30488
@@ -1018,7 +1023,8 @@ label_303EF::
     jr   c, label_30496
     cpl
     inc  e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     rrca
     nop
     nop
@@ -1041,7 +1047,8 @@ label_3046F::
     jr   c, label_3046F
     db   $E8 ; add  sp, d
     ld   [hl], b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [rJOYP], a
     nop
     nop
@@ -1229,7 +1236,8 @@ label_3051B::
     ld   [label_1916], sp
     add  hl, de
     ld   d, $1F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     add  hl, de
     add  hl, de
     ld   d, $0F
@@ -1300,7 +1308,8 @@ label_3051B::
     ld    hl, sp+$38
     sub  a, b
     ld   [hl], b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [$FFE0], a
     ret  nz
     ld   b, b
@@ -1655,7 +1664,8 @@ label_30715::
     inc  b
     ld   [label_100B], sp
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $07
     stop
     nop
     nop
@@ -1664,13 +1674,17 @@ label_30715::
     nop
     nop
     ld   [rNR41], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D0
     ld   [label_8E0], sp
     ld   [$FF08], a
     rlca
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $07
+    db   $10
+    db   $0B
+    db   $10
+    db   $04
     ld   [label_700], sp
     nop
     nop
@@ -1978,7 +1992,8 @@ label_30878::
     ld   [hl], $3E
     ld   [label_808], sp
     ld   [label_1010], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [label_1C08], sp
     inc  e
     db   $3A ; ldd  a, [hl]
@@ -2381,7 +2396,8 @@ label_30A40::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   c, label_30A8E
     ld   a, h
     ld   b, h
@@ -2396,7 +2412,8 @@ label_30A40::
     ld   a, h
     ld   b, h
     jr   c, label_30AA4
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     nop
@@ -2427,7 +2444,8 @@ label_30A8E::
     add  a, $54
     ld   l, h
     jr   z, label_30AD6
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     nop
@@ -2446,7 +2464,8 @@ label_30AA4::
     ld   b, b
     ld   a, a
     jr   nz, label_30AF1
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     ld   [label_40F], sp
     rlca
     ld   [bc], a
@@ -2959,7 +2978,8 @@ label_30C80::
     ld   d, d
     inc  a
     inc  a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   label_30CD8
     nop
     nop
@@ -3002,7 +3022,8 @@ label_30CDF::
     ld   d, b
     ld   h, h
     jr   nz, label_30D26
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     rrca
@@ -3301,7 +3322,8 @@ label_30E41::
     daa
     ld   [hl], e
     jr   nz, label_30E41
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FC
     inc  c
     ld   a, a
     inc  bc
@@ -3315,7 +3337,8 @@ label_30E41::
     call c, label_1E10
 
 label_30E59::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3E
     jr   nz, label_30E59
     ret  nz
     ld    hl, sp+$00
@@ -5451,7 +5474,8 @@ label_31806::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
     jr   label_3182E
     dec  c
     rla
@@ -5578,7 +5602,8 @@ label_3188F::
     rrca
     ld   bc, $001F
     ld   [rJOYP], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ret  z
     ld   a, [$FF24]
 
@@ -5696,7 +5721,8 @@ label_318FD::
     nop
     ld   h, b
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     adc  a, b
     ld   [hl], b
     call nz, label_C4B8
@@ -5751,7 +5777,8 @@ label_318FD::
     nop
     ld   h, b
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
 
 label_31968::
     adc  a, b
@@ -5787,12 +5814,14 @@ label_31968::
     cpl
     ld   e, a
     jr   nz, label_319C0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
     dec  de
     scf
     rrca
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   c, $1F
     nop
     ccf
@@ -5810,7 +5839,8 @@ label_31968::
     cp   h
     ret  nc
     db   $EC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DE
     inc  l
     sbc  a, $6C
     cp   h
@@ -5921,7 +5951,8 @@ label_31A19::
     or   b
     ret  nc
     ld   [$FFE8], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $48
 
 label_31A37::
     or   b
@@ -6052,9 +6083,11 @@ label_31ABD::
     inc  bc
     inc  de
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6F
     ld   e, $F7
     ld   c, $7F
     nop
@@ -6089,7 +6122,8 @@ label_31ABD::
     ld   c, b
     or   b
     db   $E8 ; add  sp, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   h, b
     ld   a, [$FFC0]
     ld    hl, sp+$00
@@ -6130,7 +6164,8 @@ label_31B27::
     cp   b
     ret  nz
     db   $E8 ; add  sp, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     ret  nc
     ld   c, b
     or   b
@@ -6314,11 +6349,14 @@ label_31C06::
     ld   [label_1907], sp
     rlca
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     rla
     ccf
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
+    db   $10
+    db   $3F
     inc  b
     cpl
     dec  d
@@ -6344,7 +6382,8 @@ label_31C06::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
     jr   label_31C63
     dec  c
     ld   [hl], $0D
@@ -6691,7 +6730,8 @@ label_31D76::
     add  a, b
     jr   nz, label_31D76
     ld   a, [$FFE0]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [rJOYP], a
     ld   [$FFC0], a
     ld   a, [$FF00]
@@ -6780,7 +6820,8 @@ label_31E1D::
     ld   b, $1F
     ld   b, $2F
     ld   d, $2F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     ld   d, $27
     jr   label_31E47
     rrca
@@ -6942,7 +6983,8 @@ label_31EE2::
     inc  a
     inc  de
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3B
     inc  d
     sbc  a, a
     add  a, e
@@ -6962,8 +7004,10 @@ label_31EE2::
     dec  sp
     inc  b
     cpl
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
+    db   $10
+    db   $2F
     dec  d
     cpl
 
@@ -6997,7 +7041,8 @@ label_31F25::
     db   $F4 ; Undefined instruction
     xor  b
     call nc, label_E8E8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   a, [$FFE8]
     ld   a, [$FF78]
     add  a, b
@@ -7183,7 +7228,8 @@ label_31FFD::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $67
     jr   label_3200E
     ld   c, l
     rst  $30
@@ -7211,7 +7257,8 @@ label_32026::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
 
 label_3202D::
     jr   label_3202E
@@ -7251,7 +7298,8 @@ label_32048::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
     jr   label_320D0
     nop
     ld   a, a
@@ -7296,7 +7344,8 @@ label_32048::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
 
 label_3208F::
     nop
@@ -7352,7 +7401,8 @@ label_320C8::
     ccf
     inc  d
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   b, b
 
 label_320D0::
@@ -7726,7 +7776,8 @@ label_3222D::
     inc  [hl]
     ld   a, l
     ld   b, $3F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     rra
     scf
     inc  e
@@ -8148,7 +8199,8 @@ label_3246A::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $67
     ld   e, b
     ld   a, a
     ld   l, l
@@ -8362,7 +8414,8 @@ label_32532::
     nop
     nop
     ld   [rJOYP], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ret  z
     ld   a, [$FF24]
     ret  c
@@ -8934,8 +8987,10 @@ label_32807::
     nop
     rra
     rrca
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     stop
     nop
     nop
@@ -8950,10 +9005,14 @@ label_32807::
     ld    hl, sp+$04
     ld    hl, sp+$04
     rrca
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     stop
     rra
     nop
@@ -8978,10 +9037,14 @@ label_32807::
     rra
     rrca
     rra
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
     stop
     nop
     nop
@@ -8998,11 +9061,15 @@ label_32807::
     db   $FC ; Undefined instruction
     inc  b
     rra
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     rra
     rra
     nop
@@ -9028,13 +9095,20 @@ label_32807::
     rra
     rrca
     rra
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $FC
     ld    hl, sp+$FC
     inc  b
     db   $FC ; Undefined instruction
@@ -9049,11 +9123,16 @@ label_32807::
     inc  b
     db   $FC ; Undefined instruction
     inc  b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
     rra
     rra
     nop
@@ -10204,7 +10283,8 @@ label_32D53::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   l, h
     ld   l, h
     ld   l, h
@@ -10259,7 +10339,8 @@ label_32D53::
     jp   label_33E81
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   z, label_32DDE
     ld   l, h
     ld   l, h
@@ -10313,7 +10394,8 @@ label_32DDE::
     add  a, c
     cp   l
     ld   b, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   z, label_32E1C
     jr   z, label_32E1E
     ld   l, h
@@ -10666,7 +10748,8 @@ label_32F2D::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     jr   label_32F79
     nop
     rst  $38
@@ -10771,7 +10854,8 @@ label_32F9D::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     jr   label_32FE9
     nop
     rst  $38
@@ -11638,7 +11722,8 @@ label_3334D::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   l, h
     ld   l, h
     ld   l, h
@@ -11694,7 +11779,8 @@ label_3334D::
     jp   label_33E81
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   z, label_333DE
     ld   l, h
     ld   l, h
@@ -11752,7 +11838,8 @@ label_333DE::
     add  a, c
     cp   l
     ld   b, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   z, label_3341C
     jr   z, label_3341E
     ld   l, h
@@ -13829,7 +13916,8 @@ label_33C01::
     ret  nz
     rra
     jr   nz, label_33CDE
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     rst  $38
     cp   [hl]
     pop  bc
@@ -14062,7 +14150,8 @@ label_33D94::
     rrca
     sub  a, b
     dec  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nc, label_33DD6
     ld   a, [$FF0D]
     ld   [$FF3F], a

--- a/src/disassembled-banks/Bank12.asm
+++ b/src/disassembled-banks/Bank12.asm
@@ -3173,7 +3173,7 @@ label_30D77::
     ld   e, h
     ld   e, h
     ld   a, [$FF00+C]
-    jp   [hl]
+    jp   hl
     xor  c
     push hl
     dec  h
@@ -4302,9 +4302,9 @@ label_31279::
     ld   sp, hl
     rst  $28
     rst  $38
-    jp   [hl]
+    jp   hl
     rst  $38
-    jp   [hl]
+    jp   hl
     rst  $38
     rst  $38
     nop
@@ -4509,7 +4509,7 @@ label_313B2::
     rst  $38
     nop
     rst  $38
-    jp   [hl]
+    jp   hl
     rra
     add  hl, bc
     db   $FD ; Undefined instruction
@@ -12282,7 +12282,7 @@ label_334AD::
     rlca
     dec  de
     inc  bc
-    jp   [hl]
+    jp   hl
     ld   bc, label_5F3
     di
     dec  h
@@ -12363,7 +12363,7 @@ label_334AD::
     inc  bc
     push af
     dec  c
-    jp   [hl]
+    jp   hl
     rla
     dec  de
     db   $DB

--- a/src/disassembled-banks/Bank13.asm
+++ b/src/disassembled-banks/Bank13.asm
@@ -3566,7 +3566,7 @@ label_34FE9::
     dec  b
     dec  b
     ld   sp, hl
-    jp   [hl]
+    jp   hl
     inc  de
     ld   de, label_317
     rst  8
@@ -4912,7 +4912,7 @@ label_35570::
     dec  b
     dec  b
     ld   sp, hl
-    jp   [hl]
+    jp   hl
     inc  de
     ld   de, label_317
     rst  8
@@ -5790,7 +5790,7 @@ label_359EB::
     dec  b
     dec  b
     ld   sp, hl
-    jp   [hl]
+    jp   hl
     inc  de
     ld   de, label_317
     rst  8
@@ -6644,7 +6644,7 @@ label_35C70::
     dec  b
     dec  b
     ld   sp, hl
-    jp   [hl]
+    jp   hl
     inc  de
     ld   de, label_317
     rst  8
@@ -8068,7 +8068,7 @@ label_3646F::
     ld   b, h
     ld   sp, hl
     inc  b
-    jp   [hl]
+    jp   hl
     inc  d
     ld   a, c
     add  a, h
@@ -8621,7 +8621,7 @@ label_366FF::
     dec  b
     dec  b
     ld   sp, hl
-    jp   [hl]
+    jp   hl
     inc  de
     ld   de, label_317
     rst  8
@@ -10646,7 +10646,7 @@ label_36FFF::
     sbc  a, a
     rst  $10
     rrca
-    jp   [hl]
+    jp   hl
     rlca
     rrca
     rst  $38
@@ -10753,7 +10753,7 @@ label_36FFF::
     cp   a
     add  hl, sp
     rst  $28
-    jp   [hl]
+    jp   hl
     rrca
     add  hl, bc
     rst  $38
@@ -12339,7 +12339,7 @@ label_3778E::
     sbc  a, a
     rst  $10
     rrca
-    jp   [hl]
+    jp   hl
     rlca
     nop
     rst  $38
@@ -12507,7 +12507,7 @@ label_3784F::
     rrca
     dec  bc
     rlca
-    jp   [hl]
+    jp   hl
     rlca
     ld   a, c
     add  a, a
@@ -12534,7 +12534,7 @@ label_3784F::
     rrca
     dec  bc
     rlca
-    jp   [hl]
+    jp   hl
     rlca
     ld   a, c
     add  a, a
@@ -13823,7 +13823,7 @@ label_37E3F::
     ld   e, $11
     inc  l
     set  1, [hl]
-    jp   [hl]
+    jp   hl
     xor  $E9
     db   $E8 ; add  sp, d
     rst  $28
@@ -14135,7 +14135,7 @@ label_37F77::
     xor  l
     db   $DB
     rst  $18
-    jp   [hl]
+    jp   hl
     rst  $18
     rst  $20
     cpl

--- a/src/disassembled-banks/Bank13.asm
+++ b/src/disassembled-banks/Bank13.asm
@@ -511,12 +511,18 @@ label_3413E::
     rst  $38
     rra
     nop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     rst  $38
     rst  $38
     rst  $38
@@ -719,11 +725,16 @@ label_3413E::
     ld   bc, $0101
     ld   bc, $0101
     ld   bc, label_F10
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     rra
     nop
     rst  $38
@@ -1185,7 +1196,8 @@ label_344FF::
     rst  $10
     jr   c, label_344F6
     ld   a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   c, label_34567
     ld   a, h
     rst  $38
@@ -2274,7 +2286,8 @@ label_34A32::
     nop
     nop
     jr   label_34A49
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [$C007], sp
     rlca
     and  b
@@ -2317,7 +2330,8 @@ label_34A49::
 
 label_34A77::
     jp   nz, label_E003
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [label_18F0], sp
     ld   [rJOYP], a
     nop
@@ -2330,7 +2344,8 @@ label_34A77::
     ld   a, e
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   [bc], a
     rst  $38
     rst  $38
@@ -2568,7 +2583,8 @@ label_34ACB::
     rst  $38
     ld   [bc], a
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     add  a, h
@@ -2731,7 +2747,8 @@ label_34C36::
     inc  c
     ld   [label_101B], sp
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     stop
     nop
     nop
@@ -2745,7 +2762,8 @@ label_34C36::
     db   $E8 ; add  sp, d
     ld   [label_1017], sp
     dec  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
     jr   label_34C6F
     rrca
     rlca
@@ -2763,7 +2781,8 @@ label_34C6F::
     db   $E8 ; add  sp, d
     ld   [label_8D8], sp
     jr   z, label_34C8E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [$FFE0], a
     nop
     nop
@@ -2859,7 +2878,8 @@ label_34CCB::
 
 label_34CD4::
     inc  l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D0
     inc  h
     jr   nz, label_34CA1
     add  hl, hl
@@ -2868,7 +2888,8 @@ label_34CD4::
     ld   l, l
     ld   [de], a
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $AE
     ld   de, label_102F
     ld   b, a
     jr   c, label_34C83
@@ -2921,7 +2942,8 @@ label_34D12::
     add  a, b
     nop
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   h, b
     nop
     nop
@@ -2967,7 +2989,8 @@ label_34D42::
     inc  c
     ld   [label_101B], sp
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     stop
     nop
     nop
@@ -2981,7 +3004,8 @@ label_34D42::
     db   $E8 ; add  sp, d
     ld   [label_1017], sp
     dec  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
     jr   label_34D6F
     rrca
     rlca
@@ -2999,7 +3023,8 @@ label_34D6F::
     db   $E8 ; add  sp, d
     ld   [label_8D8], sp
     jr   z, label_34D8E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [$FFE0], a
     nop
     nop
@@ -3014,7 +3039,8 @@ label_34D6F::
 
 label_34D85::
     dec  h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $49
     jr   nz, label_34DDA
     nop
     ld   l, a
@@ -3187,7 +3213,8 @@ label_34E22::
     inc  c
     ld   [label_101B], sp
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     stop
     nop
     nop
@@ -3201,7 +3228,8 @@ label_34E22::
     db   $E8 ; add  sp, d
     ld   [label_1017], sp
     dec  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
     jr   label_34E6F
     rrca
     rlca
@@ -3219,7 +3247,8 @@ label_34E6F::
     db   $E8 ; add  sp, d
     ld   [label_8D8], sp
     jr   z, label_34E8E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [$FFE0], a
     nop
     nop
@@ -3403,7 +3432,8 @@ label_34F3A::
     inc  c
     ld   [label_101B], sp
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     stop
     nop
     nop
@@ -3417,7 +3447,8 @@ label_34F3A::
     db   $E8 ; add  sp, d
     ld   [label_1017], sp
     dec  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
     jr   label_34F6F
     rrca
     rlca
@@ -3435,7 +3466,8 @@ label_34F6F::
     db   $E8 ; add  sp, d
     ld   [label_8D8], sp
     jr   z, label_34F8E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [$FFE0], a
     nop
     nop
@@ -3516,7 +3548,8 @@ label_34FC4::
     ld   a, a
     inc  b
     ld    hl, sp+$A8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EA
     stop
     db   $FC ; Undefined instruction
     nop
@@ -3534,7 +3567,8 @@ label_34FE9::
     nop
     ld   b, h
     add  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $82
     ld   b, h
     add  a, d
     nop
@@ -3851,7 +3885,8 @@ label_3514F::
     inc  h
     db   $DB
     jr   label_3514F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     jr   nz, label_3514B
     ld   b, b
     cp   a
@@ -5564,7 +5599,8 @@ label_35570::
     ret  nz
     jr   nz, label_35934
     ld   d, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A8
     ld   [$A414], sp
     ld   a, [bc]
     or   d
@@ -5837,7 +5873,8 @@ label_359EB::
     ret  nz
     jr   nz, label_35A74
     ld   d, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A8
     ld   [$A414], sp
     ld   a, [bc]
     or   d
@@ -6376,7 +6413,8 @@ label_35C70::
     ret  nz
     jr   nz, label_35CF4
     ld   d, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A8
     ld   [$A414], sp
     ld   a, [bc]
     or   d
@@ -6592,7 +6630,8 @@ label_35C70::
     ret  nz
     jr   nz, label_35DF4
     ld   d, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A8
     ld   [$A414], sp
     ld   a, [bc]
     or   d
@@ -6686,8 +6725,10 @@ label_35C70::
     nop
     rra
     rrca
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     stop
     nop
     nop
@@ -6702,10 +6743,14 @@ label_35C70::
     ld    hl, sp+$04
     ld    hl, sp+$04
     rrca
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     stop
     rra
     nop
@@ -6726,13 +6771,20 @@ label_35C70::
     rra
     rrca
     rra
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $FC
     ld    hl, sp+$FC
     inc  b
     db   $FC ; Undefined instruction
@@ -6747,11 +6799,16 @@ label_35C70::
     inc  b
     db   $FC ; Undefined instruction
     inc  b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
     rra
     rra
     nop
@@ -6833,7 +6890,8 @@ label_35C70::
     cp   $0F
     rrca
     ld   [de], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $22
     jr   nz, label_35F4A
     ld   b, a
     ld   [hl], a
@@ -7120,7 +7178,8 @@ label_3602D::
     inc  c
     ld   [label_101B], sp
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     stop
     nop
     nop
@@ -7134,7 +7193,8 @@ label_3602D::
     db   $E8 ; add  sp, d
     ld   [label_1017], sp
     dec  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
     jr   label_3606F
     rrca
     rlca
@@ -7152,7 +7212,8 @@ label_3606F::
     db   $E8 ; add  sp, d
     ld   [label_8D8], sp
     jr   z, label_3608E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [$FFE0], a
     nop
     nop
@@ -7178,7 +7239,8 @@ label_3608E::
     ld   a, [$FF0F]
     or   $0F
     or   $0F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     rra
     ld   [$FF67], a
     sbc  a, b
@@ -7220,7 +7282,8 @@ label_3608E::
     ld   a, a
     jr   label_360F6
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $09
     ld   a, [$FF84]
     ld   b, b
     ld   [bc], a
@@ -7328,7 +7391,8 @@ label_36125::
     inc  c
     ld   [label_101B], sp
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     stop
     nop
     nop
@@ -7342,7 +7406,8 @@ label_36125::
     db   $E8 ; add  sp, d
     ld   [label_1017], sp
     dec  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
     jr   label_3616F
     rrca
     rlca
@@ -7360,7 +7425,8 @@ label_3616F::
     db   $E8 ; add  sp, d
     ld   [label_8D8], sp
     jr   z, label_3618E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [$FFE0], a
     nop
     nop
@@ -7554,7 +7620,8 @@ label_3623A::
     inc  c
     ld   [label_101B], sp
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     stop
     nop
     nop
@@ -7568,7 +7635,8 @@ label_3623A::
     db   $E8 ; add  sp, d
     ld   [label_1017], sp
     dec  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
     jr   label_3626F
     rrca
     rlca
@@ -7588,7 +7656,8 @@ label_3626F::
 
 label_36274::
     jr   z, label_3628E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [$FFE0], a
     nop
     nop
@@ -7684,7 +7753,8 @@ label_362CB::
     nop
     ldd  [hl], a
     inc  h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $06
     ld   a, [$FF0A]
     ld   a, [$FF44]
     jr   c, label_36319
@@ -7696,7 +7766,8 @@ label_362CB::
     ld   b, h
     dec  d
     ldi  [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
     ld   e, d
     inc  h
     nop
@@ -7798,7 +7869,8 @@ label_3631C::
     inc  c
     ld   [label_101B], sp
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     stop
     nop
     nop
@@ -7812,7 +7884,8 @@ label_3631C::
     db   $E8 ; add  sp, d
     ld   [label_1017], sp
     dec  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
 
 label_36365::
     jr   label_3636F
@@ -7832,7 +7905,8 @@ label_3636F::
     db   $E8 ; add  sp, d
     ld   [label_8D8], sp
     jr   z, label_3638E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [$FFE0], a
     nop
     nop
@@ -8023,7 +8097,8 @@ label_36445::
     inc  c
     ld   [label_101B], sp
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     stop
     nop
     nop
@@ -8037,7 +8112,8 @@ label_36445::
     db   $E8 ; add  sp, d
     ld   [label_1017], sp
     dec  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
     jr   label_3646F
     rrca
     rlca
@@ -8055,7 +8131,8 @@ label_3646F::
     db   $E8 ; add  sp, d
     ld   [label_8D8], sp
     jr   z, label_3648E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [$FFE0], a
     nop
     nop
@@ -8093,7 +8170,8 @@ label_3648E::
     ld   a, a
     nop
     ld   l, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7E
     ld   bc, label_57A
 
 label_364A8::
@@ -8110,7 +8188,8 @@ label_364A8::
     ld   a, e
     inc  b
     ld   l, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     nop
     ld   a, a
     nop
@@ -8120,8 +8199,10 @@ label_364A8::
     adc  a, a
     ld   l, c
     sub  a, b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $60
     add  hl, bc
     jr   nc, label_36513
     add  hl, sp
@@ -8238,7 +8319,8 @@ label_3651D::
     inc  c
     ld   [label_101B], sp
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     stop
     nop
     nop
@@ -8252,7 +8334,8 @@ label_3651D::
     db   $E8 ; add  sp, d
     ld   [label_1017], sp
     dec  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
 
 label_36565::
     jr   label_3656F
@@ -8274,7 +8357,8 @@ label_3656F::
     db   $E8 ; add  sp, d
     ld   [label_8D8], sp
     jr   z, label_3658E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [$FFE0], a
     nop
     nop
@@ -8307,7 +8391,8 @@ label_3658E::
     ld   [hl], $40
     sbc  a, [hl]
     jr   nz, label_36569
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E6
     ld   [$00F6], sp
     ld   h, a
     ld   [label_473], sp
@@ -8456,7 +8541,8 @@ label_3663D::
     inc  c
     ld   [label_101B], sp
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     stop
     nop
     nop
@@ -8470,7 +8556,8 @@ label_3663D::
     db   $E8 ; add  sp, d
     ld   [label_1017], sp
     dec  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
     jr   label_3666F
     rrca
     rlca
@@ -8488,7 +8575,8 @@ label_3666F::
     db   $E8 ; add  sp, d
     ld   [label_8D8], sp
     jr   z, label_3668E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [$FFE0], a
     nop
     nop
@@ -8579,7 +8667,8 @@ label_3668E::
     adc  a, c
     rlca
     call nz, label_36809
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $48
     jr   nc, label_3671F
     ld   c, b
     jp   label_34304
@@ -9560,7 +9649,8 @@ label_36B32::
     inc  c
     ld   [label_101B], sp
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     stop
     nop
     nop
@@ -9574,7 +9664,8 @@ label_36B32::
     db   $E8 ; add  sp, d
     ld   [label_1017], sp
     dec  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
     jr   label_36B6F
     rrca
     rlca
@@ -9592,7 +9683,8 @@ label_36B6F::
     db   $E8 ; add  sp, d
     ld   [label_8D8], sp
     jr   z, label_36B8E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [$FFE0], a
     nop
     nop
@@ -9677,7 +9769,8 @@ label_36BB8::
     ld    hl, sp+$68
     sub  a, b
     xor  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $45
     ldi  [hl], a
     ld   b, l
     ldi  [hl], a
@@ -9694,7 +9787,8 @@ label_36BB8::
     ld   [bc], a
     add  a, c
     xor  h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $46
     jr   c, label_36B8E
     ld   h, [hl]
     jr   nz, label_36BB8
@@ -11181,7 +11275,8 @@ label_37292::
     sub  a, h
     ld   h, e
     jr   z, label_37261
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   h, [hl]
     sbc  a, c
     adc  a, d
@@ -12050,7 +12145,8 @@ label_37658::
     ld   a, h
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     inc  a
     jp   label_376FF
     rst  $38
@@ -12064,7 +12160,8 @@ label_37668::
     ld   a, h
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     inc  a
     jp   label_376FF
     rst  $38
@@ -12078,7 +12175,8 @@ label_37678::
     ld   a, h
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     inc  a
     jp   label_376FF
     rst  $38
@@ -12092,7 +12190,8 @@ label_37688::
     ld   a, h
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     inc  a
     jp   label_36FFF
     db   $FC ; Undefined instruction
@@ -13454,7 +13553,8 @@ label_37C81::
     sub  a, h
     ld   h, e
     jr   z, label_37C81
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   h, [hl]
     sbc  a, c
     adc  a, d
@@ -13847,7 +13947,8 @@ label_37E3F::
     jr   c, label_37ECD
     rst  $30
     jr   label_37E6F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     rst  $38
     rst  $38
     ld   a, a

--- a/src/disassembled-banks/Bank14.asm
+++ b/src/disassembled-banks/Bank14.asm
@@ -1657,7 +1657,7 @@ label_387AC::
     ld   d, l
     xor  e
     ld   d, h
-    jp   [hl]
+    jp   hl
     ld   d, [hl]
     cp   h
     ld   b, e

--- a/src/disassembled-banks/Bank14.asm
+++ b/src/disassembled-banks/Bank14.asm
@@ -85,7 +85,8 @@ section "bank14",romx,bank[$0E]
     rla
     ld   [label_1827], sp
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
     inc  e
     inc  hl
     inc  e
@@ -382,7 +383,8 @@ label_381C2::
     nop
     ld   [hl], c
     jr   nz, label_38206
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     inc  d
     rrca
@@ -399,7 +401,8 @@ label_381CE::
     rra
     nop
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6F
     jr   nc, label_381CE
     ld   b, c
     jp   label_101
@@ -497,7 +500,8 @@ label_3824E::
     ld   a, [hl]
     ld   bc, label_1C23
     jr   nz, label_38277
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   hl, label_231E
     inc  e
     ccf
@@ -624,7 +628,8 @@ label_38295::
     jr   label_3831A
     inc  de
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6F
     ld   d, $EF
     ld   d, b
     rst  $28
@@ -680,7 +685,8 @@ label_3831A::
     ld   [$FFB8], a
     ret  nc
     db   $FC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EE
     or   h
     rst  $38
     add  a, $DF
@@ -732,7 +738,8 @@ label_3831A::
     cp   $EC
     rst  $38
     cp   $EE
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DC
     ld   [$FFCC], a
 
 label_3836D::
@@ -1213,7 +1220,8 @@ label_3858B::
 label_385A5::
     add  a, b
     jr   nz, label_38568
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
 
 label_385AA::
     ld   [hl], b
@@ -1265,7 +1273,8 @@ label_385AA::
     ld   b, b
     add  a, b
     jr   nz, label_385AA
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [hl], b
     add  a, b
     ld   [$C8F0], sp
@@ -1343,7 +1352,8 @@ label_38617::
     nop
     ld   e, a
     jr   nz, label_38674
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     ccf
     nop
@@ -1740,7 +1750,8 @@ label_387AC::
     rla
     rrca
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
     rla
     rra
     ld   b, $1F
@@ -1871,8 +1882,10 @@ label_3887B::
     ld   [$FFF0], a
     ld   [$FFF0], a
     nop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     jr   nz, label_3887A
 
 label_388BA::
@@ -1919,7 +1932,8 @@ label_388BA::
     add  a, b
     sub  a, b
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     jr   nz, label_388BA
     ld   [rJOYP], a
     ld   a, [$FFE0]
@@ -1972,7 +1986,8 @@ label_388BA::
     ld   a, [$FF40]
     ld   a, b
     jr   nz, label_38975
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1C
     ld   [$0008], sp
     nop
     nop
@@ -2373,7 +2388,8 @@ label_38AE5::
     nop
     rrca
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  e
     inc  bc
     ld   a, $1D
@@ -2661,7 +2677,8 @@ label_38C3C::
     ccf
     ld   c, c
     ld   [hl], $EF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E6
     ld   e, c
     ld   [hl], b
 
@@ -2886,7 +2903,8 @@ label_38D48::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
     jr   label_38D90
     dec  c
     scf
@@ -3045,7 +3063,8 @@ label_38D48::
     scf
     jr   c, label_38E27
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     ld   [label_277F], sp
     ld   [hl], a
     jr   z, label_38E4C
@@ -3238,9 +3257,12 @@ label_38E9B::
     inc  bc
     add  hl, bc
     rlca
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     inc  c
     inc  bc
     inc  bc
@@ -3259,7 +3281,8 @@ label_38E9B::
     ld   l, $3F
 
 label_38F0B::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     dec  d
     ld   e, a
     dec  l
@@ -3294,7 +3317,8 @@ label_38F2B::
     ld   sp, hl
     and  $F9
     add  a, $EE
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7C
     ret  c
     cp   h
     ret  c
@@ -3315,7 +3339,8 @@ label_38F2B::
     jr   nz, label_38F6B
     jr   nc, label_38F5D
     jr   nz, label_38F6F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_38F73
     jr   nz, label_38F75
     jr   nc, label_38F67
@@ -3391,7 +3416,8 @@ label_38F7D::
     nop
     ld   h, b
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     inc  e
     ld   [rDIV], a
     ld    hl, sp+$74
@@ -3408,7 +3434,8 @@ label_38F7D::
     inc  e
     cp   h
     ld   b, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [$F8F0], sp
     nop
     nop
@@ -3446,7 +3473,8 @@ label_38F7D::
     nop
     ld   h, b
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     inc  e
     ld   [rDIV], a
     ld    hl, sp+$74
@@ -3828,7 +3856,8 @@ label_39174::
     rlca
     ld   [hl], a
     jr   label_391DC
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     inc  bc
     nop
@@ -3927,7 +3956,8 @@ label_391DC::
 
 label_39202::
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3B
     rla
 
 label_39206::
@@ -4489,9 +4519,12 @@ label_39375::
     ld   b, c
     ccf
     jr   nz, label_394B1
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     ld   sp, label_3BF0E
     ld   bc, $003F
     nop
@@ -4626,7 +4659,8 @@ label_39529::
     nop
     rrca
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_39565
     jr   nz, label_39567
     scf
@@ -4636,7 +4670,8 @@ label_39529::
     ld   e, a
     dec  [hl]
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     jr   label_39584
     rra
 
@@ -4749,7 +4784,8 @@ label_395C6::
     dec  [hl]
     nop
     dec  a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     dec  d
     scf
     dec  e
@@ -4868,8 +4904,10 @@ label_3961D::
     ld   c, b
     scf
     jr   nc, label_39663
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     inc  e
     inc  bc
     rra
@@ -4920,7 +4958,8 @@ label_39663::
     inc  de
     inc  l
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     rrca
     nop
     rrca
@@ -5237,8 +5276,10 @@ label_39806::
     inc  de
     inc  c
     cpl
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
+    db   $10
+    db   $5E
     ld   hl, label_235D
     ld   e, l
     inc  hl
@@ -5318,8 +5359,10 @@ label_39846::
     inc  de
     inc  c
     cpl
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
+    db   $10
+    db   $7E
     ld   bc, label_337D
     db   $FD ; Undefined instruction
     ld   a, e
@@ -5585,7 +5628,8 @@ label_39996::
     ld   d, b
     cpl
     ld   l, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $33
     rrca
     rra
     nop
@@ -5696,8 +5740,10 @@ label_39A10::
     ret  nz
     nop
     jr   nz, label_399E4
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
 
 label_39A28::
     call c, label_FE20
@@ -5760,7 +5806,8 @@ label_39A57::
     ld   [$FF88], a
     ld   a, [$FF08]
     ld   a, [$FFE8]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     ld   b, b
     rst  $38
     ld   b, $3D
@@ -6258,7 +6305,8 @@ label_39C6D::
     ld   l, e
     ld   a, a
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     rra
     nop
     nop
@@ -6267,7 +6315,8 @@ label_39C6D::
     nop
     and  b
     ret  nz
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [label_38F0], sp
     ret  nz
     inc  b
@@ -6312,7 +6361,8 @@ label_39C6D::
     nop
     and  b
     ret  nz
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [label_38F0], sp
     ret  nz
     inc  b
@@ -6444,8 +6494,10 @@ label_39CFD::
     ld   a, a
     nop
     ld   a, a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
+    db   $10
+    db   $7F
     jr   label_39DD6
     ld   [$003F], sp
     ld   d, a
@@ -6803,10 +6855,14 @@ label_39EFF::
     ld   b, c
     ccf
     jr   nz, label_39F71
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     rrca
     nop
     nop
@@ -7173,7 +7229,8 @@ label_3A06D::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [de], a
     ld   [de], a
     inc  e
@@ -7696,7 +7753,8 @@ label_3A33A::
     ld   b, h
     cp   b
     call nz, label_E838
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $BF
     ld   h, b
     ld   a, a
     jr   label_3A3A4
@@ -7891,7 +7949,8 @@ label_3A3A8::
     nop
     ld   a, a
     jr   nz, label_3A4A8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   d, b
     rst  $38
 
@@ -8264,7 +8323,8 @@ label_3A571::
     ld   a, h
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jp   label_A7FF
     rst  $38
     push hl
@@ -8714,11 +8774,16 @@ label_3A7AE::
     ret  nz
     nop
     jr   nz, label_3A7AE
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     jr   nc, label_3A7BA
     ld   [hl], b
     add  a, b
@@ -8739,7 +8804,8 @@ label_3A7AE::
     di
     inc  c
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     add  a, b
@@ -8969,7 +9035,8 @@ label_3A900::
     nop
     stop
     inc  a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3E
     inc  e
     rst  $38
     ld   c, $FF
@@ -9685,7 +9752,8 @@ label_3ABED::
     ld   [rJOYP], a
     ld   a, [$FF60]
     ld   a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1C
     ld   [label_40E], sp
     ld   c, $04
     rrca
@@ -9727,7 +9795,8 @@ label_3ABED::
     ld   [$FFBF], a
     rrca
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     jr   z, label_3ACA5
     ld   d, e
     ld   a, a
@@ -9862,8 +9931,10 @@ label_3ACD2::
     ld   e, $60
     sbc  a, a
     jr   nc, label_3ACC7
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
+    db   $10
+    db   $EF
     sbc  a, c
     ld   h, [hl]
     rst  $38
@@ -9951,7 +10022,8 @@ label_3AD42::
     adc  a, h
     rst  $38
     jr   nz, label_3AD42
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [label_9F8], sp
     ld   sp, hl
     ld   b, $FF
@@ -10021,7 +10093,8 @@ label_3AD42::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   nz, label_3ADC3
     ret  nz
     rst  $38
@@ -11173,11 +11246,13 @@ label_3B23D::
     nop
     rrca
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_3B2E9
     daa
     jr   label_3B2FC
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     nop
     ccf
     nop
@@ -11287,7 +11362,8 @@ label_3B334::
     ld   b, b
     ld   c, h
     jr   nz, label_3B35F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     ld   [$0000], sp
     nop
     nop
@@ -11306,7 +11382,8 @@ label_3B334::
     rlca
     nop
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
     ld   [label_204], sp
     ld   [bc], a
     ld   bc, $0001
@@ -11419,7 +11496,8 @@ label_3B3AC::
     nop
     inc  c
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $07
     nop
     ld   [$0007], sp
     ld   [$0000], sp
@@ -11483,7 +11561,8 @@ label_3B409::
     ld   bc, label_304
     ld   [label_1006], sp
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0B
     ld   hl, label_2316
     inc  d
     ld   b, a
@@ -11588,10 +11667,12 @@ label_3B459::
     ld   [bc], a
     ld   [label_806], sp
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
 
 label_3B498::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $09
     jr   nc, label_3B4A7
     ld   sp, label_330E
     inc  c
@@ -11886,7 +11967,8 @@ label_3B59E::
     inc  bc
     inc  b
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     inc  h
     jr   nc, label_3B614
     jr   nz, label_3B59E
@@ -12342,7 +12424,8 @@ label_3B7CF::
     ld   a, h
     db   $FC ; Undefined instruction
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     jr   nz, label_3B79A
     ld   b, b
     add  a, b
@@ -12880,7 +12963,8 @@ label_3BA05::
     stop
     jr   c, label_3BA34
     add  hl, sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3B
     ld   de, label_193
     add  a, a
     inc  bc
@@ -13135,7 +13219,8 @@ label_3BB41::
     rlca
     inc  d
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     nop
     nop
     nop
@@ -13172,7 +13257,8 @@ label_3BB8A::
     ld   c, [hl]
     add  hl, sp
     ld   h, $1D
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  a
     inc  bc
     ld   a, a
@@ -13362,10 +13448,12 @@ label_3BC3D::
     rrca
     ccf
     jr   label_3BCA8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     dec  de
     ld   e, $07
     ccf
@@ -14009,7 +14097,8 @@ label_3BF53::
     ld   h, b
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     jr   nc, label_3BF53
 
 label_3BF65::

--- a/src/disassembled-banks/Bank15.asm
+++ b/src/disassembled-banks/Bank15.asm
@@ -971,7 +971,8 @@ label_3C3FF::
     nop
     rst  $38
     jr   nc, label_3C426
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   label_3C42A
     sbc  a, b
     rst  $38
@@ -2228,7 +2229,8 @@ label_3C910::
     adc  a, $FF
     ld   d, e
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     sub  a, e
     rst  $38
     ld   de, label_3D1FF
@@ -2501,7 +2503,8 @@ label_3CAB1::
     db   $E8 ; add  sp, d
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [hl], b
     rst  $38
     ld   a, [$FF3F]
@@ -3538,12 +3541,15 @@ label_3CF4C::
 
 label_3CF80::
     ld   [rIE], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     ld   [rIE], a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
     ld   [rIE], a
     nop
     rst  $38
@@ -3596,9 +3602,11 @@ label_3CF80::
     rst  $38
     sub  a, b
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   e, $FF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     sub  a, b
     rst  $38
     ld   e, a
@@ -7071,7 +7079,8 @@ label_3DE17::
 label_3DE21::
     rst  $38
     ld   a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F9
     jr   nz, label_3DE17
     ld   [$FF1F], a
     ld   d, b
@@ -7154,7 +7163,8 @@ label_3DE77::
     ld   a, $FF
     rst  $38
     ld   a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F9
     jr   nz, label_3DE77
     ld   [$FF1F], a
     ld   d, b
@@ -7359,7 +7369,8 @@ label_3DF6A::
     inc  e
     db   $E8 ; add  sp, d
     ld   a, [$FF3E]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9E
     ld   [$B43C], sp
 
 label_3DF76::
@@ -7571,7 +7582,8 @@ label_3E010::
     nop
     adc  a, a
     ld   a, [$FFEF]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -7770,14 +7782,22 @@ label_3E146::
     dec  bc
     and  $09
     rst  0
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C7
+    db   $10
+    db   $A3
+    db   $10
+    db   $A3
+    db   $10
+    db   $A3
+    db   $10
+    db   $C7
+    db   $10
+    db   $C3
+    db   $10
+    db   $C3
+    db   $10
+    db   $C3
     ld   [label_8C3], sp
     db   $E3 ; Undefined instruction
     ld   [label_8C3], sp
@@ -8044,7 +8064,8 @@ label_3E259::
     ret  nc
     ld   [$FFA0], a
     sub  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
     rlca
     ld   [$C70D], a
     rlca
@@ -8091,7 +8112,8 @@ label_3E288::
     inc  de
     db   $E8 ; add  sp, d
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D7
 
 label_3E2B9::
     ld   [$C837], sp
@@ -8134,7 +8156,8 @@ label_3E2C4::
     jp   label_8604
     add  hl, bc
     adc  a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_3E30B
     ld   b, c
     inc  l
@@ -8207,8 +8230,10 @@ label_3E32D::
     ld   [hl], c
     rst  $38
     ld   de, label_1F10
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $0F
     rrca
     ld   [bc], a
     ld   bc, $0003
@@ -8239,7 +8264,8 @@ label_3E367::
     rlca
     ld   a, c
     ld   c, $FF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [$FFD8], a
     ld   [label_8F8], sp
     ld    hl, sp+$08
@@ -8432,7 +8458,8 @@ label_3E3FA::
     ld   [hl], b
     sub  a, c
     sub  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     sbc  a, h
     inc  e
     ld   a, a
@@ -8484,7 +8511,8 @@ label_3E486::
     ld   a, [hl]
     add  hl, hl
     add  hl, sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
 
 label_3E490::
     rst  $38
@@ -8662,7 +8690,8 @@ label_3E53A::
     db   $E4 ; Undefined instruction
     rrca
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [$FFE0], a
     jp   nz, label_C040
     ld   b, b
@@ -8694,7 +8723,8 @@ label_3E53A::
     db   $FD ; Undefined instruction
     rst  0
     ld   [de], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     jr   z, label_3E5C4
     daa
     ccf
@@ -9493,7 +9523,8 @@ label_3E8E4::
     ld   b, b
     rst  $18
     jr   nz, label_3E8E4
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
     ld   [label_14EB], sp
     db   $22
     ldi  [hl], a
@@ -10221,7 +10252,8 @@ label_3EB67::
     ei
     sbc  a, b
     ld   [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
     jr   nc, label_3EC38
     ld   d, b
     rst  $38
@@ -10319,7 +10351,8 @@ label_3EC91::
     nop
     jp   label_E3C0
     jr   nz, label_3ED2E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     inc  e
     or   a
     ld   d, h
@@ -10639,9 +10672,12 @@ label_3EE12::
     ret  nz
     ld   h, b
     jr   nz, label_3EE87
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
+    db   $10
+    db   $F0
+    db   $10
+    db   $D0
     jr   nc, label_3EE3F
     ld   [$FFF8], a
     sub  a, b
@@ -11581,7 +11617,8 @@ label_3F20D::
     jr   c, label_3F261
     jr   c, label_3F263
     jr   c, label_3F265
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     inc  b
     rst  $38
     rra
@@ -11700,7 +11737,8 @@ label_3F2D2::
     jr   c, label_3F2E1
     jr   c, label_3F2E3
     jr   c, label_3F2E5
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     ld   hl, label_3C3FE
@@ -11931,7 +11969,8 @@ label_3F3D2::
     rst  $38
     ld   [$00FF], sp
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     adc  a, h
     ld   a, a
     jp   nz, label_E23F
@@ -12048,7 +12087,8 @@ label_3F472::
     jr   nc, label_3F48C
     jr   c, label_3F487
     ld   a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $BF
     ld   d, b
     ccf
     ret  c
@@ -12861,7 +12901,8 @@ label_3F774::
 
 label_3F83A::
     or   b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   a, [$FF20]
     ld   h, b
     ld   bc, $0101
@@ -12995,7 +13036,8 @@ label_3F858::
     cp   b
     rrca
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   nz, label_3F906
     cpl
     jr   nz, label_3F928
@@ -13058,7 +13100,8 @@ label_3F906::
 
 label_3F928::
     ld   de, label_2608
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EA
     inc  d
     db   $EB ; Undefined instruction
     inc  [hl]
@@ -13081,8 +13124,10 @@ label_3F938::
     ld   d, $0C
     jr   label_3F94C
     inc  e
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $33
+    db   $10
+    db   $33
     jr   nz, label_3F988
     inc  hl
 
@@ -13121,7 +13166,8 @@ label_3F94C::
     add  a, b
     db   $E8 ; add  sp, d
     jr   nc, label_3F98B
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     ld   [label_4C4], sp
 
 label_3F978::
@@ -13346,7 +13392,8 @@ label_3FA46::
     add  a, d
     add  a, c
     add  a, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     pop  af
     ld   a, [$FF61]
     ld   h, b
@@ -13918,8 +13965,10 @@ label_3FD0E::
     ld   a, a
     jr   nz, label_3FD56
     jr   nz, label_3FD58
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
     ld   [label_80F], sp
     db   $FC ; Undefined instruction
     ld   a, [$FF30]
@@ -14387,10 +14436,14 @@ label_3FF10::
     rst  $38
     sub  a, d
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
     jr   c, label_3FF4C
     ld   bc, rIE
     and  l

--- a/src/disassembled-banks/Bank15.asm
+++ b/src/disassembled-banks/Bank15.asm
@@ -1304,7 +1304,7 @@ label_3C545::
     add  a, b
     nop
     ld   [rJOYP], a
-    jp   [hl]
+    jp   hl
     nop
     ld   a, l
     nop
@@ -1424,7 +1424,7 @@ label_3C545::
     inc  bc
     db   $E3 ; Undefined instruction
     inc  bc
-    jp   [hl]
+    jp   hl
     ld   a, [$FFE3]
     ret  nz
     rst  $28
@@ -2333,7 +2333,7 @@ label_3C910::
     inc  bc
     db   $E8 ; add  sp, d
     inc  bc
-    jp   [hl]
+    jp   hl
     rlca
     db   $EB ; Undefined instruction
     rlca
@@ -2376,7 +2376,7 @@ label_3CA32::
     di
     ld   h, h
     di
-    jp   [hl]
+    jp   hl
     ld    hl, sp+$1B
     ld   [$FF30], a
     ret  nz
@@ -3500,7 +3500,7 @@ label_3CF4C::
     rst  $38
     add  hl, bc
     rst  $38
-    jp   [hl]
+    jp   hl
     rst  $38
     nop
     rst  $38
@@ -5935,7 +5935,7 @@ label_3D927::
     ld   bc, $8387
     db   $EC ; Undefined instruction
     db   $E4 ; Undefined instruction
-    jp   [hl]
+    jp   hl
     ld   [$FFE3], a
     pop  hl
     rst  $20
@@ -7678,7 +7678,7 @@ label_3E0DE::
 
 label_3E0DF::
     nop
-    jp   [hl]
+    jp   hl
     jr   label_3E0CC
     jr   label_3E0D0
     jr   label_3E0DE
@@ -8013,7 +8013,7 @@ label_3E259::
     ld   sp, hl
     ld   a, $F8
     rst  $38
-    jp   [hl]
+    jp   hl
     rst  $38
     ld   b, [hl]
     pop  hl
@@ -9042,7 +9042,7 @@ label_3E6FF::
     sbc  a, a
     or   e
     or   e
-    jp   [hl]
+    jp   hl
     xor  c
     call nz, label_6C4
     ld   b, $05
@@ -9309,7 +9309,7 @@ label_3E7CF::
     db   $FC ; Undefined instruction
     rst  $38
     ld   a, [$FF00+C]
-    jp   [hl]
+    jp   hl
     di
     rla
     add  hl, de
@@ -10031,7 +10031,7 @@ label_3EB35::
     pop  hl
     pop  de
     pop  hl
-    jp   [hl]
+    jp   hl
     ld   sp, label_1F1F
     add  a, a
     add  a, d
@@ -11158,7 +11158,7 @@ label_3F042::
     rst  $38
     ld   a, c
     rst  $38
-    jp   [hl]
+    jp   hl
     rst  $18
     jr   label_3F092
     rst  $10
@@ -11481,7 +11481,7 @@ label_3F1BF::
     db   $FD ; Undefined instruction
     ld   c, c
     db   $FD ; Undefined instruction
-    jp   [hl]
+    jp   hl
     db   $FD ; Undefined instruction
     add  hl, sp
     rst  $38
@@ -13615,7 +13615,7 @@ label_3FB91::
     sbc  a, a
     rra
     ld   [rJOYP], a
-    jp   [hl]
+    jp   hl
     rst  $38
     ret
     ld   a, a

--- a/src/disassembled-banks/Bank16.asm
+++ b/src/disassembled-banks/Bank16.asm
@@ -239,7 +239,8 @@ label_400FE::
     rst  $38
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     rst  $28
     add  a, b
     ld   a, a
@@ -810,7 +811,8 @@ label_40348::
     ld   [$FFBF], a
     and  b
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld    hl, sp+$FF
     ld   b, $FF
     ld   bc, $00FF
@@ -845,7 +847,8 @@ label_403C0::
     stop
     cp   $40
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CF
     ld   [$00F7], sp
     rst  $38
     nop
@@ -1044,7 +1047,8 @@ label_4044E::
     jr   nz, label_4049E
 
 label_404BE::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     nop
     nop
     nop
@@ -1164,7 +1168,8 @@ label_40511::
     rlca
     ld   b, $06
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     nop
     ld   a, a
     nop
@@ -1219,7 +1224,8 @@ label_4055B::
     ld   [label_6FD], sp
     db   $FD ; Undefined instruction
     dec  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     adc  a, b
     ld   l, b
     ld   [label_878], sp
@@ -1543,7 +1549,8 @@ label_406A5::
     ld   sp, label_431DE
     sbc  a, [hl]
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     cp   $FF
     rst  $38
     rst  $38
@@ -1794,7 +1801,8 @@ label_407D6::
     rst  $38
     ccf
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     dec  e
     ld   sp, hl
     inc  c
@@ -2138,7 +2146,8 @@ label_4097E::
     ld   [$FFA4], a
     and  d
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     jr   label_409DC
     rrca
     rlca
@@ -2395,7 +2404,8 @@ label_40AD1::
     ld   b, h
     rst  $38
     jr   z, label_40AF8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_40AFC
     ld   b, h
     rst  $38
@@ -2540,7 +2550,8 @@ label_40B16::
     add  a, b
     add  a, b
     jr   label_40BA4
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     jp   label_8000
@@ -3015,8 +3026,10 @@ label_40DA3::
 
 label_40DA5::
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
+    db   $10
+    db   $01
 
 label_40DAB::
     jr   c, label_40DB0
@@ -3029,7 +3042,8 @@ label_40DAF::
     jr   label_40DAB
     jr   label_40DAD
     jr   label_40DAF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     jr   nc, label_40DAB
     jr   nc, label_40D9D
     jr   nz, label_40DAF
@@ -3490,7 +3504,8 @@ label_40F97::
     ld   b, h
     ld   b, h
     jr   z, label_40FE0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   z, label_40FE4
     ld   b, h
     ld   b, h
@@ -3567,7 +3582,8 @@ label_40FE4::
     rst  $38
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     rst  $28
     add  a, b
     ld   a, a
@@ -3675,7 +3691,8 @@ label_41052::
     rst  $38
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     rst  $28
     add  a, b
     ld   a, a
@@ -3785,7 +3802,8 @@ label_410C2::
     rst  $38
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     rst  $28
     add  a, b
     ld   a, a
@@ -3895,7 +3913,8 @@ label_410C2::
     rst  $38
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     rst  $28
     add  a, b
     ld   a, a
@@ -4556,13 +4575,15 @@ label_4144F::
     ld   [$FFC0], a
     ld   [$FFC0], a
     ld   [rJOYP], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
 
 label_4147E::
     ld   a, [$FF00]
     ld   bc, label_1E00
     ld   bc, label_F10
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   d, $09
     rrca
     ld   [bc], a
@@ -4772,7 +4793,8 @@ label_41577::
     ld   b, h
     ld   b, h
     jr   z, label_415B0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   z, label_415B4
     ld   b, h
     ld   b, h
@@ -4785,7 +4807,8 @@ label_41577::
     ld   b, h
     ld   b, h
     jr   z, label_415C0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   z, label_415C4
     ld   b, h
     ld   b, h
@@ -4798,7 +4821,8 @@ label_41577::
     ld   b, h
     ld   b, h
     jr   z, label_415D0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   z, label_415D4
     ld   b, h
     ld   b, h
@@ -4815,7 +4839,8 @@ label_415B4::
     ld   b, h
     ld   b, h
     jr   z, label_415E0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   z, label_415E4
     ld   b, h
     ld   b, h
@@ -5062,7 +5087,8 @@ label_416A0::
     ld   h, b
     jr   nz, label_416CA
     jr   nc, label_416DC
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   label_416C8
     ld   [label_C08], sp
     inc  c
@@ -6652,8 +6678,10 @@ label_41DD3::
     ret  nz
     nop
     jr   nz, label_41E31
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
     ld   [label_80F], sp
     rrca
     inc  b
@@ -7004,8 +7032,10 @@ label_41F90::
     ld   a, a
     jr   nz, label_41FD7
     jr   nz, label_41FD9
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
     ld   [$810F], sp
     add  a, c
     add  a, c
@@ -7175,7 +7205,8 @@ label_41FD9::
     db   $FC ; Undefined instruction
     rst  $38
     jr   nc, label_420D5
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     ret  nc
     ld   a, [$FF30]
     db   $F0
@@ -7643,9 +7674,12 @@ label_42235::
     jr   nc, label_42265
     jr   nc, label_42267
     jr   nc, label_42269
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
     ld   hl, label_21FF
     rst  $38
     rla
@@ -7686,10 +7720,14 @@ label_42235::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
     inc  de
     rst  $38
     sub  a, b
@@ -8095,7 +8133,8 @@ label_42466::
     jr   nc, label_42483
     sub  a, [hl]
     ld   bc, label_33C
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   c, label_42483
     rst  $38
     nop
@@ -8689,7 +8728,8 @@ label_426BE::
     jr   nz, label_4272B
     jr   nc, label_4271D
     jr   nz, label_4272F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_42733
     jr   nz, label_42735
     jr   nc, label_42727
@@ -8783,7 +8823,8 @@ label_42749::
     dec  bc
     dec  de
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [label_707], sp
     nop
     add  a, b
@@ -8805,7 +8846,8 @@ label_42749::
     inc  b
     ld    hl, sp+$F8
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [rJOYP], a
     nop
     nop
@@ -9200,7 +9242,8 @@ label_4292D::
     ld   a, [hl]
     jr   z, label_429C9
     jr   label_429CB
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_42952
     ld   l, d
     rst  $38
@@ -10035,7 +10078,8 @@ label_42CAE::
     ld   [de], a
     nop
     add  hl, hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
     stop
     nop
     nop
@@ -10406,7 +10450,8 @@ label_42E3F::
     inc  e
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     sub  a, $FF
     jr   nz, label_42EC4
     xor  [hl]
@@ -10525,7 +10570,8 @@ label_42EC4::
     inc  e
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     sub  a, $FF
     jr   nz, label_42F44
     xor  [hl]
@@ -10647,7 +10693,8 @@ label_42F5E::
     inc  e
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     sub  a, $FF
     jr   nz, label_42FC4
     xor  [hl]
@@ -10762,7 +10809,8 @@ label_42FC4::
     inc  e
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     sub  a, $FF
     jr   nz, label_43044
     xor  [hl]
@@ -10948,7 +10996,8 @@ label_430A8::
     db   $FD ; Undefined instruction
     push de
     jr   z, label_430A8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     nop
     rst  $38
@@ -11240,7 +11289,8 @@ label_431DE::
     sbc  a, d
     pop  af
     ld   c, $EF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     jr   nz, label_431BE
     ld   b, [hl]
     or   a
@@ -11679,7 +11729,8 @@ label_43406::
     rst  $38
     nop
     db   $EB ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D7
     jr   nz, label_4340C
     nop
     ld   e, a
@@ -11698,7 +11749,8 @@ label_43406::
     rst  $38
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
     nop
     rst  $38
     nop
@@ -11977,7 +12029,8 @@ label_43564::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $30
     nop
@@ -12057,7 +12110,8 @@ label_43582::
     rst  $38
     ld   [label_20F7], sp
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     inc  bc
     ld   a, h
     add  a, a
@@ -12127,7 +12181,8 @@ label_435E6::
     rst  $38
     ld   h, b
     sbc  a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     rrca
     ld   a, [$FF81]
     ld   a, [hl]
@@ -13014,7 +13069,8 @@ label_439BD::
     ld   [bc], a
     ld   e, b
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     nop
     ccf
     rrca

--- a/src/disassembled-banks/Bank16.asm
+++ b/src/disassembled-banks/Bank16.asm
@@ -1478,7 +1478,7 @@ label_406A5::
     dec  a
     call label_EB1B
     dec  e
-    jp   [hl]
+    jp   hl
     db   $3A ; ldd  a, [hl]
     call z, label_16F1
     rst  $28
@@ -2134,7 +2134,7 @@ label_4097E::
     ld   a, a
     ld   a, a
     cp   $F3
-    jp   [hl]
+    jp   hl
     ld   [$FFA4], a
     and  d
     rla
@@ -2503,7 +2503,7 @@ label_40B16::
     nop
     sbc  a, c
     nop
-    jp   [hl]
+    jp   hl
     nop
     rlca
     nop
@@ -4100,7 +4100,7 @@ label_41216::
     nop
     sbc  a, c
     nop
-    jp   [hl]
+    jp   hl
     nop
     rlca
     nop
@@ -5620,7 +5620,7 @@ label_4192D::
     jr   nz, label_4190E
     jr   nz, label_419AA
     ei
-    jp   [hl]
+    jp   hl
 
 label_41933::
     rst  8
@@ -5636,7 +5636,7 @@ label_41939::
     rst  $18
     jr   nz, label_418C8
     ld   b, a
-    jp   [hl]
+    jp   hl
     db   $EB ; Undefined instruction
     add  hl, de
     rst  $18
@@ -7531,7 +7531,7 @@ label_421DB::
     rst  $38
 
 label_421EA::
-    jp   [hl]
+    jp   hl
     rst  $30
 
 label_421EC::
@@ -10829,7 +10829,7 @@ label_42FFD::
     rlca
     ei
     rlca
-    jp   [hl]
+    jp   hl
     rla
     ld   a, l
     inc  bc
@@ -11049,7 +11049,7 @@ label_43121::
     rst  $38
     push bc
     inc  hl
-    jp   [hl]
+    jp   hl
     rlca
     jp   label_4170F
     rrca
@@ -13110,7 +13110,7 @@ label_43AAE::
     ret  nz
     cp   a
     ld   a, [$FFFF]
-    jp   [hl]
+    jp   hl
 
 label_43AB3::
     rst  $38
@@ -13462,7 +13462,7 @@ label_43B37::
     rst  $38
     ld   sp, hl
     rst  $38
-    jp   [hl]
+    jp   hl
     rst  $28
     pop  af
     rst  $38
@@ -13922,7 +13922,7 @@ label_43D03::
     ld   [$FFFE], a
     ld   sp, hl
     db   $EC ; Undefined instruction
-    jp   [hl]
+    jp   hl
     sbc  a, $F0
     db   $FC ; Undefined instruction
     ret  nz

--- a/src/disassembled-banks/Bank17.asm
+++ b/src/disassembled-banks/Bank17.asm
@@ -201,10 +201,14 @@ label_440BF::
     scf
     ret  c
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $AF
     ld   e, b
     scf
     adc  a, $13
@@ -482,7 +486,8 @@ label_441BF::
     cp   h
     ld   b, b
     call c, label_EC20
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     nop
     call c, label_CC20
     ld   [hl], b
@@ -495,7 +500,8 @@ label_4423C::
 
 label_44242::
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     nop
     ccf
     nop
@@ -565,7 +571,8 @@ label_44282::
     rst  $38
     ld   c, a
     ld   a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     dec  d
     jr   c, label_442A9
     ccf
@@ -590,7 +597,8 @@ label_44282::
     cp   $7C
     rst  $38
     sbc  a, $FE
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     ret  nc
     ld   a, h
     or   b
@@ -618,7 +626,8 @@ label_44282::
     jr   z, label_4430C
     rrca
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     dec  d
     db   $3A ; ldd  a, [hl]
     dec  d
@@ -1058,7 +1067,8 @@ label_444A1::
     ld   b, $07
     nop
     ld   [rJOYP], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     call c, label_F2E0
     db   $EC ; Undefined instruction
     ld   sp, hl
@@ -1620,7 +1630,8 @@ label_44746::
     db   $FC ; Undefined instruction
     ld   [label_8FC], sp
     db   $EC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E4
     ld    hl, sp+$FC
     nop
     rra
@@ -1697,7 +1708,8 @@ label_447D0::
     rra
     cpl
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     rrca
     nop
     dec  e
@@ -1745,7 +1757,8 @@ label_447D0::
     rrca
     nop
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     rra
     nop
@@ -1800,7 +1813,8 @@ label_4483F::
     rrca
     nop
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     inc  c
     rra
     dec  bc
@@ -1940,7 +1954,8 @@ label_448DD::
     ccf
     ld   d, $3F
     jr   label_44948
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     ld   [$001F], sp
     ld   a, a
     ld   bc, label_441BF
@@ -1990,7 +2005,8 @@ label_44912::
     rrca
     ld   bc, $001F
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3B
     inc  b
     ccf
     inc  b
@@ -2248,8 +2264,10 @@ label_44A3D::
     rst  $18
     and  b
     db   $E8 ; add  sp, d
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E8
+    db   $10
+    db   $F8
     nop
     rst  $38
     ret  nz
@@ -2300,7 +2318,8 @@ label_44A82::
     ld   e, $FE
     inc  c
     db   $EC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E4
     ret  c
     ld   a, [$FEEC]
     db   $F4 ; Undefined instruction
@@ -2357,9 +2376,12 @@ label_44A82::
 
 label_44AF0::
     inc  l
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2C
+    db   $10
+    db   $2C
+    db   $10
+    db   $6E
     ld   d, d
     rst  $28
     sub  a, c
@@ -2699,7 +2721,8 @@ label_44C6C::
     nop
     rrca
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  hl
     rra
     dec  sp
@@ -2739,7 +2762,8 @@ label_44C6C::
     inc  d
     db   $E8 ; add  sp, d
     db   $E8 ; add  sp, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $70
     add  a, b
     ld   [rLCDC], a
     ret  nc
@@ -2776,7 +2800,8 @@ label_44CBF::
     rra
     nop
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $4F
     jr   nc, label_44C6C
     ld   a, h
     add  a, d
@@ -2840,7 +2865,8 @@ label_44CBF::
     nop
     ld   a, c
     jr   nc, label_44D6E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9F
     ld   [$8BFE], sp
     or   [hl]
     ld   c, c
@@ -3058,7 +3084,8 @@ label_44E14::
     db   $E4 ; Undefined instruction
     ret  c
     db   $E8 ; add  sp, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $30
     ret  nz
     jr   label_44E14
     ld   a, b
@@ -3750,7 +3777,8 @@ label_450F8::
     ld   b, b
     add  a, b
     jr   nz, label_450E6
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     adc  a, b
     ld   [hl], b
     ld   b, h
@@ -3794,7 +3822,8 @@ label_4514F::
     ld   [label_814], sp
     jr   z, label_45168
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     ccf
     ld   a, a
     nop
@@ -3814,8 +3843,10 @@ label_45168::
     db   $D3 ; Undefined instruction
     jr   nz, label_451BD
     jr   nz, label_45197
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
+    db   $10
+    db   $14
     ld   [label_814], sp
     ld   [$FE00], sp
     nop
@@ -3830,7 +3861,8 @@ label_45168::
     nop
     dec  bc
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   hl, label_4431F
     ld   a, $47
     inc  a
@@ -3929,7 +3961,8 @@ label_451F0::
     inc  hl
     rra
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5F
     jr   nz, label_45289
 
 label_4520B::
@@ -4233,7 +4266,8 @@ label_4534C::
     rla
     ld   [label_1F20], sp
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     nop
     daa
     jr   label_453AA
@@ -4341,7 +4375,8 @@ label_453AA::
     nop
     ld   e, $00
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6F
     ld   sp, label_215F
     rst  $38
     nop
@@ -4481,7 +4516,8 @@ label_453DC::
     ld    hl, sp+$04
     ld    hl, sp+$38
     ret  nz
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     or   b
     ld   b, b
     ld   a, [$FF00]
@@ -4878,7 +4914,8 @@ label_4564F::
     ld   c, h
     add  hl, sp
     ld   h, $1F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   a, [bc]
     dec  c
     dec  bc
@@ -5003,7 +5040,8 @@ label_456E0::
     nop
 
 label_456E2::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     ret  nz
@@ -5125,7 +5163,8 @@ label_45750::
     ld   bc, $011F
     ld   l, $11
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $37
     jr   label_457B0
     inc  e
     ld   l, $1F
@@ -5648,8 +5687,10 @@ label_459A3::
     ld   e, $FF
     add  hl, de
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $6F
     add  hl, de
     ld   [hl], a
     rrca
@@ -5747,17 +5788,20 @@ label_45A12::
 label_45A42::
     jr   c, label_45A54
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $37
     rrca
     inc  hl
     rra
 
 label_45A4A::
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
     inc  d
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $22
 
 label_45A51::
     dec  e
@@ -6144,7 +6188,8 @@ label_45BFB::
     ld   b, $0E
     dec  b
     ld   d, $0D
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  e
     dec  bc
     rla
@@ -6164,7 +6209,8 @@ label_45BFB::
     ld   b, $0E
     dec  b
     ld   d, $0D
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     rra
 
 label_45C2B::
@@ -6200,7 +6246,8 @@ label_45C2B::
     rlca
     ld   de, label_110F
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   a, [de]
     dec  b
     db   $3A ; ldd  a, [hl]
@@ -6218,7 +6265,8 @@ label_45C2B::
     rlca
     ld   de, label_110F
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [de], a
     dec  c
     ld   a, [de]
@@ -6334,13 +6382,15 @@ label_45CAC::
     ret  nz
     nop
     jr   nz, label_45CAC
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [$88F0], sp
     ld   [hl], b
     db   $E8 ; add  sp, d
     ld   d, b
     db   $E8 ; add  sp, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A6
     jr   label_45D1A
     ld   e, $1D
     ld   [bc], a
@@ -6408,8 +6458,10 @@ label_45D1A::
     inc  c
     ccf
     jr   label_45D8A
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
+    db   $10
+    db   $3F
     nop
     ld   a, a
     ld   a, $7F
@@ -6636,8 +6688,10 @@ label_45E1E::
     jr   nz, label_45E73
     ld   l, $11
     cpl
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
+    db   $10
+    db   $17
     ld   [label_708], sp
     rlca
     nop
@@ -6886,11 +6940,13 @@ label_45F52::
     ld   b, b
     add  a, b
     jr   nz, label_45F26
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ret  nc
     jr   nz, label_45EFB
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     jr   nz, label_45F30
     inc  hl
     ret  nz
@@ -6910,11 +6966,13 @@ label_45F52::
     ld   b, b
     add  a, b
     jr   nz, label_45F46
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ret  nc
     jr   nz, label_45F1B
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     jr   nz, label_45F50
     jr   nz, label_45F52
     ld   b, [hl]
@@ -7087,7 +7145,8 @@ label_46013::
     ld   e, a
     ldd  [hl], a
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     jr   label_46092
     inc  e
     ccf
@@ -7653,7 +7712,8 @@ label_462D7::
     ld   [rJOYP], a
     ret  nc
     ld   [$FFE8], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     and  b
     db   $FC ; Undefined instruction
     ret  nc
@@ -7692,7 +7752,8 @@ label_46305::
     ld   e, a
     jr   c, label_4634A
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     rrca
     nop
     ld   bc, $0100
@@ -8528,7 +8589,8 @@ label_4661D::
     jr   nc, label_46718
     inc  e
     jr   nz, label_46717
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  c
     inc  bc
     inc  bc
@@ -8582,7 +8644,8 @@ label_46718::
     or   [hl]
     ret  z
     db   $EC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FC
     ld   b, b
     xor  $DC
     cp   $C0
@@ -9010,7 +9073,8 @@ label_468D5::
     rra
     ld   [$001F], sp
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     ld   c, $7F
     rra
     rst  $38
@@ -9031,7 +9095,8 @@ label_4693D::
     cp   $84
     cp   $34
     db   $FC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     ret  nz
     db   $FC ; Undefined instruction
     ld   b, b
@@ -9278,7 +9343,8 @@ label_46A46::
     scf
     ld   c, $1F
     ld   b, $EF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $AA
     call nc, label_34EA
     sbc  a, $EC
     cp   d
@@ -9553,7 +9619,8 @@ label_46BA0::
     inc  bc
     ld   [de], a
     dec  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     rrca
     nop
     nop
@@ -9589,7 +9656,8 @@ label_46BCD::
 label_46BCF::
     add  a, b
     jr   nz, label_46B92
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     adc  a, b
     ld   [hl], b
     ld   b, h
@@ -9662,7 +9730,8 @@ label_46BFC::
     scf
     jr   c, label_46C27
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     ld   [label_277F], sp
     ld   [hl], a
     jr   z, label_46C4C
@@ -9709,7 +9778,8 @@ label_46C2D::
     jr   nz, label_46CCA
     jr   nz, label_46CAC
     jr   nz, label_46C8E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
     jr   label_46CD2
     inc  l
     ld   a, a
@@ -9986,7 +10056,8 @@ label_46D5B::
 
 label_46D9B::
     ld   l, $6F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     nop
     ld   a, [$FF00]
     ld    hl, sp+$00
@@ -10181,7 +10252,8 @@ label_46E3A::
     jr   nz, label_46E36
     jr   nz, label_46E38
     jr   nz, label_46E3A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     inc  e
     ld   [rNR12], a
     db   $EC ; Undefined instruction
@@ -10392,7 +10464,8 @@ label_46F25::
     ld   a, [bc]
     inc  de
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [label_807], sp
     rlca
     inc  b
@@ -10512,7 +10585,8 @@ label_46FB2::
     ld   b, b
     add  a, b
     jr   nz, label_46FB2
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     rla
     ld   [$FF09], a
     or   $09
@@ -10647,8 +10721,10 @@ label_4703D::
     add  a, b
     and  b
     ret  nz
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     ld   [label_8F0], sp
     ld   a, [$FF04]
     ld    hl, sp+$04
@@ -10725,8 +10801,10 @@ label_470C9::
     add  a, b
     and  b
     ret  nz
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     ld   [label_8F0], sp
     ld   a, [$FF06]
     ld   a, [$FA06]
@@ -10910,7 +10988,8 @@ label_47122::
     call c, label_FF00
     ret  c
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   l, h
     rst  $38
     inc  [hl]
@@ -10940,10 +11019,12 @@ label_47122::
     ret  nz
     ld   h, b
     ret  nz
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     sub  a, b
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     adc  a, b
     ld   [hl], b
     and  h
@@ -11024,7 +11105,8 @@ label_4723F::
     rrca
     ld   hl, label_201E
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
 
 label_4724E::
     inc  c
@@ -11757,7 +11839,8 @@ label_4758D::
     dec  de
     inc  sp
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   label_4759B
     inc  c
     inc  bc
@@ -11834,7 +11917,8 @@ label_475E2::
     dec  a
     nop
     add  hl, sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     nop
     ld   b, h
     jr   c, label_47573
@@ -12712,7 +12796,8 @@ label_479B6::
     ld   e, $2C
     rra
     jr   nz, label_479E7
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     rra
     nop
     ccf
@@ -13084,11 +13169,13 @@ label_47B52::
     ld   b, b
     add  a, b
     jr   nz, label_47B26
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ret  nc
     jr   nz, label_47AFB
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     jr   nz, label_47B30
     inc  hl
     ret  nz
@@ -13110,11 +13197,13 @@ label_47B7D::
     ld   b, b
     add  a, b
     jr   nz, label_47B46
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ret  nc
     jr   nz, label_47B1B
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     jr   nz, label_47B50
     jr   nz, label_47B52
     ld   b, [hl]
@@ -13266,7 +13355,8 @@ label_47BF8::
     db   $EB ; Undefined instruction
     or   $B9
     add  a, $EE
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FC
     ld   [$FFF0], a
     nop
     ld    hl, sp+$00
@@ -13280,7 +13370,8 @@ label_47BF8::
     jr   nc, label_47C86
     rrca
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     nop
     cp   a
     ld   b, b
@@ -13350,7 +13441,8 @@ label_47C86::
     inc  bc
     ld   bc, $0007
     ld   [rJOYP], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   l, b
     sub  a, b
     inc  e
@@ -13406,7 +13498,8 @@ label_47CCA::
     nop
     nop
     ld   [rJOYP], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   l, b
     sub  a, b
     inc  e
@@ -13995,9 +14088,12 @@ label_47F3C::
     nop
     ld   [label_1607], sp
     rrca
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     add  hl, bc
     ld   b, $07
     ld   bc, label_205

--- a/src/disassembled-banks/Bank17.asm
+++ b/src/disassembled-banks/Bank17.asm
@@ -2497,7 +2497,7 @@ label_44B2F::
     cp   $30
     ld   sp, hl
     or   [hl]
-    jp   [hl]
+    jp   hl
     or   $F9
     add  a, $BD
     jp   nz, label_827D
@@ -4363,7 +4363,7 @@ label_453DC::
     nop
     ld   [hl], l
     inc  bc
-    jp   [hl]
+    jp   hl
     db   $76 ; Halt
     cp   e
     ld   b, h
@@ -4415,7 +4415,7 @@ label_453DC::
     ld   [bc], a
     rst  8
     nop
-    jp   [hl]
+    jp   hl
     add  a, a
     ld   [hl], d
     rst  8
@@ -4459,7 +4459,7 @@ label_453DC::
     ld  [$FF00+C], a
     db   $FD ; Undefined instruction
     ld   [de], a
-    jp   [hl]
+    jp   hl
     ld   [hl], $F1
     ld   c, $38
     nop
@@ -13923,7 +13923,7 @@ label_47F24::
     dec  [hl]
     rst  $38
     add  hl, bc
-    jp   [hl]
+    jp   hl
     or   $60
     sbc  a, a
     ld   b, b
@@ -14088,4 +14088,4 @@ label_47FE7::
     adc  a, $DA
     inc  a
     db   $F4 ; Undefined instruction
-    ld    hl, sp+$00
+    ld    hl, sp+$57

--- a/src/disassembled-banks/Bank18.asm
+++ b/src/disassembled-banks/Bank18.asm
@@ -97,7 +97,8 @@ label_48050::
     inc  c
     daa
     jr   label_480A0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5F
     jr   nz, label_480D4
     jr   nz, label_480D6
     jr   nz, label_48044
@@ -121,7 +122,8 @@ label_48050::
 label_4808B::
     ret  nz
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D7
     jr   c, label_48050
     ld   a, b
     ld   a, e
@@ -231,13 +233,15 @@ label_48103::
     inc  c
     daa
     jr   label_48140
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5F
     jr   nz, label_48164
     jr   nc, label_48192
     inc  b
     rst  8
     jr   nc, label_4811A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $AF
     ld   e, b
     or   a
     ld   c, a
@@ -532,7 +536,8 @@ label_4823C::
     ld   a, [$FAFC]
     adc  a, h
     ld   a, [$EC04]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FC
     nop
     ld    hl, sp+$80
     jr   nc, label_4823C
@@ -884,7 +889,8 @@ label_483FF::
     rla
     rrca
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     rla
     dec  de
     rlca
@@ -1102,7 +1108,8 @@ label_4850B::
     dec  hl
     rla
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     dec  c
     rra
     dec  c
@@ -1350,7 +1357,8 @@ label_4850B::
 
 label_48642::
     dec  a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     jr   label_48674
     ld   a, [de]
     dec  de
@@ -1752,9 +1760,12 @@ label_48825::
     add  a, b
     jr   nz, label_487E8
     jr   nz, label_487EA
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     ld   [label_8F0], sp
     ld   a, [$FF08]
     ld   a, [$FF8E]
@@ -1769,7 +1780,8 @@ label_4883E::
     dec  c
     ld   b, $08
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   a, h
     inc  bc
     db   $FC ; Undefined instruction
@@ -1797,8 +1809,10 @@ label_48857::
     ret  nz
     nop
     jr   nz, label_48824
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     ld   [label_8F0], sp
     ld   a, [$FF04]
     ld    hl, sp+$04
@@ -1819,7 +1833,8 @@ label_48879::
     nop
     inc  de
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
 
 label_48886::
     rla
@@ -1909,7 +1924,8 @@ label_488CF::
 label_488E2::
     ret  c
     jr   nc, label_488CD
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E4
     sbc  a, b
     db   $E4 ; Undefined instruction
     jr   label_488CF
@@ -2023,8 +2039,10 @@ label_48911::
     rrca
     ld   [label_80F], sp
     rra
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
     stop
     nop
     nop
@@ -2162,7 +2180,8 @@ label_48A0A::
     ccf
     jr   nz, label_48A54
     jr   nz, label_48A36
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  c
     inc  bc
     inc  bc
@@ -2205,7 +2224,8 @@ label_48A36::
     rrca
     ld   [label_101F], sp
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     ld   h, b
     rst  $38
     add  a, b
@@ -2238,9 +2258,12 @@ label_48A54::
     jr   nz, label_48AAA
     jr   nz, label_48AAC
     jr   nz, label_48A8E
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $0F
     ld   [label_80F], sp
     rlca
     inc  b
@@ -2306,18 +2329,30 @@ label_48AAC::
     ret  nz
     ccf
     jr   nz, label_48ADC
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $0F
     ld   [label_80F], sp
     rlca
     inc  b
@@ -2589,7 +2624,8 @@ label_48BE5::
     ld   c, $00
     dec  d
     ld   a, [bc]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   e, $01
     rst  8
     ld   b, $E5
@@ -2747,7 +2783,8 @@ label_48CAE::
     dec  c
     ld   b, $10
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     dec  e
     ld   [bc], a
     rrca
@@ -2889,7 +2926,8 @@ label_48D1F::
     dec  b
     rrca
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     dec  hl
     inc  d
     ld   a, [hli]
@@ -3090,7 +3128,8 @@ label_48E14::
     rst  $38
     nop
     jr   nz, label_48E02
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [label_4F0], sp
     ld    hl, sp+$04
     ld    hl, sp+$02
@@ -3618,7 +3657,8 @@ label_4906C::
     rlca
     ld   [hl], a
     jr   label_490DC
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     inc  bc
     nop
@@ -3954,7 +3994,8 @@ label_49149::
     add  a, b
     nop
     ld   [rJOYP], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   a, [$FF00]
     nop
     nop
@@ -4180,7 +4221,8 @@ label_4926C::
     rrca
     ld   d, $0F
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
     add  hl, de
     cpl
 
@@ -4286,8 +4328,10 @@ label_4936B::
     cpl
     ld   e, a
     ld   l, $2F
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
+    db   $10
+    db   $1F
     dec  b
     ld   l, a
     dec  b
@@ -4336,8 +4380,10 @@ label_493A3::
     cpl
     ld   e, a
     ld   l, $2F
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
+    db   $10
+    db   $1F
     rlca
     rrca
     inc  bc
@@ -5301,7 +5347,8 @@ label_497E0::
     rra
     rla
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  c
     inc  bc
     inc  bc
@@ -5359,7 +5406,8 @@ label_49845::
     rra
     rla
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  c
     inc  bc
     inc  bc
@@ -5411,8 +5459,10 @@ label_49869::
     rra
     daa
     rra
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     inc  c
     inc  bc
     inc  bc
@@ -5465,7 +5515,8 @@ label_498D0::
     rra
     inc  de
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  c
     inc  bc
     inc  bc
@@ -5706,7 +5757,8 @@ label_4997B::
     db   $FC ; Undefined instruction
     inc  de
     db   $EC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     ei
     rlca
     db   $FC ; Undefined instruction
@@ -6232,7 +6284,8 @@ label_49BB5::
     jr   label_49C33
     jr   label_49C71
     ret  nz
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld    hl, sp+$00
     ld   a, [$FF00]
     nop
@@ -6256,7 +6309,8 @@ label_49BB5::
 
 label_49C55::
     jr   label_49C96
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     rlca
     ld   [label_1F07], sp
     nop
@@ -6565,7 +6619,8 @@ label_49DC5::
     add  hl, bc
     ld   b, $08
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   sp, label_4870E
     add  hl, sp
     adc  a, a
@@ -7090,7 +7145,8 @@ label_4A000::
     rrca
     nop
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     rra
     nop
@@ -7147,7 +7203,8 @@ label_4A03F::
     rrca
     nop
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     inc  c
     rra
     dec  bc
@@ -7402,7 +7459,8 @@ label_4A14F::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     nop
@@ -7538,7 +7596,8 @@ label_4A1FC::
     scf
     jr   c, label_4A227
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     ld   [label_277F], sp
     ld   [hl], a
     jr   z, label_4A24C
@@ -7679,9 +7738,12 @@ label_4A2A3::
     inc  bc
     add  hl, bc
     rlca
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     inc  c
     inc  bc
     inc  bc
@@ -7696,7 +7758,8 @@ label_4A2A3::
     nop
     ld   [hl], c
     jr   nz, label_4A306
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     inc  d
     rrca
@@ -7713,7 +7776,8 @@ label_4A2CE::
     rra
     nop
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6F
     jr   nc, label_4A2CE
     ld   b, c
     jp   label_101
@@ -8009,7 +8073,8 @@ label_4A41F::
     nop
     ld   a, a
     jr   nz, label_4A4A8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   d, b
     rst  $38
 
@@ -8329,7 +8394,8 @@ label_4A584::
     add  hl, hl
 
 label_4A587::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $26
     add  hl, de
     jr   nz, label_4A5AB
     ld   a, [hli]
@@ -8344,7 +8410,8 @@ label_4A587::
     ld   a, $43
     inc  a
     ld   a, $01
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     dec  de
     dec  c
     rra
@@ -8457,7 +8524,8 @@ label_4A60B::
     dec  hl
     rla
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     dec  c
     rra
     dec  c
@@ -8527,7 +8595,8 @@ label_4A60B::
     jr   nz, label_4A68B
     jr   nc, label_4A67D
     jr   nz, label_4A68F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_4A693
     jr   nz, label_4A695
     jr   nc, label_4A687
@@ -8550,7 +8619,8 @@ label_4A687::
     ld   l, $3F
 
 label_4A68B::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     dec  d
     ld   e, a
 
@@ -8595,7 +8665,8 @@ label_4A6AB::
     ld   sp, hl
     and  $F9
     add  a, $EE
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7C
     ret  c
     cp   h
     ret  c
@@ -8633,7 +8704,8 @@ label_4A6AB::
     nop
     ld   h, b
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     inc  e
     ld   [rDIV], a
     ld    hl, sp+$74
@@ -8650,7 +8722,8 @@ label_4A6AB::
     inc  e
     cp   h
     ld   b, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [$F8F0], sp
     nop
     nop
@@ -8700,7 +8773,8 @@ label_4A6AB::
     jr   label_4A733
     jr   label_4A771
     ret  nz
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld    hl, sp+$00
     ld   a, [$FF00]
     nop
@@ -8724,7 +8798,8 @@ label_4A6AB::
 
 label_4A755::
     jr   label_4A796
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     rlca
     ld   [label_1F07], sp
     nop
@@ -8801,7 +8876,8 @@ label_4A790::
     ret  nz
     ld   [rJOYP], a
     ld   a, [$FF00]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   a, [$FF00]
     ld   [$FFC0], a
     ld   a, [$FF00]
@@ -9186,7 +9262,8 @@ label_4A888::
 
 label_4A946::
     ld   a, [hli]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5D
     ldd  [hl], a
     ld   [hl], a
     db   $3A ; ldd  a, [hl]
@@ -10275,7 +10352,8 @@ label_4ADA8::
     nop
     inc  c
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   de, label_230F
     rra
     daa
@@ -12248,7 +12326,8 @@ label_4B60D::
     add  hl, de
     rlca
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $4B
     scf
     ld   [hl], a
     inc  c
@@ -12340,7 +12419,8 @@ label_4B686::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
     jr   label_4B6AE
     dec  c
     rla
@@ -13137,7 +13217,8 @@ label_4B987::
     rrca
     inc  c
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     ld   h, $3F
     ld   l, $7F
     ld   c, h
@@ -13342,7 +13423,8 @@ label_4BAF0::
     rrca
     inc  c
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1C
     inc  de
     dec  sp
     daa
@@ -13833,7 +13915,8 @@ label_4BD3C::
     xor  $5C
     ld   l, h
     jr   z, label_4BD92
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     nop
@@ -13957,7 +14040,8 @@ label_4BDDE::
     ld   a, [$FF44]
     ld   [hl], b
     jr   z, label_4BE1E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     rrca
@@ -14233,7 +14317,8 @@ label_4BE81::
     inc  b
     ld   [label_100B], sp
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $07
     stop
     nop
     nop
@@ -14242,13 +14327,17 @@ label_4BE81::
     nop
     nop
     ld   [rNR41], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D0
     ld   [label_8E0], sp
     ld   [$FF08], a
     rlca
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $07
+    db   $10
+    db   $0B
+    db   $10
+    db   $04
     ld   [label_700], sp
     nop
     nop

--- a/src/disassembled-banks/Bank18.asm
+++ b/src/disassembled-banks/Bank18.asm
@@ -1317,7 +1317,7 @@ label_4850B::
     ld   a, c
     ld   a, $C7
     ld   a, b
-    jp   [hl]
+    jp   hl
     ld   d, [hl]
     adc  a, e
     ld   [hl], l
@@ -1364,7 +1364,7 @@ label_48642::
     ld   a, c
     ld   a, $C7
     ld   a, b
-    jp   [hl]
+    jp   hl
     ld   d, [hl]
     adc  a, e
     ld   [hl], l
@@ -1380,7 +1380,7 @@ label_48642::
     nop
     push hl
     ld   [bc], a
-    jp   [hl]
+    jp   hl
     ld   b, $D5
     ld   c, $EF
     ld   e, $FD
@@ -1806,7 +1806,7 @@ label_48857::
     ld    hl, sp+$1E
     ld   [rBGPD], a
     sub  a, [hl]
-    jp   [hl]
+    jp   hl
     ld   d, $FF
 
 label_48879::
@@ -1916,7 +1916,7 @@ label_488E2::
     ld    hl, sp+$B2
     ld   e, h
     ld   a, [$FF00+C]
-    jp   [hl]
+    jp   hl
     ld   [hl], $F1
     xor  $F1
     sbc  a, $F3
@@ -3770,7 +3770,7 @@ label_49108::
     ccf
     jp   label_2FFF
     or   $D9
-    jp   [hl]
+    jp   hl
     or   $00
     nop
     nop
@@ -4019,7 +4019,7 @@ label_49149::
     cp   $07
     cp   $0F
     or   $19
-    jp   [hl]
+    jp   hl
     or   $00
     nop
     nop

--- a/src/disassembled-banks/Bank19.asm
+++ b/src/disassembled-banks/Bank19.asm
@@ -280,7 +280,8 @@ label_4C0A5::
     inc  c
     rlca
     jr   label_4C14B
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     nop
     nop
     ccf
@@ -519,7 +520,8 @@ label_4C249::
     ld   a, a
     ld   e, b
     ld   e, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1C
     sub  a, b
     sbc  a, h
     ld   [bc], a
@@ -594,7 +596,8 @@ label_4C29D::
     inc  b
     nop
     ld   [label_1000], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     jr   nz, label_4C2DD
     jr   nz, label_4C2C3
     inc  b
@@ -629,11 +632,13 @@ label_4C2C3::
     nop
     ld   b, h
     ld   b, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
 
 label_4C2E6::
     jr   c, label_4C310
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     ld   b, h
     ld   b, h
     nop
@@ -740,8 +745,10 @@ label_4C310::
     ld   h, c
     ld   e, b
     ld   e, b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
+    db   $10
+    db   $1C
     ld   [bc], a
     ld   [bc], a
     add  a, [hl]
@@ -762,7 +769,8 @@ label_4C310::
     rrca
     add  a, b
     ret  nz
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $90
     dec  d
     sub  a, l
     nop
@@ -812,10 +820,12 @@ label_4C310::
     call z, label_C1CC
     inc  b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $04
     nop
     ld   [label_1000], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     jr   nz, label_4C3DD
     jr   nz, label_4C3C3
     inc  b
@@ -952,7 +962,8 @@ label_4C440::
     add  a, b
     inc  b
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     ld   [bc], a
@@ -986,7 +997,8 @@ label_4C440::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     dec  b
     dec  b
 
@@ -1038,7 +1050,8 @@ label_4C478::
     ld   b, c
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $04
     nop
     nop
     nop
@@ -2176,7 +2189,8 @@ label_4C9B3::
     sbc  a, $FF
     ld    hl, sp+$F0
     jr   nc, label_4C9B3
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $78
     sbc  a, b
     dec  sp
     ret  z
@@ -3565,7 +3579,8 @@ label_4CFF7::
     rrca
     ccf
     jr   nc, label_4D02A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     nop
     inc  bc
     nop
@@ -3603,7 +3618,8 @@ label_4D02A::
     rra
     nop
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $70
     rrca
     ld   [hl], b
     rrca
@@ -3800,7 +3816,8 @@ label_4D111::
     rra
     nop
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7C
     inc  de
     ld   a, [hl]
     ld   sp, label_4F0FF
@@ -3838,7 +3855,8 @@ label_4D111::
     ld   [hl], a
     sub  a, b
     ld   l, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     dec  h
     jp  c, label_956A
     rst  $10
@@ -3931,7 +3949,8 @@ label_4D1A1::
     rst  $38
     rst  $38
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D5
     ld   a, [hli]
     xor  d
     ld   d, l
@@ -4975,7 +4994,8 @@ label_4D601::
 
 label_4D688::
     sub  a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CF
     nop
     db   $FC ; Undefined instruction
     nop
@@ -5007,7 +5027,8 @@ label_4D696::
     inc  bc
     nop
     inc  a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     rst  $38
     rrca
 
@@ -5097,7 +5118,8 @@ label_4D6CC::
     adc  a, a
     rst  $38
     jr   nc, label_4D71A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     di
     inc  c
@@ -5332,7 +5354,8 @@ label_4D7FC::
     rst  $38
     ld   b, l
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   [$00FB], sp
     cp   h
     ld   [bc], a
@@ -5554,7 +5577,8 @@ label_4D8DE::
 
 label_4D92D::
     ld   [$0000], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5A
     nop
     dec  c
     nop
@@ -5578,7 +5602,8 @@ label_4D92D::
 label_4D94C::
     ld   d, b
     jr   nz, label_4D99E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
     nop
     rlca
     nop
@@ -5792,7 +5817,8 @@ label_4DA01::
     rst  $18
     dec  c
     cp   a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     ld   c, e
     rst  $38
     sbc  a, a
@@ -5806,10 +5832,12 @@ label_4DA01::
     ld   b, e
     inc  e
     jr   nz, label_4DA53
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
     inc  e
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_4DA6B
     ld   b, b
     ccf
@@ -5912,7 +5940,8 @@ label_4DA6B::
     nop
     ld   h, b
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C0
     inc  c
     ld   [rJOYP], a
     nop
@@ -6006,7 +6035,8 @@ label_4DB0A::
     rst  $38
     inc  c
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -6279,7 +6309,8 @@ label_4DC25::
     inc  sp
     nop
     db   $EB ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CC
     inc  sp
     ld   a, d
     dec  b
@@ -6320,7 +6351,8 @@ label_4DC25::
     adc  a, e
     ld   d, b
     dec  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F9
     ld   b, $27
     ret  nz
     add  hl, bc
@@ -6524,7 +6556,8 @@ label_4DD6C::
     nop
     nop
     ld    hl, sp+$CA
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $8C
     nop
     rst  $18
     nop
@@ -6566,7 +6599,8 @@ label_4DD6C::
     add  a, b
     ld   a, a
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $40
     add  a, b
     ld   h, b
     ld   [label_4E8F0], sp
@@ -6574,7 +6608,8 @@ label_4DD6C::
     ld   h, b
     add  hl, bc
     jr   nc, label_4DD6C
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     nop
     inc  c
     ld   h, $19
@@ -6946,7 +6981,8 @@ label_4DF05::
     rst  $38
     jr   label_4DF75
     jr   label_4DF77
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -6967,7 +7003,8 @@ label_4DF05::
     nop
     inc  h
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F4
     dec  bc
     ld   a, d
     dec  b
@@ -7152,7 +7189,8 @@ label_4E04E::
     ret  nz
     inc  c
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_4E085
     jr   nz, label_4E087
     ld   b, [hl]
@@ -7162,7 +7200,8 @@ label_4E04E::
     rra
     ld   h, b
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E7
     nop
     rst  $38
     nop
@@ -7193,7 +7232,8 @@ label_4E087::
     rst  $28
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CF
     call c, label_FEF8
     ld   a, h
     ld   a, a
@@ -7894,7 +7934,8 @@ label_4E38D::
     rst  $20
     sub  a, b
     rst  $20
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E7
     jr   z, label_4E36D
     ld   c, b
     or   e
@@ -8018,7 +8059,8 @@ label_4E400::
     add  a, b
     dec  b
     ld   a, [$F009]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     jr   nz, label_4E400
     rst  0
     nop
@@ -8039,7 +8081,8 @@ label_4E44A::
     ld   h, $00
     ld   d, $60
     adc  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     rst  $38
     ld   [rIE], a
     ld   [rIE], a
@@ -8213,7 +8256,8 @@ label_4E44A::
     db   $FC ; Undefined instruction
     ld   a, b
     jp   label_E378
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     inc  sp
     nop
@@ -8348,7 +8392,8 @@ label_4E58D::
 
 label_4E5A2::
     ld   l, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F2
     ld   l, h
     pop  af
     ld   h, $73
@@ -8453,7 +8498,8 @@ label_4E5BD::
     db   $FC ; Undefined instruction
     ld   a, b
     jp   label_E378
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     ccf
     nop
@@ -8989,7 +9035,8 @@ label_4E84E::
     rlca
     ld   [label_807], sp
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     rra
     jr   nz, label_4E8FE
@@ -9038,7 +9085,8 @@ label_4E899::
     nop
     ret  nz
     jr   nz, label_4E88D
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [label_1000], sp
     nop
     jr   nz, label_4E8B5
@@ -9074,7 +9122,8 @@ label_4E8BB::
     ld   b, $DF
     nop
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D8
     jr   nz, label_4E90B
     nop
     nop
@@ -9094,13 +9143,15 @@ label_4E8EE::
     jr   nz, label_4E910
 
 label_4E8F0::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   [bc], a
     rrca
     nop
     sub  a, b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $41
     ld   b, c
     nop
     nop
@@ -9207,7 +9258,8 @@ label_4E910::
     rrca
     nop
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     jr   nz, label_4E9A8
     nop
     ccf
@@ -9479,10 +9531,12 @@ label_4EA71::
     ld   [bc], a
     rst  $38
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     sbc  a, $10
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -9599,7 +9653,8 @@ label_4EA71::
     ccf
     ldi  [hl], a
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     jr   label_4EB49
     inc  c
     rrca
@@ -10750,7 +10805,8 @@ label_4EF4C::
     rst  $38
     ld   b, l
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   [$00FB], sp
     cp   h
     ld   [bc], a
@@ -10968,7 +11024,8 @@ label_4F0FF::
 
 label_4F12D::
     ld   [$0000], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5A
     nop
     dec  c
     nop
@@ -11210,7 +11267,8 @@ label_4F229::
     rst  $18
     dec  c
     cp   a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     ld   c, e
     rst  $38
     sbc  a, a
@@ -11306,7 +11364,8 @@ label_4F280::
     rst  $38
     nop
     db   $E8 ; add  sp, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E4
     jr   label_4F269
     jr   c, label_4F229
     ld   a, h
@@ -11417,7 +11476,8 @@ label_4F280::
     rst  $38
     inc  c
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -11430,7 +11490,8 @@ label_4F280::
     nop
     rrca
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_4F34D
     jr   nz, label_4F34F
     ld   b, b
@@ -11443,7 +11504,8 @@ label_4F280::
     inc  a
     inc  h
     jr   label_4F363
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $19
     nop
     dec  b
     nop
@@ -11520,7 +11582,8 @@ label_4F368::
     nop
     ld   h, b
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [$84F0], sp
     ld   a, b
     call nz, label_E438
@@ -12377,7 +12440,8 @@ label_4F705::
     rst  $38
     jr   label_4F775
     jr   label_4F777
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -12506,7 +12570,8 @@ label_4F808::
     ld   bc, $0007
     ld   c, $01
     jr   label_4F819
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_4F835
     jr   nz, label_4F837
     ld   b, b
@@ -12680,9 +12745,12 @@ label_4F86B::
     ld   c, b
     and  c
     jr   label_4F86B
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $62
+    db   $10
+    db   $62
+    db   $10
+    db   $22
     nop
     ld   [de], a
     nop
@@ -12859,7 +12927,8 @@ label_4F979::
     jr   c, label_4F9D9
     jr   c, label_4F9BB
     jr   label_4F9BD
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     nop
     rst  $20
     rst  $18
@@ -12911,7 +12980,8 @@ label_4F9BD::
 
 label_4F9D5::
     rst  $30
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     jr   nz, label_4F9B9
     ret  nz
     ccf
@@ -13413,8 +13483,10 @@ label_4FBCC::
     add  a, b
     jr   nz, label_4FBCA
     jr   nz, label_4FBCC
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     ld   [label_8F0], sp
     ld   a, [$FF04]
     ld    hl, sp+$04
@@ -13553,7 +13625,8 @@ label_4FC99::
     ei
     adc  a, b
     rst  $30
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     jr   nz, label_4FC99
     ret  nz
     ccf
@@ -13790,7 +13863,8 @@ label_4FD99::
     ei
     adc  a, b
     rst  $30
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     jr   nz, label_4FD99
     ret  nz
     ccf

--- a/src/disassembled-banks/Bank19.asm
+++ b/src/disassembled-banks/Bank19.asm
@@ -3544,6 +3544,8 @@ label_4CFF4::
     inc  a
     nop
     ld   a, [hl]
+
+label_4CFF7::
     nop
     rst  $38
     nop
@@ -4084,7 +4086,7 @@ label_4D220::
     rst  $38
     jp   label_EDF3
     db   $ED ; Undefined instruction
-    jp   [hl]
+    jp   hl
     push hl
     di
     di
@@ -4926,7 +4928,7 @@ label_4D601::
     cp   $00
     nop
     cp   $D5
-    jp   [hl]
+    jp   hl
     or   [hl]
     ld   e, a
     and  b
@@ -5840,7 +5842,7 @@ label_4DA53::
     ld   [de], a
 
 label_4DA6B::
-    jp   [hl]
+    jp   hl
     rla
     db   $E3 ; Undefined instruction
     scf
@@ -7408,7 +7410,7 @@ label_4E154::
     inc  b
     ld   a, [$F409]
     ld   [de], a
-    jp   [hl]
+    jp   hl
     scf
     add  a, c
     add  hl, sp
@@ -9461,7 +9463,7 @@ label_4EA71::
     rst  $38
     rst  $38
     rst  $38
-    jp   [hl]
+    jp   hl
     sbc  a, a
     ret
     cp   a
@@ -12806,7 +12808,7 @@ label_4F90E::
     ld   d, $EA
     ld   d, $EB
     inc  de
-    jp   [hl]
+    jp   hl
     inc  hl
     db   $21
     ld   hl, $FCDE
@@ -14324,4 +14326,4 @@ label_4FEF7::
     rst  $30
     adc  a, h
     rst  $30
-    ld   [$00F7], sp
+    ld   [label_4D0F7], sp

--- a/src/disassembled-banks/Bank2.asm
+++ b/src/disassembled-banks/Bank2.asm
@@ -1082,7 +1082,8 @@ label_861E::
     ld   de, rNR11
     nop
     ld   d, $17
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     rst  $38
     nop
     inc  d
@@ -1103,13 +1104,15 @@ label_864E::
     inc  de
 
 label_8652::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0B
     nop
     ld    hl, sp+$F3
     db   $ED ; Undefined instruction
     ld   a, [$FFF5]
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0D
     ld    hl, sp+$F5
     ld    hl, sp+$00
     ld   a, [$FFF3]
@@ -1135,7 +1138,8 @@ label_8666::
     nop
     nop
     dec  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0D
     dec  c
 
 label_867E::
@@ -1526,7 +1530,8 @@ label_88C4::
 
 label_88C5::
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     nop
     nop
     inc  c
@@ -1565,7 +1570,8 @@ label_88E5::
     ld   a, [$FFF4]
     db   $F4 ; Undefined instruction
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
     inc  c
     nop
     nop
@@ -2601,7 +2607,8 @@ label_8EF0::
 
 label_8F00::
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     nop
     nop
     inc  c
@@ -2638,7 +2645,8 @@ label_8F20::
     ld   a, [$FFF4]
     db   $F4 ; Undefined instruction
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
     inc  c
     nop
     nop
@@ -3740,7 +3748,8 @@ label_95BC::
     stop
     inc  b
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     rst  $20
     xor  c
     and  $01
@@ -4440,7 +4449,8 @@ label_99D5::
     inc  de
     ld   d, l
     ld   de, label_8612
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $56
     ld   e, b
     ld   e, c
     inc  de
@@ -4451,7 +4461,8 @@ label_99D5::
     inc  de
     ld   e, l
     ld   de, label_8E12
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5E
     ld   [bc], a
     inc  bc
     inc  de
@@ -4462,20 +4473,24 @@ label_99D5::
     ld   [de], a
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   de, label_1310
     ld   [de], a
     ld   de, label_1310
     ld   [de], a
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   de, label_1310
     ld   [de], a
 
@@ -4494,7 +4509,8 @@ label_9A1C::
     nop
     ld   [$0008], sp
     ld   [label_1008], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   [label_1010], sp
     ld   [$0000], sp
     nop
@@ -4504,7 +4520,8 @@ label_9A1C::
     nop
     nop
     ld   bc, label_1001
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
     ld   bc, label_1010
 
 label_9A50::
@@ -4774,7 +4791,8 @@ label_9BC5::
     inc  de
     ld   e, l
     ld   de, label_8E12
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5E
     ld   b, b
     ld   b, c
     ld   e, b
@@ -4810,7 +4828,8 @@ label_9BF4::
     nop
     nop
     ld   bc, label_1001
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $35
     scf
     add  hl, sp
     dec  sp
@@ -7154,7 +7173,8 @@ label_A8AB::
 
 label_A8B1::
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
 
 label_A8B4::
     rst  $38
@@ -7192,7 +7212,8 @@ label_A8E4::
     rst  0
     ld   bc, $A16A
     ld   l, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $69
 
 label_A8ED::
     nop
@@ -7596,7 +7617,8 @@ label_AB57::
 
 label_AB61::
     ld   [label_408], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0B
 
 label_AB66::
     ld   c, $04
@@ -8024,7 +8046,8 @@ label_AE27::
     ld   bc, $00FF
 
 label_AE3D::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     nop
     nop
 
@@ -10065,7 +10088,8 @@ label_BB5F::
 label_BB63::
     inc  d
     inc  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
 
 label_BB67::
     nop
@@ -10091,7 +10115,8 @@ label_BB73::
 
 label_BB77::
     ld   bc, $F0FF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
     rst  $38
     ld    hl, sp+$08
     ld   a, [$FFBB]

--- a/src/disassembled-banks/Bank2.asm
+++ b/src/disassembled-banks/Bank2.asm
@@ -5055,7 +5055,7 @@ label_9D4F::
     ld   e, [hl]
     inc  bc
     ld   e, [hl]
-    jp   [hl]
+    jp   hl
     ld   e, l
     jr   label_9DD5
     jp   nz, label_CD5D

--- a/src/disassembled-banks/Bank20.asm
+++ b/src/disassembled-banks/Bank20.asm
@@ -492,7 +492,8 @@ label_50240::
     inc  c
     dec  c
     ld   c, $0F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     nop
     ld   bc, label_1200
     inc  de
@@ -1166,7 +1167,8 @@ label_504E0::
     nop
     nop
     ld   c, $0F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     nop
     nop
     nop
@@ -2164,7 +2166,8 @@ label_5094E::
 
 label_50959::
     add  hl, bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $19
     jr   nz, label_50987
     jr   nc, label_50999
 
@@ -2355,7 +2358,8 @@ label_50A0A::
     jr   z, label_50A25
 
 label_50A25::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     jr   nc, label_50A69
     ld   d, b
     ld   h, b
@@ -3687,112 +3691,170 @@ label_51111::
     inc  c
     dec  l
     inc  c
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $B5
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     and  l
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A8
+    db   $10
+    db   $10
     or   a
     or   h
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     and  c
     ld   [label_808], sp
     ld   [$B010], sp
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $83
     inc  b
     inc  b
     inc  b
     inc  b
     and  [hl]
     ld   [label_808], sp
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     inc  b
     cp   h
     inc  b
     inc  b
     ld   [$A608], sp
     ld   [$B310], sp
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     inc  b
     inc  b
     inc  b
     inc  b
     ld   [label_808], sp
     ld   [label_10B8], sp
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     inc  b
     inc  b
     inc  b
     inc  b
     call nz, label_A10
     ld   a, [bc]
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $FC
     sbc  a, l
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     cp   l
     and  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0A
     ld   a, [bc]
     and  d
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $FB
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $0A
     ld   a, [bc]
     ld   a, [bc]
     ld   a, [bc]
     add  a, e
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $BA
+    db   $10
+    db   $B1
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $0A
     ld   a, [bc]
     ld   a, [bc]
     add  a, e
     xor  c
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $A4
+    db   $10
+    db   $10
+    db   $10
+    db   $AF
     xor  a
     cp   c
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     or   d
     dec  bc
     dec  bc
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $BE
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     xor  a
     xor  a
     ld   sp, hl
@@ -3801,25 +3863,42 @@ label_51111::
     db   $DB
     dec  bc
     dec  bc
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $C3
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
 
 label_51202::
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $9E
+    db   $10
+    db   $10
     nop
     nop
     nop
@@ -4072,8 +4151,10 @@ label_51333::
     inc  b
     inc  b
     inc  b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     nop
     nop
     nop

--- a/src/disassembled-banks/Bank21.asm
+++ b/src/disassembled-banks/Bank21.asm
@@ -8430,7 +8430,7 @@ label_570F7::
     db   $E4 ; Undefined instruction
     push hl
     rst  $20
-    jp   [hl]
+    jp   hl
     db   $ED ; Undefined instruction
 
 label_570FC::
@@ -8458,13 +8458,13 @@ label_570FF::
     ei
     or   $F1
     db   $ED ; Undefined instruction
-    jp   [hl]
+    jp   hl
     rst  $20
     push hl
     db   $E4 ; Undefined instruction
     push hl
     rst  $20
-    jp   [hl]
+    jp   hl
     db   $ED ; Undefined instruction
     pop  af
     or   $FB

--- a/src/disassembled-banks/Bank21.asm
+++ b/src/disassembled-banks/Bank21.asm
@@ -3462,7 +3462,8 @@ label_55501::
     nop
     ld   [label_20FF], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   nz, label_55512
 
 label_55512::
@@ -3475,7 +3476,8 @@ label_55512::
     nop
     ld   [label_560FF], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   h, b
     nop
     nop
@@ -3486,7 +3488,8 @@ label_55512::
     nop
     ld   [label_20FF], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   nz, label_55532
 
 label_55532::
@@ -3499,7 +3502,8 @@ label_55532::
     nop
     ld   [label_560FF], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   h, b
     ld    hl, sp+$F8
     ld   a, d
@@ -3510,7 +3514,8 @@ label_55532::
     ld    hl, sp+$08
     ld   a, h
     jr   nz, label_55546
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7A
     jr   nz, label_5555A
     ld    hl, sp+$7A
     ld   b, b
@@ -3529,7 +3534,8 @@ label_55532::
     ld    hl, sp+$08
     ld   a, b
     jr   nz, label_55566
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $76
     jr   nz, label_5557A
     ld    hl, sp+$76
     ld   b, b
@@ -3548,7 +3554,8 @@ label_55532::
     ld    hl, sp+$08
     ld   [hl], h
     jr   nz, label_55586
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $72
     jr   nz, label_5559A
     ld    hl, sp+$72
     ld   b, b
@@ -3567,7 +3574,8 @@ label_55532::
     ld    hl, sp+$08
     ld   l, b
     jr   nz, label_555A6
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
     jr   nz, label_555BA
     ld    hl, sp+$66
     ld   b, b
@@ -3575,7 +3583,8 @@ label_55532::
     nop
     ld   [label_56A08], sp
     jr   nz, label_555C6
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
     ld   h, b
     ld    hl, sp+$F8
     ld   h, b
@@ -3586,7 +3595,8 @@ label_55532::
     ld    hl, sp+$08
     ld   h, d
     jr   nz, label_555C6
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_555DA
     ld    hl, sp+$60
     ld   b, b
@@ -3594,7 +3604,8 @@ label_55532::
     nop
     ld   [label_56408], sp
     jr   nz, label_555E6
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     ld   h, b
     ld    hl, sp+$F8
     ld   l, h
@@ -3605,7 +3616,8 @@ label_55532::
     ld    hl, sp+$08
     ld   l, [hl]
     jr   nz, label_555E6
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6C
     jr   nz, label_555FA
     ld    hl, sp+$6C
     ld   b, b
@@ -3613,7 +3625,8 @@ label_55532::
     nop
     ld   [label_57008], sp
     jr   nz, label_55606
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6C
     ld   h, b
     nop
     nop
@@ -3626,7 +3639,8 @@ label_55606::
     nop
     ld   [label_20FF], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   nz, label_55612
 
 label_55612::
@@ -3639,7 +3653,8 @@ label_55612::
     nop
     ld   [label_560FF], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   h, b
 
 label_55621::
@@ -4207,7 +4222,8 @@ label_5594B::
 
 label_5595B::
     jr   label_55971
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
     ld   [label_205], sp
     ld   bc, $E0AF
     pop  af
@@ -4424,7 +4440,8 @@ label_55AA7::
     ld   a, [$FFF1]
     ld   a, [$FF00+C]
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   c, $10
 
 label_55ABB::
@@ -4462,14 +4479,18 @@ label_55ACF::
     inc  bc
 
 label_55AE3::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0D
     dec  c
 
 label_55AE6::
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
+    db   $10
+    db   $0D
     dec  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     push af
     or   $F5
     db   $F4 ; Undefined instruction
@@ -4576,7 +4597,8 @@ label_55B74::
     ld    hl, sp+$08
     ld   h, d
     jr   nz, label_55B79
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_55B8A
     ld    hl, sp+$6E
     nop
@@ -4584,7 +4606,8 @@ label_55B74::
     nop
     ld   [label_56408], sp
     jr   nz, label_55B96
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6E
     jr   nz, label_55B8D
     ld    hl, sp+$60
     nop
@@ -4594,7 +4617,8 @@ label_55B74::
     ld    hl, sp+$08
     ld   h, d
     jr   nz, label_55B99
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_55BAA
     ld   sp, hl
     ld   l, [hl]
@@ -4614,7 +4638,8 @@ label_55B74::
     ld    hl, sp+$08
     ld   h, d
     jr   nz, label_55BB9
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_55BCB
     ld   sp, hl
     ld   l, [hl]
@@ -4638,7 +4663,8 @@ label_55BD7::
     ld    hl, sp+$08
     ld   h, d
     jr   nz, label_55BD9
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_55BEB
     ld    hl, sp+$6E
     nop
@@ -4650,7 +4676,8 @@ label_55BEB::
 
 label_55BEF::
     jr   nz, label_55BF7
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6E
     jr   nz, label_55BEF
     ld    hl, sp+$60
 
@@ -4662,7 +4689,8 @@ label_55BFB::
     nop
     ld   a, [label_56208]
     jr   nz, label_55BFB
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_55C0D
     ld    hl, sp+$6E
     nop
@@ -4672,7 +4700,8 @@ label_55BFB::
 
 label_55C0F::
     jr   nz, label_55C19
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6E
     jr   nz, label_55C0F
     ld    hl, sp+$60
     nop
@@ -4682,7 +4711,8 @@ label_55C1B::
     nop
     ld   a, [label_56608]
     jr   nz, label_55C1B
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_55C2A
     ld    hl, sp+$6E
     nop
@@ -4692,7 +4722,8 @@ label_55C1B::
 
 label_55C2F::
     jr   nz, label_55C36
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6E
     jr   nz, label_55C2F
     ld    hl, sp+$60
     nop
@@ -4702,7 +4733,8 @@ label_55C3B::
     nop
     ld   a, [label_56608]
     jr   nz, label_55C3B
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_55C4A
     ld   sp, hl
     ld   l, [hl]
@@ -4724,7 +4756,8 @@ label_55C5B::
     nop
     ld   a, [label_56608]
     jr   nz, label_55C5B
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_55C6B
     ld   sp, hl
     ld   l, [hl]
@@ -4750,7 +4783,8 @@ label_55C7B::
     nop
     ld   a, [label_56608]
     jr   nz, label_55C7B
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_55C8B
     ld    hl, sp+$6E
     nop
@@ -4760,7 +4794,8 @@ label_55C8B::
     nop
     ld   [label_56808], sp
     jr   nz, label_55C97
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6E
     jr   nz, label_55C8D
     ld    hl, sp+$60
 
@@ -4772,7 +4807,8 @@ label_55C97::
     ld    hl, sp+$08
     ld   h, [hl]
     jr   nz, label_55C99
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_55CA9
     ld    hl, sp+$6E
     nop
@@ -4780,7 +4816,8 @@ label_55C97::
     nop
     ld   [label_56808], sp
     jr   nz, label_55CB5
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6E
     jr   nz, label_55CAD
 
 label_55CB5::
@@ -5435,7 +5472,8 @@ label_56010::
     jr   nz, label_56037
 
 label_56037::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $78
     jr   nz, label_56043
     nop
     ld   a, h
@@ -5610,7 +5648,8 @@ label_56135::
     ld    hl, sp+$08
     ld   h, d
     jr   nz, label_5613A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_5614E
     ld    hl, sp+$64
 
@@ -5620,7 +5659,8 @@ label_56148::
     nop
     ld   [label_56608], sp
     jr   nz, label_5615A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $64
     jr   nz, label_5614E
     ld    hl, sp+$60
     nop
@@ -5630,7 +5670,8 @@ label_56148::
     ld    hl, sp+$08
     ld   h, d
     jr   nz, label_5615A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_5616E
     ld    hl, sp+$6C
     nop
@@ -5649,7 +5690,8 @@ label_56148::
     ld    hl, sp+$08
     ld   h, d
     jr   nz, label_5617A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_5618E
     ld    hl, sp+$68
     ld   b, b
@@ -5668,7 +5710,8 @@ label_56148::
     ld    hl, sp+$08
     ld   h, d
     jr   nz, label_5619A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_561AE
     ld    hl, sp+$60
     ld   b, b
@@ -5729,7 +5772,8 @@ label_56148::
 
 label_56200::
     jr   nz, label_561FA
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     jr   nz, label_5620E
     ld    hl, sp+$60
 
@@ -5750,7 +5794,8 @@ label_56208::
     ld    hl, sp+$08
     ld   h, d
     jr   nz, label_5621A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_5622E
     ld    hl, sp+$60
     ld   b, b
@@ -5758,7 +5803,8 @@ label_56208::
     ld   b, b
     ld   [label_56E08], sp
     jr   nz, label_5623A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6C
     jr   nz, label_562A6
     nop
     ld   [hl], b
@@ -6436,8 +6482,10 @@ label_56608::
     nop
 
 label_56610::
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
+    db   $10
+    db   $F0
     db   $E8 ; add  sp, d
     ld   a, [$FF10]
     jr   label_565E6
@@ -6665,7 +6713,8 @@ label_5677F::
     jr   label_5679B
     inc  d
     ld   [de], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0E
     inc  c
     ld   a, [bc]
     ld   [label_406], sp
@@ -6953,7 +7002,8 @@ label_56948::
     nop
     ld   [label_56C08], sp
     jr   nz, label_56969
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6A
     jr   nz, label_56964
     rst  $38
     rst  $38
@@ -6975,7 +7025,8 @@ label_56969::
     nop
     ld   [label_56C08], sp
     jr   nz, label_56989
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6A
     jr   nz, label_56984
 
 label_56985::
@@ -6997,7 +7048,8 @@ label_56985::
     nop
     ld   [label_56C08], sp
     jr   nz, label_569A9
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6A
     jr   nz, label_569A4
     rst  $38
     rst  $38
@@ -7021,7 +7073,8 @@ label_569AC::
     nop
     ld   [label_56C08], sp
     jr   nz, label_569C9
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6A
     jr   nz, label_569C4
     rst  $38
     rst  $38
@@ -7099,7 +7152,8 @@ label_56A08::
     rst  $38
     rst  $38
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     nop
     ei
     jr   label_56A82
@@ -7116,7 +7170,8 @@ label_56A08::
     db   $F4 ; Undefined instruction
 
 label_56A2E::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $64
 
 label_56A30::
     jr   nz, label_56A30
@@ -7168,7 +7223,8 @@ label_56A5C::
     ld    hl, sp+$66
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
     jr   nz, label_56A65
     rst  $38
     rst  $38
@@ -7378,7 +7434,8 @@ label_56B41::
     ld    hl, sp+$08
     ld   a, b
     jr   nz, label_56B41
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $76
     jr   nz, label_56B55
     ld    hl, sp+$76
     ld   b, b
@@ -7496,13 +7553,15 @@ label_56B71::
     nop
     ld   [label_2074], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $72
     jr   nz, label_56BD5
 
 label_56BD5::
     ld   [rIE], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     rst  $38
     nop
     nop
@@ -8483,7 +8542,8 @@ label_57127::
     inc  c
     ld   c, $10
     ld   de, label_1112
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0E
     inc  c
     ld   a, [bc]
     ld   b, $03
@@ -8791,7 +8851,8 @@ label_57320::
     ldi  [hl], a
 
 label_57328::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     nop
     nop
 
@@ -9597,7 +9658,8 @@ label_5781B::
     inc  c
 
 label_5781D::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
     nop
     db   $F4 ; Undefined instruction
     ld   a, [$FFF4]

--- a/src/disassembled-banks/Bank22.asm
+++ b/src/disassembled-banks/Bank22.asm
@@ -809,7 +809,8 @@ label_58323::
     ld   c, e
     add  hl, bc
     ld   c, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $4B
     rla
     ld   c, e
 
@@ -1270,7 +1271,8 @@ label_58527::
     ld   d, b
     add  hl, bc
     ld   d, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $50
     dec  d
     ld   d, b
     inc  e
@@ -1367,7 +1369,8 @@ label_585BE::
     ld   d, c
     dec  c
     ld   d, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $51
     inc  de
     ld   d, c
     ld   d, $51
@@ -4491,14 +4494,19 @@ label_592FF::
     cpl
     rst  $38
     scf
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $53
+    db   $10
+    db   $57
+    db   $10
+    db   $45
     ld   [de], a
     rst  $38
     inc  sp
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $53
+    db   $10
+    db   $45
     ld   [de], a
     ld   d, a
     ld   de, label_5A4FF
@@ -4574,15 +4582,21 @@ label_5932D::
     nop
     cp   a
     inc  d
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
+    db   $10
+    db   $34
+    db   $10
+    db   $25
     ld   [de], a
     rst  $38
     inc  de
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
+    db   $10
+    db   $35
+    db   $10
+    db   $24
     ld   [de], a
     rst  $38
     rst  $38
@@ -5177,7 +5191,8 @@ label_59567::
     ld   h, d
     push bc
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CD
     ld   d, $CD
     ld   d, b
     call label_CD56

--- a/src/disassembled-banks/Bank22.asm
+++ b/src/disassembled-banks/Bank22.asm
@@ -44,7 +44,7 @@ section "bank22",romx,bank[$16]
     ld   d, c
     db   $E8 ; add  sp, d
     ld   d, c
-    jp   [hl]
+    jp   hl
     ld   d, c
     db   $EC ; Undefined instruction
     ld   d, c
@@ -264,7 +264,7 @@ label_5811C::
 label_58120::
     db   $E8 ; add  sp, d
     ld   d, e
-    jp   [hl]
+    jp   hl
     ld   d, e
     ld   a, [$FF00+C]
     ld   bc, label_654
@@ -797,7 +797,7 @@ label_58323::
     db   $E3 ; Undefined instruction
     ld   c, d
     and  $4A
-    jp   [hl]
+    jp   hl
     ld   c, d
     ld   [$EB4A], a
     ld   c, d
@@ -1348,7 +1348,7 @@ label_58527::
     ld   d, b
     db   $E4 ; Undefined instruction
     ld   d, b
-    jp   [hl]
+    jp   hl
     ld   d, b
     xor  $50
     pop  af
@@ -5316,7 +5316,7 @@ label_59631::
     dec  [hl]
     ld   [$EA44], a
     inc  [hl]
-    jp   [hl]
+    jp   hl
     ld   b, l
     db   $EB ; Undefined instruction
     rst  $38

--- a/src/disassembled-banks/Bank23.asm
+++ b/src/disassembled-banks/Bank23.asm
@@ -45,7 +45,8 @@ label_5C021::
     dec  l
     ld   d, $3C
     ldd  [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     ld   [bc], a
     ld   l, $0D
     add  hl, de
@@ -1301,7 +1302,8 @@ label_5C4CE::
     ld   a, [bc]
     ld   a, [bc]
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
 
 label_5C4D4::
     nop
@@ -1314,7 +1316,8 @@ label_5C4D4::
     inc  c
     dec  c
     ld   c, $0F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     nop
     ld   bc, label_1312
     inc  d
@@ -1754,41 +1757,66 @@ label_5C746::
     inc  de
 
 label_5C74C::
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $50
 
 label_5C752::
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     ld   d, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   d, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
 
 label_5C760::
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $50
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     ld   d, b
     ld   d, b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     ld   d, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [hl], b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
 
 label_5C784::
     ld   a, [$D011]
@@ -3885,13 +3913,15 @@ label_5D265::
     nop
     jr   nz, label_5D294
     add  a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     ld   b, d
     nop
     nop
     sub  a, d
     jr   nz, label_5D2BE
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   b, a
     ret
     dec  d
@@ -3906,7 +3936,8 @@ label_5D280::
     ret
     dec  d
     add  a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     ld   b, d
     nop
 
@@ -3915,7 +3946,8 @@ label_5D288::
     inc  c
     inc  e
     add  a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     ld   b, d
     nop
     nop
@@ -3926,21 +3958,24 @@ label_5D292::
     add  a, h
 
 label_5D294::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     ld   b, d
     inc  c
     inc  e
     add  hl, bc
     ld   c, b
     add  a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     ld   b, d
     adc  a, h
 
 label_5D2A0::
     ld   bc, label_2092
     ld   c, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     ld   b, d
     nop
     nop
@@ -3991,7 +4026,8 @@ label_5D2A0::
     nop
     nop
     ld   c, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   [label_5C7FF], sp
     push hl
     inc  c
@@ -4024,7 +4060,8 @@ label_5D2FB::
     ld   [label_2129], sp
     add  a, $00
     ld   c, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   [label_2129], sp
     nop
     nop
@@ -4057,10 +4094,12 @@ label_5D337::
     inc  bc
     inc  d
     ld   hl, $A504
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     ld   [label_1403], sp
     ld   hl, $A504
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $63
     nop
     dec  h
     ld   [label_423], sp
@@ -7589,7 +7628,8 @@ label_5E51D::
     sbc  a, c
     add  a, [hl]
     dec  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
     inc  d
@@ -8260,12 +8300,14 @@ label_5EA0C::
     ld   b, [hl]
     inc  b
     xor  e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $B3
     ld   a, [hl]
     nop
     nop
     xor  e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $B1
     add  hl, hl
     push bc
     ld   c, h
@@ -8319,8 +8361,10 @@ label_5EA33::
     nop
     nop
     ld   h, b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C3
+    db   $10
+    db   $B3
     ld   a, [hl]
     nop
     nop
@@ -8598,12 +8642,18 @@ label_5EBA1::
     dec  d
     dec  d
     dec  d
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     dec  d
     dec  d
     dec  d
@@ -9316,7 +9366,8 @@ label_5EFB9::
     ld   c, $98
     ld  [$FF00+C], a
     ld   c, $0E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     nop
     inc  de
@@ -9406,7 +9457,8 @@ label_5F0D1::
     ld   [$C108], sp
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CE
     nop
     ld   [$CF10], sp
     nop
@@ -9432,7 +9484,8 @@ label_5F0F2::
     ld   [$C108], sp
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CE
     nop
     ld   [$CF10], sp
     nop
@@ -9458,7 +9511,8 @@ label_5F11A::
     ld   [$D108], sp
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CE
     nop
     ld   [$CF10], sp
     nop
@@ -9484,7 +9538,8 @@ label_5F142::
     ld   [$D108], sp
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CE
     nop
     ld   [$CF10], sp
     nop
@@ -9741,7 +9796,8 @@ label_5F2D8::
     ld   [$004E], sp
     ld   [label_5CF08], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     ld   h, b
     nop
     jr   label_5F2E6
@@ -9755,13 +9811,15 @@ label_5F2D8::
 label_5F2F6::
     ld   h, e
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   h, h
     nop
     jr   label_5F306
     ld   h, l
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   h, [hl]
     nop
     jr   label_5F316
@@ -9779,7 +9837,8 @@ label_5F306::
     ld   [$004E], sp
     ld   [label_5CF08], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     ld   l, b
     nop
     jr   label_5F316
@@ -9793,13 +9852,15 @@ label_5F306::
 label_5F326::
     ld   l, e
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   l, h
     nop
     jr   label_5F336
     ld   l, l
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   l, [hl]
     nop
     jr   label_5F346
@@ -9817,7 +9878,8 @@ label_5F336::
     ld   [$004E], sp
     ld   [label_5CF08], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     ld   [hl], b
     nop
     jr   label_5F346
@@ -9831,13 +9893,15 @@ label_5F336::
 label_5F356::
     ld   [hl], e
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   [hl], h
     nop
     jr   label_5F366
     ld   [hl], l
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     db   $76 ; Halt
     nop
     jr   label_5F376
@@ -9855,7 +9919,8 @@ label_5F366::
     ld   [$004E], sp
     ld   [label_5CF08], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     ld   a, b
     nop
     jr   label_5F376
@@ -9869,13 +9934,15 @@ label_5F366::
 label_5F386::
     ld   a, e
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   a, h
     nop
     jr   label_5F396
     ld   a, l
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   a, [hl]
     nop
     jr   label_5F3A6
@@ -9961,7 +10028,8 @@ label_5F3FF::
     nop
     ld   [$0002], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $04
     nop
     nop
     jr   label_5F414
@@ -9974,12 +10042,14 @@ label_5F3FF::
 label_5F414::
     jr   z, label_5F420
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     inc  d
 
 label_5F41A::
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
     ld   d, $00
     jr   nz, label_5F441
     ld   e, $00
@@ -10024,7 +10094,8 @@ label_5F44B::
     ld   b, b
     ld   [$0032], sp
     ld   b, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $34
     nop
     ld   b, b
     jr   label_5F48C
@@ -10050,13 +10121,16 @@ label_5F46B::
     stop
     inc  c
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
 
 label_5F471::
     ld   c, $00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     stop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   [de], a
     nop
     jr   nz, label_5F485
@@ -10080,17 +10154,20 @@ label_5F485::
     stop
     inc  c
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
 
 label_5F491::
     ld   b, d
 
 label_5F492::
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   b, h
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   b, [hl]
     nop
     jr   nz, label_5F4A5
@@ -10114,15 +10191,18 @@ label_5F4A5::
     stop
     inc  c
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
 
 label_5F4B1::
     ld   d, d
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   d, h
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   d, [hl]
     nop
     jr   nz, label_5F4C5
@@ -10261,16 +10341,21 @@ label_5F572::
     ld   h, d
     stop
     ld   [label_3062], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   h, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld    hl, sp+$66
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     ld   l, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [label_3068], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   h, [hl]
     jr   nc, label_5F59F
     jr   label_5F5F5
@@ -10279,16 +10364,19 @@ label_5F572::
 
 label_5F594::
     ld   l, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     ld   [label_306A], sp
     jr   nc, label_5F594
     ld   l, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $30
 
 label_5F59F::
     nop
     ld   l, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $30
     ld   [label_306E], sp
     jr   nc, label_5F5B8
 
@@ -10328,7 +10416,8 @@ label_5F5E1::
     nop
     ld   [$00B2], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $B4
     nop
     nop
     jr   label_5F5A2
@@ -10336,15 +10425,18 @@ label_5F5E1::
     nop
     jr   nz, label_5F5A8
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     cp   d
     nop
 
 label_5F5F5::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     cp   h
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     add  a, [hl]
 
 label_5F5FC::
@@ -10396,7 +10488,8 @@ label_5F623::
     nop
     ld   [$00C2], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C4
     nop
     nop
     jr   label_5F5F6
@@ -10404,13 +10497,15 @@ label_5F623::
     nop
     jr   nz, label_5F5FC
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
 
 label_5F637::
     jp   z, label_1000
     jr   label_5F608
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     sub  a, [hl]
     nop
     jr   nz, label_5F643
@@ -10462,7 +10557,8 @@ label_5F667::
     nop
     ld   [$00D2], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D4
     nop
     nop
     jr   label_5F64A
@@ -10470,13 +10566,15 @@ label_5F667::
     nop
     jr   nz, label_5F650
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
 
 label_5F67B::
     jp  c, label_1000
     jr   label_5F65C
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     and  [hl]
     nop
     jr   nz, label_5F687
@@ -10698,7 +10796,8 @@ label_5F7A9::
     nop
     ld   [$000E], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1E
     nop
     nop
     jr   label_5F7E2
@@ -10706,13 +10805,16 @@ label_5F7A9::
     stop
     ld   d, b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   d, d
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   d, h
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   e, b
     nop
 
@@ -10720,7 +10822,8 @@ label_5F7C5::
     nop
     ld   [$000E], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1E
     nop
     nop
     jr   label_5F7FE
@@ -10728,13 +10831,16 @@ label_5F7C5::
     stop
     ld   h, b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   h, d
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   h, h
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   l, b
     nop
 
@@ -11112,7 +11218,8 @@ label_5F9C1::
     add  hl, bc
     ld   e, h
     ld   e, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0A
     ld   e, d
     ld   e, e
     ld   c, e
@@ -11376,7 +11483,8 @@ label_5FB71::
     jr   nz, label_5FBB3
     ld   h, b
     ld   a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $48
     ld   l, b
     sub  a, b
     jr   nc, label_5FBCB

--- a/src/disassembled-banks/Bank23.asm
+++ b/src/disassembled-banks/Bank23.asm
@@ -7463,7 +7463,7 @@ label_5E51D::
     add  a, $05
     or   h
     or   l
-    jp   [hl]
+    jp   hl
     ld   [$B9B8], a
     sbc  a, c
     and  $05

--- a/src/disassembled-banks/Bank24.asm
+++ b/src/disassembled-banks/Bank24.asm
@@ -406,7 +406,8 @@ label_602BA::
     nop
     ld   [$0062], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $64
     nop
     nop
     jr   label_6032F
@@ -414,13 +415,16 @@ label_602BA::
     stop
     ld   l, b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   l, d
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   l, h
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   l, [hl]
     nop
     nop
@@ -430,7 +434,8 @@ label_602BA::
     nop
     ld   [$0072], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $74
     nop
     nop
     jr   label_6035F
@@ -438,13 +443,16 @@ label_602BA::
     stop
     ld   l, b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   l, d
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   l, h
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   l, [hl]
     nop
     nop
@@ -454,7 +462,8 @@ label_602BA::
     nop
     ld   [$007A], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7C
     nop
     nop
     jr   label_60387
@@ -462,13 +471,16 @@ label_602BA::
     stop
     ld   l, b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   l, d
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   l, h
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   l, [hl]
     nop
     nop
@@ -479,7 +491,8 @@ label_602BA::
 label_6031F::
     ld   [label_207C], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7A
     jr   nz, label_60327
 
 label_60327::
@@ -491,7 +504,8 @@ label_60327::
 
 label_6032F::
     ld   [label_206C], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   l, d
     jr   nz, label_60347
     jr   label_603A1
@@ -505,7 +519,8 @@ label_6033B::
 label_6033F::
     ld   [label_2074], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $72
     jr   nz, label_60347
 
 label_60347::
@@ -517,7 +532,8 @@ label_6034B::
     ld   l, [hl]
     jr   nz, label_6035F
     ld   [label_206C], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   l, d
     jr   nz, label_60367
     jr   label_603C1
@@ -1205,7 +1221,8 @@ label_60728::
     nop
     ld   [$0042], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $44
     nop
     call label_C05
     jr   nz, label_60746
@@ -1268,7 +1285,8 @@ label_6078F::
     stop
     ld   d, h
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   d, [hl]
     nop
     ld    hl, sp+$10
@@ -1282,7 +1300,8 @@ label_6078F::
     nop
     jr   label_6080C
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   e, [hl]
     ld   b, b
     nop
@@ -1294,7 +1313,8 @@ label_6078F::
     stop
     ld   c, d
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   c, h
     nop
     ld    hl, sp+$10
@@ -1308,7 +1328,8 @@ label_6078F::
     nop
     jr   label_60830
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   e, [hl]
     ld   b, b
     nop
@@ -1320,7 +1341,8 @@ label_6078F::
     stop
     ld   d, h
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   d, [hl]
     nop
     ld    hl, sp+$10
@@ -1334,7 +1356,8 @@ label_6078F::
     nop
     jr   label_60854
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   e, [hl]
     ld   b, b
     nop
@@ -1346,7 +1369,8 @@ label_6078F::
     stop
     ld   c, d
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   c, h
     nop
     ld    hl, sp+$10
@@ -1360,7 +1384,8 @@ label_6078F::
     nop
     jr   label_60878
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   e, [hl]
     ld   b, b
 
@@ -1883,7 +1908,8 @@ label_60B15::
     stop
     ld   [hl], h
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   [hl], h
     jr   nz, label_60B66
 
@@ -1897,7 +1923,8 @@ label_60B6A::
     stop
     ld   [hl], h
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   [hl], h
     jr   nz, label_60B76
 
@@ -1911,7 +1938,8 @@ label_60B7A::
     stop
     ld   [hl], h
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   [hl], h
     jr   nz, label_60B86
 
@@ -1924,7 +1952,8 @@ label_60B86::
     stop
     ld   [hl], h
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   [hl], h
     jr   nz, label_60C10
     ld   [bc], a
@@ -2778,7 +2807,8 @@ label_61110::
     stop
     ld   a, h
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   a, h
     ld   h, a
     jr   nz, label_6111A
@@ -2813,14 +2843,16 @@ label_61126::
     ld   b, b
     ld   [label_6277A], sp
     ld   b, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $78
     ld   h, a
 
 label_61140::
     stop
     ld   a, h
     ld   d, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   a, h
     inc  [hl]
     jr   nz, label_6114A
@@ -2855,7 +2887,8 @@ label_61156::
     ld   b, b
     ld   [label_6347A], sp
     ld   b, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $78
     ld   [hl], h
 
 label_61170::
@@ -3837,13 +3870,16 @@ label_6179B::
     ld   bc, $0010
     ld   a, b
     ld   b, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   a, d
     ld   b, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   a, h
     ld   b, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   a, [hl]
     ld   b, c
     nop
@@ -3853,7 +3889,8 @@ label_6179B::
     nop
     ld   [label_6016A], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6C
     ld   b, c
     nop
     jr   label_61898
@@ -3861,13 +3898,16 @@ label_6179B::
     stop
     ld   h, b
     ld   b, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   h, d
     ld   b, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   h, h
     ld   b, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   h, [hl]
     ld   b, c
     ld   c, $00
@@ -3885,13 +3925,16 @@ label_6179B::
     stop
     rst  $38
     ld   b, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     rst  $38
     ld   b, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     rst  $38
     ld   b, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     rst  $38
     ld   b, c
 
@@ -4726,7 +4769,8 @@ label_61D7D::
 label_61D7F::
     nop
     ld   bc, $00FF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     call label_63DE8
     ld   a, $01
     ld   [$FFA4], a
@@ -4807,7 +4851,8 @@ label_61DFB::
     ld   b, $00
     ld   [label_654], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $56
     ld   b, $00
     ld    hl, sp+$50
     inc  bc
@@ -4818,7 +4863,8 @@ label_61DFB::
     nop
     ld   [label_354], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $56
     inc  bc
 
 label_61E1B::
@@ -5600,7 +5646,8 @@ label_6232D::
     ret
 
 label_6237D::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     jr   nc, label_623C1
     ld   d, b
     ld   h, b
@@ -6131,7 +6178,8 @@ label_62679::
     add  hl, bc
     dec  c
     ld   c, $0F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   de, $0111
 
 label_626A3::
@@ -6336,7 +6384,8 @@ label_6273A::
     db   $FD ; Undefined instruction
     ld   [label_236E], sp
     db   $FD ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6C
     inc  hl
     nop
     nop
@@ -6445,7 +6494,8 @@ label_6273A::
     db   $FC ; Undefined instruction
     ld   [label_236E], sp
     db   $FC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6C
     inc  hl
     nop
     nop
@@ -6460,7 +6510,8 @@ label_6273A::
     ld   l, h
     inc  hl
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6E
     inc  hl
     nop
     jr   label_628CD
@@ -6480,7 +6531,8 @@ label_6273A::
     inc  b
     ld   [label_236E], sp
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6C
     inc  hl
     nop
     nop
@@ -6718,7 +6770,8 @@ label_629BD::
     ld   [label_100C], sp
     inc  c
     ld   [label_2104], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C0
     ld   a, [$FFE7]
     rra
     rra
@@ -8420,9 +8473,12 @@ label_633FA::
     db   $FC ; Undefined instruction
 
 label_63406::
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     call label_C05
     jr   nz, label_63416
     ld   [hl], $80
@@ -8734,7 +8790,8 @@ label_6358E::
     ld   a, [$FF08]
     ld   a, h
     ld   [hl], $F0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $70
     daa
     nop
     nop
@@ -9104,7 +9161,8 @@ label_637ED::
     ldi  [hl], a
 
 label_6381D::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     ld   de, $F1F0
     rla

--- a/src/disassembled-banks/Bank25.asm
+++ b/src/disassembled-banks/Bank25.asm
@@ -1675,7 +1675,8 @@ label_64A50::
     add  hl, bc
     ld   e, h
     ld   e, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0A
     ld   e, d
     ld   e, e
     ld   c, e
@@ -2098,10 +2099,13 @@ label_64D25::
 
 label_64D35::
     ld   a, [$FFFC]
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
+    db   $10
+    db   $F0
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     db   $E8 ; add  sp, d
     ld   a, [$FFF8]
     ld    hl, sp+$08
@@ -2669,7 +2673,8 @@ label_650A1::
     jp   label_2373
 
 label_650A4::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
     inc  de
@@ -3107,7 +3112,8 @@ label_6536C::
     ld    hl, sp+$08
     ld   h, d
     jr   nz, label_65371
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_65385
     ld    hl, sp+$60
     ld   b, b
@@ -3431,7 +3437,8 @@ label_6554B::
     nop
     ld   [label_252], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     ldi  [hl], a
     nop
     jr   label_655AA
@@ -3439,13 +3446,16 @@ label_6554B::
     stop
     ld   d, h
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   d, [hl]
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   d, [hl]
     ldi  [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   d, h
     ldi  [hl], a
 
@@ -3457,7 +3467,8 @@ label_6556B::
     nop
     ld   [label_352], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     inc  hl
     nop
     jr   label_655CA
@@ -3465,13 +3476,16 @@ label_6556B::
     stop
     ld   d, h
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   d, [hl]
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   d, [hl]
     inc  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   d, h
     inc  hl
     ld   a, [$FFF1]
@@ -3708,7 +3722,8 @@ label_656BD::
     ld   d, [hl]
     db   $ED ; Undefined instruction
     ld   d, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $57
     ld   c, b
     ld   d, a
     ld   a, [$FFEC]
@@ -3792,7 +3807,8 @@ label_65768::
     nop
     ld   [label_772], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $72
     daa
     nop
     jr   label_657E7
@@ -3800,13 +3816,16 @@ label_65768::
     stop
     ld   [hl], h
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     db   $76 ; Halt
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     db   $76 ; Halt
     daa
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   [hl], h
     daa
 
@@ -4996,7 +5015,8 @@ label_65DF8::
     inc  bc
 
 label_65E10::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
     inc  de
@@ -5417,7 +5437,8 @@ label_6608D::
     nop
     inc  b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $98
     rlca
     adc  a, c
     ld   bc, $0111
@@ -6103,7 +6124,8 @@ label_66449::
     ld   b, $00
     ld   [label_678], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7A
     ld   b, $00
     nop
     rst  $38
@@ -6113,7 +6135,8 @@ label_66449::
     ld   b, $00
     ld   [label_67E], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7E
     ld   h, $00
     jr   label_664E2
     ld   h, $00
@@ -6122,7 +6145,8 @@ label_66449::
     ld   h, $00
     ld   [label_2678], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $76
     ld   h, $00
     nop
     rst  $38
@@ -6194,7 +6218,8 @@ label_66449::
     ld   [bc], a
     ld   l, b
     dec  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $02
     ld   l, d
     ld   b, $20
     ld   [bc], a
@@ -6203,14 +6228,16 @@ label_66449::
     dec  b
     ld   l, b
     dec  [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $05
     ld   l, d
     ld   h, $20
     dec  b
     ld   l, d
     ld   h, $00
     ld   bc, label_1568
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
     ld   l, d
     ld   b, $20
     ld   bc, label_66A
@@ -6218,7 +6245,8 @@ label_66449::
     rlca
     ld   l, b
     dec  [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $07
     ld   l, d
     ld   h, $20
     rlca
@@ -6236,7 +6264,8 @@ label_664FA::
     ld   l, d
     ld   b, $00
     ld   [label_3568], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   l, d
     ld   h, $20
     ld   [label_266A], sp
@@ -7760,15 +7789,18 @@ label_66E25::
     nop
     ld   [label_352], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $54
     inc  bc
     stop
     ld   d, [hl]
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   e, b
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   e, d
     inc  bc
     rst  $38
@@ -7786,18 +7818,22 @@ label_66E25::
     nop
     ld   [label_352], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5C
     inc  bc
     stop
     ld   d, [hl]
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   e, b
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   e, [hl]
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   h, b
     inc  bc
     rst  $38
@@ -7811,18 +7847,22 @@ label_66E25::
     nop
     ld   [label_364], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
     inc  bc
     stop
     ld   l, b
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   e, b
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   e, [hl]
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   h, b
     inc  bc
     rst  $38
@@ -7836,18 +7876,22 @@ label_66E25::
     nop
     ld   [label_36C], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6E
     inc  bc
     stop
     ld   l, b
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   e, b
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   e, [hl]
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   h, b
     inc  bc
     rst  $38
@@ -7859,17 +7903,21 @@ label_66EA5::
     stop
     ld   [hl], h
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     db   $76 ; Halt
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [hl], h
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     db   $76 ; Halt
     rlca
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $74
     rlca
     nop
     jr   label_66F32
@@ -8075,7 +8123,8 @@ label_66FD9::
     ld   [label_66008], sp
     ldi  [hl], a
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $50
 
 label_67004::
     ldi  [hl], a
@@ -8288,7 +8337,8 @@ label_67118::
     inc  b
     ld   [label_374], sp
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $70
     inc  hl
     db   $F4 ; Undefined instruction
     nop
@@ -8303,7 +8353,8 @@ label_67118::
     inc  b
     ld   [label_2372], sp
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7A
     inc  hl
     db   $F4 ; Undefined instruction
     nop
@@ -8780,7 +8831,8 @@ label_67421::
     db   $E8 ; add  sp, d
     ld   [$007C], sp
     db   $E8 ; add  sp, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7C
     ld   h, b
     ld    hl, sp+$08
 
@@ -8814,7 +8866,8 @@ label_6746E::
     ret  c
     ld   [label_6407C], sp
     ret  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7C
     jr   nz, label_67469
 
 label_67481::
@@ -9050,7 +9103,8 @@ label_675C1::
     ld    hl, sp+$08
     ld   l, d
     jr   nz, label_675C5
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     jr   nz, label_675D9
     nop
     ld   l, h
@@ -9074,7 +9128,8 @@ label_675E1::
     ld    hl, sp+$08
     ld   h, h
     jr   nz, label_675E5
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $62
     jr   nz, label_675F9
     nop
     ld   h, [hl]
@@ -9098,7 +9153,8 @@ label_67601::
     ld    hl, sp+$08
     ld   e, h
     jr   nz, label_67605
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5A
     jr   nz, label_67619
     ld    hl, sp+$5E
     nop
@@ -9106,7 +9162,8 @@ label_67601::
     nop
     ld   [label_66008], sp
     jr   nz, label_67625
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5E
     jr   nz, label_67619
     ld    hl, sp+$56
     nop
@@ -9116,7 +9173,8 @@ label_67601::
     ld    hl, sp+$08
     ld   e, b
     jr   nz, label_67625
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $56
     jr   nz, label_67639
     ld    hl, sp+$56
     ld   b, b
@@ -9284,7 +9342,8 @@ label_6775C::
     ld    hl, sp+$78
     ld   b, b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $78
     ld   h, b
     nop
 
@@ -9418,7 +9477,8 @@ label_677F4::
     nop
     ld   [label_66076], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $76
     nop
     db   $E4 ; Undefined instruction
     inc  b
@@ -9439,7 +9499,8 @@ label_6780A::
 label_6780C::
     ld   [label_66078], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $78
     nop
     db   $F4 ; Undefined instruction
 
@@ -9453,7 +9514,8 @@ label_67818::
     db   $F4 ; Undefined instruction
 
 label_6781C::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $76
     ld   h, b
     db   $F4 ; Undefined instruction
 
@@ -9465,7 +9527,8 @@ label_67822::
     db   $EC ; Undefined instruction
     ld    hl, sp+$74
     jr   nz, label_67814
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $74
     nop
     ld   a, [$FFD8]
     ld   a, b

--- a/src/disassembled-banks/Bank25.asm
+++ b/src/disassembled-banks/Bank25.asm
@@ -9935,7 +9935,7 @@ label_67A8F::
     ld   a, [hli]
     ld   h, [hl]
     ld   l, a
-    jp   [hl]
+    jp   hl
     cp   [hl]
     ld   a, d
     db   $DB

--- a/src/disassembled-banks/Bank26.asm
+++ b/src/disassembled-banks/Bank26.asm
@@ -952,12 +952,12 @@ label_68437::
     ld   [bc], a
 
 label_68484::
-    jp   [hl]
+    jp   hl
     add  a, e
 
 label_68486::
     ld   [de], a
-    jp   [hl]
+    jp   hl
     jp   nz, label_E22
     jp   nz, label_3862
 

--- a/src/disassembled-banks/Bank26.asm
+++ b/src/disassembled-banks/Bank26.asm
@@ -14,7 +14,8 @@ label_68009::
     jp   nz, label_F542
     jp   label_F533
     jp   nz, label_F544
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3C
     jp   nz, label_3720
 
 label_68021::
@@ -126,11 +127,13 @@ label_68021::
     dec  bc
     inc  h
     or   $E1
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A5
     ld   d, b
     ld   a, h
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A6
     ld   d, b
     ld   a, h
     ld   d, h
@@ -239,7 +242,8 @@ label_6812F::
     nop
     inc  b
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $04
     add  a, a
     jr   nz, label_6813D
     adc  a, b
@@ -317,7 +321,8 @@ label_6817C::
     db   $3A ; ldd  a, [hl]
     ld   [bc], a
     jr   c, label_6810C
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
     ld   [de], a
     ld   c, [hl]
     add  a, d
@@ -489,7 +494,8 @@ label_68225::
     ld   b, l
     pop  hl
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9C
     ld   d, b
     ld   a, h
     add  a, l
@@ -573,7 +579,8 @@ label_6828B::
     ld   b, a
     ei
     ld  [$FF00+C], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E9
     ld   [$FE70], sp
     inc  bc
     inc  b
@@ -581,7 +588,8 @@ label_6828B::
     rst  $38
     push af
     add  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2C
     ld   [de], a
     dec  l
     ldi  [hl], a
@@ -788,7 +796,8 @@ label_683AC::
     nop
     db   $3A ; ldd  a, [hl]
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     adc  a, d
     jr   nz, label_683FE
     call nz, label_3722
@@ -843,7 +852,8 @@ label_683F1::
 label_683FE::
     db   $3A ; ldd  a, [hl]
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     add  a, h
     jr   nz, label_6843F
     inc  h
@@ -1234,7 +1244,8 @@ label_685D2::
     ld   [hl], b
     push af
     add  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0A
     ldi  [hl], a
     ld   a, [bc]
     jp   nz, label_A30
@@ -1453,7 +1464,8 @@ label_68682::
     db   $3A ; ldd  a, [hl]
     dec  b
     dec  sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F5
     jp   label_E08
     add  a, [hl]
     inc  [hl]
@@ -1517,7 +1529,8 @@ label_68700::
     pop  hl
     rra
     ld   a, [$FF38]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $06
     dec  sp
     jp   nz, label_3808
     call nz, label_E09
@@ -1762,7 +1775,8 @@ label_6886A::
     add  a, d
     rst  $30
     push af
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0B
     call nz, label_B11
     add  a, d
     ld   b, d
@@ -1790,7 +1804,8 @@ label_6886A::
     ld   [de], a
     rst  $30
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A7
     ld   d, b
     ld   a, h
     ld   h, $44
@@ -1820,7 +1835,8 @@ label_6886A::
     inc  [hl]
     db   $FD ; Undefined instruction
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A3
 
 label_688C3::
     ld   d, b
@@ -1900,7 +1916,8 @@ label_688C3::
     inc  sp
     pop  hl
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $B4
     ld   d, b
     ld   a, h
     ld   b, h
@@ -1969,7 +1986,8 @@ label_68954::
     add  a, l
     ld   a, [$FFF5]
     add  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2C
     inc  de
     dec  l
     add  a, [hl]
@@ -2019,7 +2037,8 @@ label_6898A::
     add  hl, bc
     push af
     add  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [de], a
     inc  d
     add  a, $20
@@ -2047,7 +2066,8 @@ label_689D7::
     inc  d
     add  a, $23
     ld   [de], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6E
     cp   $03
     inc  b
     add  a, d
@@ -2215,7 +2235,8 @@ label_68A98::
     ld   bc, label_93C
     dec  a
     rst  0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     rst  0
     ld   de, $C737
     add  hl, de
@@ -2277,7 +2298,8 @@ label_68AED::
     nop
     cpl
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     add  a, $20
     or   [hl]
     call nz, label_B643
@@ -2302,7 +2324,8 @@ label_68AED::
     nop
     cpl
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     push bc
     dec  h
     or   [hl]
@@ -2351,7 +2374,8 @@ label_68B31::
     ld   [$C538], sp
     add  hl, bc
     ld   c, $82
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     ld   [de], a
     dec  sp
     inc  d
@@ -2445,7 +2469,8 @@ label_68B31::
     inc  sp
     rst  $30
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A9
     ld   d, b
     ld   a, h
     rlca
@@ -2488,7 +2513,8 @@ label_68B31::
     ld   b, l
     pop  hl
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CB
     ld   d, b
     ld   a, h
     rlca
@@ -2560,7 +2586,8 @@ label_68C67::
     inc  b
     push bc
     ld    hl, sp+$F5
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3C
     push bc
     jr   nz, label_68CAE
     add  a, d
@@ -2631,11 +2658,13 @@ label_68CAE::
     dec  de
     jr   z, label_68CE6
     add  hl, hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $34
     dec  d
     add  a, e
     dec  [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     ld   d, $C2
     ld   d, e
     ld   a, [bc]
@@ -2676,7 +2705,8 @@ label_68CE6::
     db   $3A ; ldd  a, [hl]
     ld   bc, label_3E0
     dec  sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1A
     add  a, d
     ld   de, label_1310
     add  hl, de
@@ -2717,7 +2747,8 @@ label_68D0E::
     jr   label_68D57
     jr   z, label_68D57
     add  hl, de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     rrca
     cp   $03
     inc  b
@@ -2756,7 +2787,8 @@ label_68D57::
 label_68D70::
     ld   [hl], h
     db   $D3 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   nz, label_68D85
     ld   de, label_2119
     rla
@@ -3369,7 +3401,8 @@ label_6905B::
     dec  d
     add  a, e
     ld   [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $82
     ld   [$F804], sp
     push af
     cp   $03
@@ -3384,7 +3417,8 @@ label_6905B::
     ld   [hl], h
     ld   a, [bc]
     add  a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0A
     add  a, h
     ld   d, $0A
     adc  a, b
@@ -3401,7 +3435,8 @@ label_6905B::
     ldd  [hl], a
 
 label_6908A::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $34
     add  hl, de
     scf
     call nc, label_6AE38
@@ -3418,7 +3453,8 @@ label_69092::
     dec  d
     add  a, d
     ld   b, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $47
     add  hl, de
     add  a, d
     ld   d, b
@@ -3652,7 +3688,8 @@ label_691A7::
     inc  b
     ld   b, $38
     add  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $04
     add  a, e
     inc  de
     dec  a
@@ -3750,7 +3787,8 @@ label_69222::
     nop
     cpl
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     adc  a, c
     ld   h, c
     ld   a, [bc]
@@ -3780,14 +3818,16 @@ label_69222::
     ld   b, d
     ld  [$FF00+C], a
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DB
     ld   d, b
     ld   a, h
     jp   nz, label_6A260
     jr   z, label_692A5
     ld   [hl], $FD
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DD
     ld   d, b
     ld   a, h
     cp   $03
@@ -3796,7 +3836,8 @@ label_69222::
     nop
     cpl
     adc  a, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     add  hl, bc
     inc  a
     rst  0
@@ -3811,13 +3852,15 @@ label_69222::
     ld   h, b
     ld   a, h
     ld   hl, $E1F7
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D9
     ld   d, b
     ld   a, h
     inc  h
     rst  $30
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DA
     ld   d, b
     ld   a, h
     push bc
@@ -4325,7 +4368,8 @@ label_694F9::
     inc  sp
     db   $FD ; Undefined instruction
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C7
     ld   d, b
     ld   a, h
     cp   $03
@@ -4337,7 +4381,8 @@ label_694F9::
     ld   a, [bc]
     ld   b, $0A
     call nz, label_6AE07
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0A
     add  a, [hl]
     ld   de, label_135C
     db   $D3 ; Undefined instruction
@@ -4536,12 +4581,14 @@ label_695A5::
     ld   d, $44
     jp   nz, label_A62
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E3
     ld   d, b
     ld   a, h
     rst  $38
     push af
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
     ld   de, $FE3C
     inc  bc
     ld   a, [bc]
@@ -4601,7 +4648,8 @@ label_695A5::
     nop
     ld   a, [bc]
     add  a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0A
     add  a, d
     jr   nz, label_6967B
     add  a, d
@@ -4619,7 +4667,8 @@ label_6967C::
     inc  d
     rst  $30
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D7
     ld   d, b
     ld   a, h
     add  a, d
@@ -4673,7 +4722,8 @@ label_69689::
     add  hl, sp
     add  a, h
     ld   d, $3A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $B6
     jr   nz, label_6967D
     jr   nc, label_69704
     push bc
@@ -4834,7 +4884,8 @@ label_69780::
 
 label_69783::
     db   $3A ; ldd  a, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FB
     jr   label_69783
     ld   e, b
     ei
@@ -4863,7 +4914,8 @@ label_69783::
     adc  a, d
     nop
     db   $3A ; ldd  a, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FB
     ld   d, $FB
     jr   label_697AE
     ld   d, b
@@ -4892,7 +4944,8 @@ label_69783::
     inc  de
     db   $FD ; Undefined instruction
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     ld   d, b
     ld   a, h
     cp   $02
@@ -4916,7 +4969,8 @@ label_69783::
     jr   c, label_69813
     ld   h, h
     inc  h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FB
     ld   [de], a
     ei
     inc  d
@@ -4979,7 +5033,8 @@ label_6982F::
     rlca
     dec  [hl]
     add  a, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
     ld   d, $4E
     add  a, e
     rla
@@ -5033,7 +5088,8 @@ label_69873::
     ld   b, e
     push af
     add  a, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0A
     add  a, [hl]
     jr   nz, label_69892
     inc  [hl]
@@ -5107,7 +5163,8 @@ label_698D2::
     ld   d, e
     pop  hl
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9D
     ld   d, b
     ld   a, h
 
@@ -5196,7 +5253,8 @@ label_69920::
     adc  a, d
     nop
     ld   c, $8A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0E
     add  a, a
     inc  hl
     ld   c, $85
@@ -5210,7 +5268,8 @@ label_69920::
     scf
     rlca
     jr   c, label_698D2
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2C
     ld   [de], a
     dec  l
     inc  de
@@ -5360,7 +5419,8 @@ label_699E1::
     jp   nz, label_F5F3
     add  a, d
     or   $F5
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
     ld   de, label_213C
     scf
     ld   sp, label_3233
@@ -5428,7 +5488,8 @@ label_69A48::
     ld   a, [$FFF5]
     cp   $03
     ld   [label_3700], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $31
     call nz, label_3804
     ld   b, $33
     add  a, e
@@ -5574,7 +5635,8 @@ label_69ACF::
     ld   a, $08
     ld   l, $09
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
     ld   de, label_164E
     inc  h
     rla
@@ -5624,7 +5686,8 @@ label_69B3B::
     adc  a, d
 
 label_69B5E::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     adc  a, d
     ld   d, b
     ld   e, $8A
@@ -5638,7 +5701,8 @@ label_69B5E::
 
 label_69B6B::
     ld   bc, $C24E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     ld   de, label_213F
     dec  sp
     inc  hl
@@ -5658,7 +5722,8 @@ label_69B6B::
     nop
     db   $3A ; ldd  a, [hl]
     add  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     ld   [bc], a
     ccf
     ld   [de], a
@@ -5877,7 +5942,8 @@ label_69C48::
 label_69C71::
     ld   [rHDMA5], a
     inc  [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3D
     ld   de, label_122F
     ld   c, b
     inc  de
@@ -8595,7 +8661,8 @@ label_6A783::
     pop  af
     di
     ld   c, $01
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   c, d
     ld   c, e
     ld   e, d
@@ -8846,7 +8913,8 @@ label_6A8CA::
     inc  c
     inc  e
     inc  e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     ld   [de], a
     ld   a, a
     ld   a, a
@@ -8963,7 +9031,8 @@ label_6A940::
     dec  h
     ld   c, $0F
     ld   h, $27
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     ld   a, h
     nop
@@ -9011,7 +9080,8 @@ label_6A940::
     ld   [de], a
     nop
     ld   l, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6D
     ld   [de], a
     ld   a, h
     inc  de
@@ -9022,7 +9092,8 @@ label_6A940::
     dec  de
     nop
     dec  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1B
     dec  bc
     ld   bc, label_111B
     dec  bc
@@ -9470,7 +9541,8 @@ label_6AB5B::
     pop  af
     di
     ld   c, $01
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   c, d
     ld   c, e
     ld   e, d
@@ -9721,7 +9793,8 @@ label_6AC9E::
     inc  c
     inc  e
     inc  e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     ld   [de], a
     ld   a, a
     ld   a, a
@@ -9834,7 +9907,8 @@ label_6AD14::
     dec  h
     ld   c, $0F
     ld   h, $27
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     ld   a, h
     nop
@@ -9882,7 +9956,8 @@ label_6AD14::
     ld   [de], a
     nop
     ld   l, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6D
     ld   [de], a
     ld   a, h
     inc  de
@@ -9893,7 +9968,8 @@ label_6AD14::
     dec  de
     nop
     dec  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1B
     dec  bc
     ld   bc, label_111B
     dec  bc

--- a/src/disassembled-banks/Bank27.asm
+++ b/src/disassembled-banks/Bank27.asm
@@ -1921,7 +1921,8 @@ label_6CA54::
     ld   b, [hl]
     nop
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C0
     inc  hl
     nop
     jr   nz, label_6CAAD
@@ -1940,11 +1941,13 @@ label_6CA54::
     add  a, c
     nop
     db   $3A ; ldd  a, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C0
     add  a, b
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C0
     ld   d, a
     nop
     nop
@@ -4073,7 +4076,8 @@ label_6D403::
     nop
     ret  z
     ld   c, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $54
     ld   e, $54
     inc  l
     ld   d, h
@@ -5917,7 +5921,8 @@ label_6DB96::
     add  a, d
     nop
     and  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1E
     and  c
     inc  h
     and  d
@@ -5925,7 +5930,8 @@ label_6DB96::
     jr   z, label_6DB88
     ld   bc, label_CA1
     ld   c, $A2
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A1
     ld   e, $A2
     inc  h
     ld   h, $A1
@@ -7812,7 +7818,8 @@ label_6E3CC::
     nop
     sbc  a, d
     sbc  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A1
     jr   z, label_6E415
     sbc  a, h
     sbc  a, c
@@ -8394,7 +8401,8 @@ label_6E64D::
     ld   l, h
     and  e
     ld   [hl], b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6C
     nop
     nop
     sbc  a, l
@@ -9816,7 +9824,8 @@ label_6EC90::
     ld   l, a
     adc  a, b
     ld   l, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $70
     and  a
     ld   l, l
     add  a, e
@@ -9920,7 +9929,8 @@ label_6ECEA::
     add  a, d
     nop
     and  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     sbc  a, l
     ld   [hl], c
     add  a, d
@@ -9936,7 +9946,8 @@ label_6ECEA::
     nop
     and  d
     ld   bc, label_1006
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9D
     ld   [hl], c
     add  a, d
     add  a, b
@@ -9986,11 +9997,13 @@ label_6ECEA::
     add  a, d
     nop
     and  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     and  h
     ld   bc, label_1A2
     ld   b, $10
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A4
     ld   bc, label_10A3
     sbc  a, e
     inc  bc
@@ -10634,7 +10647,8 @@ label_6F00C::
     and  l
     ld   bc, $009C
     sbc  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A5
     ld   bc, $009C
     xor  b
     ld   bc, $A600
@@ -11275,7 +11289,8 @@ label_6F32B::
     and  d
     dec  d
     and  e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9C
     and  d
     dec  d
     dec  d

--- a/src/disassembled-banks/Bank27.asm
+++ b/src/disassembled-banks/Bank27.asm
@@ -4087,7 +4087,7 @@ label_6D403::
     ld   d, h
     ld   [hl], c
     ld   d, h
-    jp   [hl]
+    jp   hl
     ld   d, h
     rst  $38
     rst  $38

--- a/src/disassembled-banks/Bank28.asm
+++ b/src/disassembled-banks/Bank28.asm
@@ -251,7 +251,7 @@ label_7006C::
     ld   [hl], a
     ret  c
     ld   [hl], a
-    jp   [hl]
+    jp   hl
     ld   [hl], a
     ld   a, [label_70877]
     ld   a, b
@@ -1215,7 +1215,7 @@ label_704FF::
     ld   [hl], a
     cp   l
     ld   [hl], a
-    jp   [hl]
+    jp   hl
     ld   [hl], a
     add  hl, hl
     ld   a, b
@@ -1346,7 +1346,7 @@ label_705B6::
     push hl
     and  $E7
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     ld   [$ECEB], a
     db   $ED ; Undefined instruction
     xor  $EF

--- a/src/disassembled-banks/Bank28.asm
+++ b/src/disassembled-banks/Bank28.asm
@@ -399,7 +399,8 @@ label_70181::
     ld   [hl], b
     db   $E4 ; Undefined instruction
     ld   [hl], c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $72
     sub  a, b
     ld   [hl], d
     adc  a, a
@@ -762,7 +763,8 @@ label_70320::
     ld   b, e
     xor  a
     ld   b, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $44
     scf
     ld   b, h
     ld   a, b
@@ -877,7 +879,8 @@ label_70380::
     rst  0
     ld   d, d
     or   $52
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $53
     dec  de
     ld   d, h
     ei
@@ -1264,7 +1267,8 @@ label_704FF::
     push hl
     ld   a, h
     ld   bc, $007D
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     jr   nc, label_705A6
     ld   d, b
     ld   h, b
@@ -1277,7 +1281,8 @@ label_704FF::
     ret  nc
     ld   [$FFF0], a
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     jr   nc, label_705B6
     ld   d, b
     ld   h, b
@@ -1555,7 +1560,8 @@ label_705FF::
     inc  c
     dec  c
     ld   c, $0F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
     inc  d

--- a/src/disassembled-banks/Bank3.asm
+++ b/src/disassembled-banks/Bank3.asm
@@ -227,7 +227,8 @@ label_C0FB::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $02
     nop
     nop
     nop
@@ -521,7 +522,8 @@ label_C1F6::
     ld   a, [de]
     add  hl, de
     inc  e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     nop
     rra
@@ -812,7 +814,8 @@ label_C36D::
     ld   b, d
     ld   b, d
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [$0018], sp
     inc  de
     nop
@@ -1562,7 +1565,8 @@ label_C73C::
     rst  $38
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   b, b
     nop
     nop
@@ -1692,8 +1696,10 @@ label_C7F1::
     inc  b
     ld   [label_1808], sp
     ld   [label_804], sp
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
+    db   $10
+    db   $08
     ld   [label_804], sp
     ld   [label_808], sp
     ld   [label_808], sp
@@ -1704,7 +1710,8 @@ label_C7F1::
     inc  c
     inc  c
     inc  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     ld   [label_408], sp
     inc  b
     inc  b
@@ -2621,7 +2628,8 @@ label_CE04::
     ret
 
 label_CE05::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     call label_3A81
     call label_FF7E
     call label_FFA9
@@ -3184,7 +3192,8 @@ label_D156::
     ld   a, e
 
 label_D15A::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $12
     ld   de, $F813
     ld   sp, hl
     ld   a, [label_EFB]
@@ -3763,7 +3772,8 @@ label_D4C8::
     ld   bc, label_10F8
     db   $3A ; ldd  a, [hl]
     ld   hl, $F8F8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $02
     ld    hl, sp+$00
     ld   [de], a
     ld   [bc], a
@@ -3771,7 +3781,8 @@ label_D4C8::
     ld   [de], a
     ldi  [hl], a
     ld    hl, sp+$10
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $22
     ld   [label_10F8], sp
     ld   b, d
     ld   [label_1200], sp
@@ -4085,7 +4096,8 @@ label_D6DF::
 
 label_D6EA::
     ld   bc, label_808
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
     inc  b
     inc  b
 
@@ -5580,7 +5592,8 @@ label_DFEF::
 label_DFFB::
     jp   z, label_F014
     ld    hl, sp+$E6
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C2
     adc  a, l
     ccf
     call label_E1DE
@@ -6467,7 +6480,8 @@ label_E530::
     ld   bc, label_1008
     ldd  [hl], a
     ld   hl, $F8F8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $02
     ld    hl, sp+$00
     ld   [de], a
     ld   [bc], a
@@ -6475,7 +6489,8 @@ label_E530::
     ld   [de], a
     ldi  [hl], a
     ld    hl, sp+$10
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $22
     ld   [label_10F8], sp
     ld   b, d
     ld   [label_1200], sp
@@ -6851,7 +6866,8 @@ label_E75D::
 
 label_E769::
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     stop
     nop
     stop
@@ -8160,7 +8176,8 @@ label_EF5C::
     ret
 
 label_EF65::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     nop
     nop
 
@@ -9628,7 +9645,8 @@ label_F85F::
     ld   [label_608], sp
     ld   a, [bc]
     ld   [$FF08], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   [label_D02], sp
 
 label_F87F::

--- a/src/disassembled-banks/Bank3.asm
+++ b/src/disassembled-banks/Bank3.asm
@@ -1883,7 +1883,7 @@ label_C918::
     ld   [hl], $05
     ld   a, $03
     call label_9D3
-    jp   [hl]
+    jp   hl
 
 label_C924::
     ld   bc, label_2104

--- a/src/disassembled-banks/Bank30.asm
+++ b/src/disassembled-banks/Bank30.asm
@@ -7624,7 +7624,7 @@ label_7A46E::
     rst  $10
     ld   h, h
     ld   [$FF64], a
-    jp   [hl]
+    jp   hl
     ld   h, h
     ld   c, $6E
     ld   a, [$FF00+C]
@@ -7861,9 +7861,9 @@ label_7A569::
     ld   h, h
     ld   [$FF64], a
     ld   [$FF64], a
-    jp   [hl]
+    jp   hl
     ld   h, h
-    jp   [hl]
+    jp   hl
     ld   h, h
     ld   a, [$FF00+C]
     ld   a, [$FF00+C]
@@ -7904,10 +7904,10 @@ label_7A569::
     ld   h, h
     inc  de
     ld   l, [hl]
-    jp   [hl]
+    jp   hl
     ld   h, h
     ld   c, $6E
-    jp   [hl]
+    jp   hl
     ld   h, h
     ld   a, [$FF00+C]
     inc  de
@@ -9381,7 +9381,7 @@ label_7AB67::
     ld   l, h
     sbc  a, e
     ld   l, l
-    jp   [hl]
+    jp   hl
     ld   l, h
     adc  a, h
     ld   l, l
@@ -9389,17 +9389,17 @@ label_7AB67::
 label_7AC6C::
     sbc  a, l
     ld   l, [hl]
-    jp   [hl]
+    jp   hl
     ld   l, h
     sub  a, h
     ld   l, [hl]
-    jp   [hl]
+    jp   hl
     ld   l, h
     sbc  a, e
     ld   l, l
     sub  a, a
     ld   l, [hl]
-    jp   [hl]
+    jp   hl
     ld   l, h
     ld   a, h
     ld   l, [hl]
@@ -9447,23 +9447,23 @@ label_7AC9A::
     ld   e, a
     sbc  a, e
     ld   l, l
-    jp   [hl]
+    jp   hl
     ld   l, h
     adc  a, h
     ld   l, l
     sbc  a, l
     ld   l, [hl]
-    jp   [hl]
+    jp   hl
     ld   l, h
     db   $EB ; Undefined instruction
     ld   l, l
     sub  a, h
     ld   l, [hl]
-    jp   [hl]
+    jp   hl
     ld   l, h
     sub  a, a
     ld   l, [hl]
-    jp   [hl]
+    jp   hl
     ld   l, h
     adc  a, h
     ld   l, l

--- a/src/disassembled-banks/Bank30.asm
+++ b/src/disassembled-banks/Bank30.asm
@@ -128,7 +128,8 @@ label_7807F::
     ld   h, h
     and  l
     ld   [hl], d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
 
 label_780A1::
     ld   [hl], $66
@@ -1912,7 +1913,8 @@ label_78A51::
     ld   b, [hl]
     nop
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C0
     inc  hl
     nop
     jr   nz, label_78AAA
@@ -1931,11 +1933,13 @@ label_78A51::
     add  a, c
     nop
     db   $3A ; ldd  a, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C0
     add  a, b
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C0
     ld   d, a
     nop
     nop
@@ -1943,7 +1947,8 @@ label_78A51::
     add  a, b
     stop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $80
     ld   bc, label_402
     ld   [label_2010], sp
     ld   b, $0C
@@ -3234,7 +3239,8 @@ label_78EAA::
     ld   l, l
     or   b
     ld   l, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6D
     add  hl, bc
     ld   l, [hl]
     ld   d, c
@@ -4140,8 +4146,10 @@ label_7941F::
     nop
     ret  nz
     and  c
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
+    db   $10
+    db   $28
     ld   bc, label_1C1A
     ld   bc, $0110
     ld   [de], a
@@ -4246,7 +4254,8 @@ label_794A7::
     sbc  a, b
     nop
     and  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9B
     rrca
     ld   c, $9C
     nop
@@ -4348,18 +4357,22 @@ label_794A7::
     rra
     ld   [$009C], sp
     and  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9B
     dec  c
     ld   c, $9C
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $12
     sbc  a, e
     rrca
     inc  d
     sbc  a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9B
     ld   c, $0E
     sbc  a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $12
     sbc  a, e
     rlca
     inc  d
@@ -4372,7 +4385,8 @@ label_794A7::
     sbc  a, e
     ld   [bc], a
     and  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   bc, label_2810
     ld   bc, label_1C1A
     ld   bc, $0110
@@ -4558,7 +4572,8 @@ label_796A5::
     sub  a, c
     ld   d, a
     sbc  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A5
     ld   bc, $A39C
     ld   bc, label_CA1
     jr   label_796D6
@@ -4660,7 +4675,8 @@ label_796D6::
     sbc  a, d
     and  c
     ld   a, [bc]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   d, $A5
     ld   e, $A4
     ld   bc, label_20A1
@@ -6294,7 +6310,8 @@ label_79E6C::
     rst  $38
     ld   [hl], l
     ld   e, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6D
     ld   a, l
     ld   l, l
     sbc  a, e
@@ -6388,7 +6405,8 @@ label_79EF3::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6D
     ld   a, l
     ld   l, l
     add  hl, de
@@ -6656,12 +6674,14 @@ label_7A001::
     ld   c, b
     nop
     sbc  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $99
     and  d
     jr   label_7A029
     sbc  a, h
     sbc  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $04
     inc  e
     sbc  a, h
     nop
@@ -6829,7 +6849,8 @@ label_7A0A2::
     ld   l, [hl]
     inc  bc
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6D
     db   $E3 ; Undefined instruction
     ld   h, b
     rst  $38
@@ -7005,7 +7026,8 @@ label_7A13F::
     db   $E8 ; add  sp, d
     nop
     and  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   e, $26
     and  e
     ld   d, [hl]
@@ -7015,7 +7037,8 @@ label_7A13F::
     and  e
     ld   h, b
     and  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1E
     jr   z, label_7A1DE
     ld   e, h
     ld   e, b
@@ -7115,7 +7138,8 @@ label_7A21E::
     and  h
     ld   c, b
     and  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   e, $26
     jr   z, label_7A25F
     ld   [hl], $3E
@@ -7245,7 +7269,8 @@ label_7A2B3::
 label_7A2B4::
     ld   a, l
     ld   l, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6D
     ld   a, [$FF00+C]
     add  hl, bc
     ld   l, [hl]
@@ -8004,7 +8029,8 @@ label_7A636::
     ld   l, [hl]
     inc  h
     ld   l, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6D
     ld   d, e
     ld   h, [hl]
     rst  $38
@@ -8041,7 +8067,8 @@ label_7A669::
 label_7A66D::
     add  hl, bc
     ld   l, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6D
     add  a, l
     ld   h, [hl]
     sbc  a, e
@@ -8110,7 +8137,8 @@ label_7A6A2::
     nop
     ld   a, l
     ld   l, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6D
     or   $66
     and  h
     ld   l, [hl]
@@ -8125,7 +8153,8 @@ label_7A6A2::
     jp   nz, label_A066
     ld   l, l
     or   $66
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6D
     and  h
     ld   l, [hl]
     cp   [hl]
@@ -8301,7 +8330,8 @@ label_7A757::
     ld   h, a
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6D
     ld   a, b
     ld   l, l
     db   $DB
@@ -8804,7 +8834,8 @@ label_7A9A2::
     nop
     ld   a, l
     ld   l, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6D
     ld   [rOBPI], sp
     rst  $38
     ld    hl, sp+$69
@@ -8871,7 +8902,8 @@ label_7A9A2::
     ld   l, l
     xor  b
     ld   l, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6D
     ld   a, l
     ld   l, l
     ld   [label_246A], sp
@@ -8897,7 +8929,8 @@ label_7A9A2::
     ld   l, d
     ld   a, l
     ld   l, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6D
     sbc  a, e
     ld   l, d
     dec  l
@@ -8917,7 +8950,8 @@ label_7AA62::
 
 label_7AA6A::
     jr   nz, label_7AAD9
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6D
     ld   a, l
     ld   l, l
     jr   z, label_7AADD
@@ -8927,7 +8961,8 @@ label_7AA6A::
 
 label_7AA75::
     ld   l, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6D
     rst  $38
     rst  $38
     ld   e, h
@@ -8939,7 +8974,8 @@ label_7AA75::
     ld   l, [hl]
     or   b
     ld   l, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6D
     ld   h, a
     ld   e, l
     ld   b, [hl]
@@ -9324,7 +9360,8 @@ label_7AB67::
     nop
     ld   l, l
     ld   l, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6D
     rst  $38
     rst  $38
     jr   nz, label_7AC9A
@@ -10988,12 +11025,14 @@ label_7B2D7::
     ld   bc, $009C
     ld   bc, label_7A635
     ld   d, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $02
     ld   b, [hl]
     adc  a, d
     ld   bc, label_7A635
     ld   d, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $02
     ld   b, [hl]
     adc  a, d
     nop
@@ -11180,14 +11219,16 @@ label_7B36A::
     ld   b, e
 
 label_7B3C1::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
     inc  [hl]
     ld   b, [hl]
     ld   a, c
     sbc  a, b
     ld   h, h
     ld   b, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
     inc  [hl]
     sbc  a, l
     cp   h
@@ -12168,23 +12209,29 @@ label_7B808::
 label_7B80A::
     sbc  a, b
     and  [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A1
 
 label_7B80E::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
     and  d
     inc  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     and  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A2
     inc  c
     inc  d
 
 label_7B819::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     inc  c
     and  a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9D
     and  c
     nop
     add  a, b
@@ -12622,7 +12669,8 @@ label_7B9F6::
     ld   a, d
     rst  $38
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7A
     ld   c, l
     ld   a, d
     rst  $38
@@ -13092,7 +13140,8 @@ label_7BBA4::
     ld   a, [de]
     sbc  a, h
     sbc  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A0
     dec  d
     sbc  a, h
     sbc  a, [hl]

--- a/src/disassembled-banks/Bank31.asm
+++ b/src/disassembled-banks/Bank31.asm
@@ -507,7 +507,7 @@ label_7C223::
     call label_7FA64
     ld   de, $D390
     ld   bc, $D394
-    jp   [hl]
+    jp   hl
     xor  a
     ld   [$D370], a
     ld   [$D371], a
@@ -1453,7 +1453,7 @@ label_7C7C9::
     ld   b, a
     db   $E3 ; Undefined instruction
     ld   b, a
-    jp   [hl]
+    jp   hl
     ld   b, a
 
 label_7C7D1::
@@ -3607,7 +3607,7 @@ label_7D40C::
     ld   a, [$D3CD]
     and  a
     ret  nz
-    jp   [hl]
+    jp   hl
 
 label_7D41B::
     and  a
@@ -6696,7 +6696,7 @@ label_7E508::
 label_7E50B::
     ld   de, $D393
     ld   bc, $D398
-    jp   [hl]
+    jp   hl
 
 label_7E512::
     ld   a, [$C50E]
@@ -7159,7 +7159,7 @@ label_7E7AA::
     jp   label_7FA25
 
 label_7E7DC::
-    jp   [hl]
+    jp   hl
     ld   h, a
     db   $EC ; Undefined instruction
     ld   h, a

--- a/src/disassembled-banks/Bank31.asm
+++ b/src/disassembled-banks/Bank31.asm
@@ -324,7 +324,8 @@ label_7C100::
     ld   c, l
     rst  $28
     ld   c, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $4E
     ld   d, [hl]
     ld   c, [hl]
     add  a, a
@@ -918,7 +919,8 @@ label_7C477::
     ld   [$9F1F], sp
     add  a, c
     jr   nz, label_7C427
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $21
     ret  z
     ld   b, h
     call label_7FAB7
@@ -1145,11 +1147,13 @@ label_7C5E4::
     dec  bc
     nop
     add  a, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     add  a, b
     ld   c, $00
     push bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C3
     ld   e, h
     ld   a, e
     ld   a, $17
@@ -1432,7 +1436,8 @@ label_7C784::
 label_7C7A8::
     cpl
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     add  a, [hl]
     inc  d
     ld   hl, label_7C7D1
@@ -1575,7 +1580,8 @@ label_7C869::
 label_7C86F::
     nop
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7B
     add  a, a
     inc  b
     ld   a, $2C
@@ -1699,7 +1705,8 @@ label_7C925::
     pop  hl
     nop
     rst  0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A0
     add  a, $09
     nop
     add  a, $18
@@ -1841,7 +1848,8 @@ label_7C9F7::
     and  a
     add  a, a
     ld   bc, $0000
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A7
     add  a, a
     ld   bc, label_7E1FA
     db   $D3 ; Undefined instruction
@@ -1991,7 +1999,8 @@ label_7CAC1::
     ld  [$FF00+C], a
     cp   [hl]
     add  a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $21
     and  $4A
     jp   label_7D39A
     call label_7FA71
@@ -2328,7 +2337,8 @@ label_7CCCF::
     add  a, a
     ld   bc, $0000
     ld   b, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $87
     ld   bc, $0000
     ld   b, a
     ld   [hl], b
@@ -2463,7 +2473,8 @@ label_7CD7C::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   a, [$FFFF]
     ld   a, [$FFFF]
     ld   a, [$FFFF]
@@ -2507,7 +2518,8 @@ label_7CDAB::
     rst  $30
     nop
     add  a, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3E
     rlca
     ld   [$D3BC], a
     ld   hl, label_7CDE9
@@ -3088,7 +3100,8 @@ label_7D101::
     jr   nz, label_7D103
 
 label_7D103::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   a, [$FFFF]
     ld   a, [$FFFF]
     ld   a, [$FFFF]
@@ -3256,7 +3269,8 @@ label_7D1F0::
 label_7D1F6::
     nop
     ld   b, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D0
     add  a, a
     ld   bc, label_7E1FA
     db   $D3 ; Undefined instruction
@@ -3397,7 +3411,8 @@ label_7D2CD::
     add  a, [hl]
     ld   bc, $8000
     pop  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $86
     ld   bc, label_43E
     ld   [$D3BC], a
     ld   hl, label_7D32B
@@ -3443,7 +3458,8 @@ label_7D319::
 
 label_7D327::
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld    hl, sp+$00
     add  a, b
     ld   a, [de]
@@ -3451,7 +3467,8 @@ label_7D327::
     add  a, d
     ld   bc, $8000
     push hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $84
     ld   bc, label_7E021
     ld   d, e
     jp   label_7D395
@@ -3686,7 +3703,8 @@ label_7D461::
     ld   d, l
     cp   h
     ld   d, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $56
     ld   e, [hl]
     ld   d, [hl]
     ld  [$FF00+C], a
@@ -3835,7 +3853,8 @@ label_7D52B::
     jr   nz, label_7D52D
 
 label_7D52D::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   a, [$FFFF]
     ld   [$FF80], a
     nop
@@ -4501,7 +4520,8 @@ label_7D8D7::
     ld   e, c
     db   $3A ; ldd  a, [hl]
     ld   e, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $59
     ccf
     ld   e, c
     ld   d, $59
@@ -5455,9 +5475,11 @@ label_7DE09::
     ld   a, [$FF00]
     jr   nz, label_7DE1F
     ld   a, [$FF00]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld    hl, sp+$00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld    hl, sp+$00
     ld   [$F9FF], sp
     nop
@@ -5493,48 +5515,66 @@ label_7DE5D::
     nop
     ld   [$F7FF], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     xor  $00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     xor  $00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     xor  $00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     xor  $00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     xor  $00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     xor  $00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     xor  $00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     xor  $00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     xor  $00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     xor  $00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     db   $EC ; Undefined instruction
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     db   $EC ; Undefined instruction
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     db   $EC ; Undefined instruction
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     db   $EC ; Undefined instruction
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     db   $EC ; Undefined instruction
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     db   $EC ; Undefined instruction
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     db   $EC ; Undefined instruction
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     db   $EC ; Undefined instruction
 
 label_7DEB1::
@@ -5747,7 +5787,8 @@ label_7DFDE::
     ld   a, [bc]
     ld   h, b
     ld    hl, sp+$5F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     cp   $5F
     ld   d, $60
 
@@ -6443,7 +6484,8 @@ label_7E3DC::
     db   $76 ; Halt
     ld   d, h
     ldd  [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1E
     ld   h, l
     dec  a
     ld   h, l
@@ -6658,7 +6700,8 @@ label_7E46C::
     ld   [hl], l
     and  a
     db   $76 ; Halt
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $76
     jr   nc, label_7E557
     sub  a, b
     ld   [hl], a
@@ -6804,7 +6847,8 @@ label_7E5A2::
     call z, label_C765
     ld   h, l
     jp   nz, label_3765
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $04
     ret  nz
     ld   [bc], a
     nop
@@ -6862,7 +6906,8 @@ label_7E5E3::
 label_7E60A::
     dec  d
     ld   h, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
     ld   a, [de]
     ld   h, [hl]
 
@@ -7086,7 +7131,8 @@ label_7E74F::
     inc  b
     jr   nc, label_7E71C
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C0
     inc  b
     ld   hl, label_7E783
     jp   label_7F9E9
@@ -7633,7 +7679,8 @@ label_7EA71::
     add  hl, hl
     ld   l, b
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3C
     ret  nz
     ld   d, b
     ret  nz
@@ -7659,7 +7706,8 @@ label_7EA7A::
     ld   h, d
     add  hl, bc
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $21
     ret
     ld   l, d
     jp   label_7F9E9
@@ -8402,7 +8450,8 @@ label_7EEA2::
     ld   bc, $006D
     ld   bc, $006E
     ld   bc, $006F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3E
     dec  b
     ld   [$D3BF], a
     ld   hl, label_7EF1D
@@ -8719,10 +8768,12 @@ label_7F09A::
     ret  nz
     ld   [bc], a
     ld   h, $29
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C0
     inc  b
     ld   h, $10
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C0
     ld   [bc], a
     ld   h, $19
     ld   h, b
@@ -8733,7 +8784,8 @@ label_7F09A::
     ret  nz
     ld   [bc], a
     ld   h, $10
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C0
     inc  bc
     ld   a, $08
     ld   [$D3BF], a
@@ -9054,19 +9106,23 @@ label_7F26D::
     add  a, b
     dec  b
     scf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $30
     ret  nz
     ld   [bc], a
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $40
     add  a, b
     inc  bc
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $50
     add  a, b
     inc  b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     add  a, b
     dec  b
     ld   hl, label_7F2CE
@@ -9446,7 +9502,8 @@ label_7F460::
     add  a, b
     ld   [bc], a
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $15
     add  a, b
     ld   [bc], a
     ld   a, $40
@@ -9851,7 +9908,8 @@ label_7F647::
     add  a, b
     ld   [bc], a
     scf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $4D
     ret  nz
     ld   [bc], a
     ld   hl, label_7F6D6
@@ -9956,7 +10014,8 @@ label_7F6E6::
 label_7F716::
     inc  b
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     ret  nz
     inc  b
     xor  a
@@ -10078,7 +10137,8 @@ label_7F7D6::
     ld   bc, label_7E000
     jr   nz, label_7F75F
     ld   bc, label_7C000
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A0
     add  a, a
     ld   bc, $A321
     ld   a, b

--- a/src/disassembled-banks/Bank32.asm
+++ b/src/disassembled-banks/Bank32.asm
@@ -270,7 +270,7 @@ label_80100::
     add  a, b
     ld   e, d
     dec  b
-    jp   [hl]
+    jp   hl
     ld   e, l
     jr   label_801A6
     ld   d, l
@@ -1493,7 +1493,7 @@ label_80669::
     ld   [hl], e
     ld   l, $69
     inc  b
-    jp   [hl]
+    jp   hl
     dec  l
     ld   l, c
     inc  b
@@ -2834,7 +2834,7 @@ label_80D88::
     db   $E3 ; Undefined instruction
     push hl
     and  $E8
-    jp   [hl]
+    jp   hl
     db   $EB ; Undefined instruction
     db   $EC ; Undefined instruction
     xor  $EF
@@ -2876,7 +2876,7 @@ label_80D88::
     db   $E3 ; Undefined instruction
     push hl
     and  $E8
-    jp   [hl]
+    jp   hl
     db   $EB ; Undefined instruction
     db   $EC ; Undefined instruction
     xor  $F0
@@ -2918,7 +2918,7 @@ label_80D88::
     db   $E4 ; Undefined instruction
     push hl
     and  $E8
-    jp   [hl]
+    jp   hl
     ld   [$EDEC], a
     xor  $F0
     pop  af
@@ -2960,7 +2960,7 @@ label_80D88::
     db   $E4 ; Undefined instruction
     push hl
     and  $E8
-    jp   [hl]
+    jp   hl
     ld   [$EDEC], a
     xor  $EF
     pop  af
@@ -3003,7 +3003,7 @@ label_80E95::
     push hl
     and  $E7
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     db   $EB ; Undefined instruction
     db   $EC ; Undefined instruction
     db   $ED ; Undefined instruction
@@ -3046,7 +3046,7 @@ label_80E95::
     push hl
     and  $E7
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     ld   [$ECEB], a
     xor  $EF
     ld   a, [$FFF1]
@@ -3086,7 +3086,7 @@ label_80F01::
     push hl
     and  $E7
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     ld   [$ECEB], a
     db   $ED ; Undefined instruction
     xor  $EF
@@ -3128,7 +3128,7 @@ label_80F55::
     and  $E7
     db   $E8 ; add  sp, d
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     ld   [$ECEB], a
     db   $ED ; Undefined instruction
     xor  $EF
@@ -3169,7 +3169,7 @@ label_80F55::
     ld   a, [$FFF0]
     rst  $20
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     ld   [$ECEB], a
     db   $EC ; Undefined instruction
     db   $EC ; Undefined instruction
@@ -3213,7 +3213,7 @@ label_80FB8::
     ld   a, [de]
     dec  de
     ld   a, [$FFE9]
-    jp   [hl]
+    jp   hl
     ld   [$EBEB], a
     db   $EC ; Undefined instruction
     db   $ED ; Undefined instruction
@@ -6077,7 +6077,7 @@ label_81DFB::
 
 label_81E00::
     ld   e, l
-    jp   [hl]
+    jp   hl
     ld   e, l
     db   $ED ; Undefined instruction
     ld   e, l
@@ -11350,7 +11350,7 @@ label_83679::
     rst  $38
     db   $F4 ; Undefined instruction
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     ld   [$FFEB], a
     rst  $38
     rst  $38

--- a/src/disassembled-banks/Bank32.asm
+++ b/src/disassembled-banks/Bank32.asm
@@ -103,7 +103,8 @@ label_80064::
     ld   b, h
     ld   c, h
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $75
     ld   b, $AF
     ld   l, d
     add  hl, de
@@ -467,7 +468,8 @@ label_80207::
     ld   c, l
     ld   d, [hl]
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $55
     rlca
     ldi  [hl], a
     ld   d, e
@@ -1504,7 +1506,8 @@ label_80669::
     dec  l
     and  a
     dec  l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2E
     ld   b, c
     ld   l, $06
     ld   l, $66
@@ -2065,7 +2068,8 @@ label_80917::
     ret
 
 label_8091F::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $12
     ld   de, label_3E13
     dec  c
     ld   [$DDD8], a
@@ -2164,7 +2168,8 @@ label_809AF::
     ret
 
 label_809B2::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [label_C08], sp
     inc  c
     ld   a, [$FF10]
@@ -2853,7 +2858,8 @@ label_80D88::
     inc  c
     dec  c
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $12
     inc  de
     dec  d
     ld   d, $18
@@ -2893,7 +2899,8 @@ label_80D88::
     inc  c
     dec  c
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $12
     inc  de
     dec  d
     ld   d, $18
@@ -2980,7 +2987,8 @@ label_80E8D::
     inc  c
     dec  c
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  d
     dec  d
@@ -3069,7 +3077,8 @@ label_80F01::
     inc  c
     dec  c
     ld   c, $0F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
     dec  d
@@ -3109,7 +3118,8 @@ label_80F01::
     inc  c
     dec  c
     ld   c, $0F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
 
 label_80F55::
     ld   [de], a
@@ -3154,7 +3164,8 @@ label_80F55::
     inc  c
     dec  c
     ld   c, $0F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
     inc  d
@@ -3202,7 +3213,8 @@ label_80FB8::
     dec  c
     ld   c, $0E
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
     inc  d
@@ -3249,7 +3261,8 @@ label_80FFB::
     inc  c
     dec  c
     ld   c, $0E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     ld   [de], a
     inc  de
@@ -3301,7 +3314,8 @@ label_81040::
     dec  c
     ld   c, $0E
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   de, label_1212
     inc  de
     inc  d
@@ -3353,7 +3367,8 @@ label_81090::
     dec  c
     ld   c, $0F
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   de, label_1212
     inc  de
     ld   a, [$FFF1]
@@ -3406,7 +3421,8 @@ label_81090::
     ld   c, $0E
     rrca
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F3
     db   $F4 ; Undefined instruction
     db   $F4 ; Undefined instruction
     db   $F4 ; Undefined instruction
@@ -3857,7 +3873,8 @@ label_81319::
     ld   [bc], a
     ld   [bc], a
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $02
     ld   [de], a
     nop
     inc  b
@@ -4001,12 +4018,14 @@ label_8138E::
     db   $E4 ; Undefined instruction
     and  $E8
     db   $E8 ; add  sp, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $12
     inc  d
     ld   d, $18
     inc  e
     ld   [de], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     inc  d
     inc  e
     jr   label_8143C
@@ -4646,8 +4665,10 @@ label_8168A::
     jr   z, label_81702
     add  hl, hl
     ld   a, [hli]
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
+    db   $10
+    db   $11
     ld   a, [label_82EFA]
     ld   l, a
     inc  d
@@ -4664,8 +4685,10 @@ label_8168A::
     dec  bc
     jr   c, label_81719
     jr   nz, label_81735
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
+    db   $10
+    db   $11
     ei
     ei
     cp   $FE
@@ -6212,7 +6235,8 @@ label_81EA0::
     add  hl, bc
     ret
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0A
     rst  $20
     inc  b
     ld   c, e
@@ -6555,7 +6579,8 @@ label_820AB::
     ld    hl, sp+$20
     nop
     db   $FD ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     jr   nz, label_820B1
     nop
     jr   nz, label_820B7
@@ -6566,14 +6591,16 @@ label_820B7::
     db   $FD ; Undefined instruction
     ld   [$0020], sp
     db   $FD ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     jr   nz, label_820C7
     ld    hl, sp+$20
     nop
 
 label_820C7::
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     nop
     inc  bc
     nop
@@ -6585,7 +6612,8 @@ label_820CF::
     inc  bc
     ld   [$0020], sp
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     nop
     nop
     nop
@@ -7022,12 +7050,18 @@ label_8232E::
     ret
 
 label_8233A::
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
+    db   $10
+    db   $30
+    db   $10
+    db   $30
+    db   $10
+    db   $30
+    db   $10
+    db   $30
+    db   $10
+    db   $30
 
 label_82346::
     ld   c, $0E
@@ -8030,7 +8064,8 @@ label_82801::
     rst  $38
     inc  bc
     db   $FD ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $22
     inc  hl
     db   $FD ; Undefined instruction
     db   $FD ; Undefined instruction
@@ -8043,7 +8078,8 @@ label_82801::
     nop
     ld   [label_37A], sp
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $22
     inc  bc
     rlca
     db   $FD ; Undefined instruction
@@ -8091,7 +8127,8 @@ label_82801::
     db   $F4 ; Undefined instruction
     ld   [label_744], sp
     db   $F4 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $46
     rlca
     inc  b
     ld    hl, sp+$48
@@ -8103,10 +8140,12 @@ label_82801::
     inc  b
     ld   [label_74C], sp
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $4E
     rlca
     db   $F4 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $40
     daa
     db   $F4 ; Undefined instruction
     ld   [label_2742], sp
@@ -8118,7 +8157,8 @@ label_82801::
     ld    hl, sp+$46
     daa
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $48
     daa
     inc  b
     ld   [label_274A], sp
@@ -8130,7 +8170,8 @@ label_82801::
     ld    hl, sp+$4E
     daa
     db   $F4 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $50
     daa
     db   $F4 ; Undefined instruction
     ld   [label_2752], sp
@@ -8142,7 +8183,8 @@ label_82801::
     ld    hl, sp+$56
     daa
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $58
     daa
     inc  b
     ld   [label_275A], sp
@@ -8163,7 +8205,8 @@ label_82801::
     db   $F4 ; Undefined instruction
     ld   [label_754], sp
     db   $F4 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $56
     rlca
     inc  b
     ld    hl, sp+$58
@@ -8175,7 +8218,8 @@ label_82801::
     inc  b
     ld   [label_75C], sp
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5E
     rlca
     ld   [bc], a
     db   $FC ; Undefined instruction
@@ -8257,7 +8301,8 @@ label_82801::
     ld   [bc], a
     ld   [label_2750], sp
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $4E
     daa
     ld   a, [$FF00+C]
     ld   d, d
@@ -8317,7 +8362,8 @@ label_82801::
     ld   [bc], a
     ld   [label_2450], sp
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $4E
     inc  h
     ld   a, [$FFFC]
     ld   d, b
@@ -8632,7 +8678,8 @@ label_82B9C::
     nop
     nop
     add  a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $8C
     ld   sp, label_1084
     ld   a, [$FFFE]
     and  a
@@ -10244,7 +10291,8 @@ label_83334::
     add  hl, bc
     nop
     ld   c, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     jr   nz, label_833A6
     ld   bc, label_A0A
     dec  bc
@@ -10256,7 +10304,8 @@ label_83334::
     ld   c, h
     ld   h, l
     ld   h, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $12
     dec  bc
     ld   h, l
     add  hl, bc
@@ -11609,11 +11658,13 @@ label_838CC::
 label_83915::
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     nop
     ld   [label_1704], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $06
     rla
     nop
     jr   label_8392A
@@ -11631,20 +11682,25 @@ label_8392C::
     stop
     ld   [label_1017], sp
     ld   [label_170A], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     inc  c
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     inc  c
 
 label_8393C::
     scf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     ld   a, [bc]
     scf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
     ld   [label_2037], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     rla
     jr   nz, label_83963
     jr   nc, label_83964
@@ -11653,13 +11709,15 @@ label_8393C::
     jr   nc, label_8396B
     jr   nc, label_8396C
     ld   b, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     rla
     ld   b, b
     jr   label_8398C
     rla
     ld   d, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     rla
     ld   d, b
     jr   label_83994
@@ -11667,7 +11725,8 @@ label_8393C::
 label_83964::
     rla
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
 
 label_83968::
     rla
@@ -11677,25 +11736,29 @@ label_83968::
 label_8396C::
     rla
     ld   [hl], b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     rla
     ld   [hl], b
     jr   label_839A4
     rla
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     rla
     add  a, b
     jr   label_839AC
     rla
     sub  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     rla
     sub  a, b
     jr   label_839B4
     rla
     and  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     rla
     and  b
     jr   label_839BC
@@ -11703,7 +11766,8 @@ label_8396C::
 label_8398C::
     rla
     or   b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     rla
     or   b
     jr   label_839C4
@@ -11719,7 +11783,8 @@ label_83995::
     nop
     ld   [label_1714], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     rla
     nop
     jr   label_839BA
@@ -11736,23 +11801,28 @@ label_839AC::
     scf
     stop
     jr   label_839C8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   a, [de]
 
 label_839B4::
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     inc  e
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     inc  e
 
 label_839BC::
     scf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     ld   a, [de]
     scf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
     jr   label_839FC
     jr   nz, label_839D7
     ld   b, b
@@ -11769,31 +11839,36 @@ label_839C8::
     ld   d, b
     rla
     ld   b, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $40
     rla
     ld   b, b
     jr   label_83A2C
     rla
     ld   d, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $40
     rla
     ld   d, b
     jr   label_83A34
     rla
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $40
     rla
     ld   h, b
     jr   label_83A3C
     rla
     ld   [hl], b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $40
     rla
     ld   [hl], b
     jr   label_83A44
     rla
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $40
     rla
     add  a, b
     jr   label_83A4C
@@ -11801,19 +11876,22 @@ label_839C8::
 label_839FC::
     rla
     sub  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $40
     rla
     sub  a, b
     jr   label_83A54
     rla
     and  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $40
     rla
     and  b
     jr   label_83A5C
     rla
     or   b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $40
     rla
     or   b
     jr   label_83A64
@@ -11827,7 +11905,8 @@ label_83A15::
     nop
     ld   [label_1724], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $26
     rla
     nop
     jr   label_83A4A
@@ -11842,23 +11921,28 @@ label_83A2C::
     scf
     stop
     jr   z, label_83A48
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   a, [hli]
 
 label_83A34::
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     inc  l
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     inc  l
 
 label_83A3C::
     scf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     ld   a, [hli]
     scf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
     jr   z, label_83A7C
     jr   nz, label_83A57
     ld   h, b
@@ -11879,7 +11963,8 @@ label_83A4C::
 label_83A54::
     rla
     ld   b, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     rla
     ld   b, b
     jr   label_83ACC
@@ -11887,7 +11972,8 @@ label_83A54::
 label_83A5C::
     rla
     ld   d, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     rla
     ld   d, b
     jr   label_83AD4
@@ -11895,19 +11981,22 @@ label_83A5C::
 label_83A64::
     rla
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     rla
     ld   h, b
     jr   label_83ADC
     rla
     ld   [hl], b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     rla
     ld   [hl], b
     jr   label_83AE4
     rla
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     rla
     add  a, b
     jr   label_83AEC
@@ -11915,19 +12004,22 @@ label_83A64::
 label_83A7C::
     rla
     sub  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     rla
     sub  a, b
     jr   label_83AF4
     rla
     and  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     rla
     and  b
     jr   label_83AFC
     rla
     or   b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     rla
     or   b
     jr   label_83B04
@@ -11941,7 +12033,8 @@ label_83A95::
     nop
     ld   [label_1734], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $36
     rla
     nop
     jr   label_83ADA
@@ -11954,19 +12047,24 @@ label_83A95::
     scf
     stop
     jr   c, label_83AC8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     db   $3A ; ldd  a, [hl]
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     inc  a
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     inc  a
     scf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     db   $3A ; ldd  a, [hl]
     scf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
     jr   c, label_83AFC
     jr   nz, label_83AD7
     ld   d, d
@@ -11987,7 +12085,8 @@ label_83ACC::
 label_83AD4::
     rla
     ld   b, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     rla
     ld   b, b
 
@@ -11999,7 +12098,8 @@ label_83ADC::
     ld   d, b
 
 label_83ADE::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     rla
     ld   d, b
     jr   label_83B46
@@ -12007,7 +12107,8 @@ label_83ADE::
 label_83AE4::
     rla
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     rla
     ld   h, b
     jr   label_83B4E
@@ -12015,7 +12116,8 @@ label_83AE4::
 label_83AEC::
     rla
     ld   [hl], b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     rla
     ld   [hl], b
     jr   label_83B56
@@ -12023,7 +12125,8 @@ label_83AEC::
 label_83AF4::
     rla
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     rla
     add  a, b
     jr   label_83B5E
@@ -12031,7 +12134,8 @@ label_83AF4::
 label_83AFC::
     rla
     sub  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     rla
     sub  a, b
     jr   label_83B66
@@ -12039,13 +12143,15 @@ label_83AFC::
 label_83B04::
     rla
     and  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     rla
     and  b
     jr   label_83B6E
     rla
     or   b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     rla
     or   b
     jr   label_83B76
@@ -12059,7 +12165,8 @@ label_83B15::
     nop
     ld   [label_1744], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $46
     rla
     nop
     jr   label_83B6A
@@ -12075,23 +12182,29 @@ label_83B24::
     stop
     ld   c, b
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   c, d
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   c, h
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   c, h
     scf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     ld   c, d
     scf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
     ld   [label_2037], sp
 
 label_83B46::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $56
     rla
     jr   nz, label_83B63
     ld   h, [hl]
@@ -12105,7 +12218,8 @@ label_83B46::
     ld   b, b
 
 label_83B56::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $56
     rla
     ld   b, b
     jr   label_83BC2
@@ -12113,7 +12227,8 @@ label_83B56::
     ld   d, b
 
 label_83B5E::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $56
     rla
     ld   d, b
     jr   label_83BCA
@@ -12121,7 +12236,8 @@ label_83B5E::
     ld   h, b
 
 label_83B66::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $56
     rla
     ld   h, b
 
@@ -12133,7 +12249,8 @@ label_83B6C::
     ld   [hl], b
 
 label_83B6E::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $56
     rla
     ld   [hl], b
     jr   label_83BDA
@@ -12141,25 +12258,29 @@ label_83B6E::
     add  a, b
 
 label_83B76::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $56
     rla
     add  a, b
     jr   label_83BE2
     rla
     sub  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $56
     rla
     sub  a, b
     jr   label_83BEA
     rla
     and  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $56
     rla
     and  b
     jr   label_83BF2
     rla
     or   b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $56
     rla
     or   b
     jr   label_83BFA
@@ -12337,7 +12458,8 @@ label_83C68::
     add  hl, de
     ld   e, e
     ld   b, $03
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5A
     ld   b, $05
     ld   [label_659], sp
     ld   [$EB20], sp
@@ -12355,7 +12477,8 @@ label_83C68::
     nop
 
 label_83C89::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CE
     dec  b
     ld   [$C108], sp
     dec  b
@@ -12381,7 +12504,8 @@ label_83C89::
     nop
 
 label_83CB1::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CE
     dec  b
     ld   [$C108], sp
     dec  b
@@ -12407,7 +12531,8 @@ label_83CB1::
     nop
 
 label_83CD9::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CE
     dec  b
     ld   [$D108], sp
     dec  b
@@ -12431,7 +12556,8 @@ label_83CD9::
     ld   [$CF10], sp
     dec  b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CE
     dec  b
     ld   [$D108], sp
     dec  b

--- a/src/disassembled-banks/Bank33.asm
+++ b/src/disassembled-banks/Bank33.asm
@@ -455,7 +455,8 @@ label_842B1::
     ld   e, h
     ret  nc
     ld   e, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5E
     and  b
     ld   e, [hl]
     ld   a, [$FF5E]
@@ -469,7 +470,8 @@ label_842B1::
     ld   d, a
     nop
     ld   e, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $59
     jr   nz, label_8434A
     ld   d, b
     ld   e, d
@@ -506,7 +508,8 @@ label_842EF::
     dec  d
     ld   d, $16
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0E
     ld   c, $0E
 
 label_84314::
@@ -702,7 +705,8 @@ label_84401::
     ld   [hl], b
     ld   h, c
     jr   nz, label_84469
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $63
     nop
     ld   h, h
     ld   h, b
@@ -782,7 +786,8 @@ label_84454::
     ld   l, l
     ret  nz
     ld   l, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6E
     ld   h, b
     ld   l, [hl]
     or   b
@@ -807,7 +812,8 @@ label_84469::
     add  a, b
     ld   [hl], c
     jr   nz, label_844E3
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $73
     nop
     ld   h, l
     ld   h, b
@@ -824,7 +830,8 @@ label_8447B::
     ld   l, d
     ret  nc
     ld   [hl], c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $69
     ld   h, b
     ld   l, c
     nop
@@ -1605,7 +1612,8 @@ label_847FF::
     dec  c
     rlca
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
     ld   bc, label_303
     inc  b
     ld   a, [bc]
@@ -3696,7 +3704,8 @@ label_851F6::
     ld   h, c
     nop
     ld   h, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $65
     ld   h, b
     ld   h, [hl]
     ld   b, b
@@ -6012,7 +6021,8 @@ label_85C8F::
     ld   l, $13
     ld   h, $09
     ld   b, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   d, $D9
     ld   de, label_10CE
     nop
@@ -7196,7 +7206,8 @@ label_861B5::
 
 label_861CF::
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     call nz, label_2126
     dec  d
     nop
@@ -7226,12 +7237,14 @@ label_861DF::
     ld   c, [hl]
     ld   h, $46
     ld   bc, $0000
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     add  hl, hl
     ld   bc, label_1A72
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     reti
     ld   de, label_10CE
     nop
@@ -7244,7 +7257,8 @@ label_86207::
     add  hl, sp
     jp   nz, label_2C
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     reti
     ld   de, label_10CE
     nop
@@ -7364,12 +7378,14 @@ label_8627F::
     ld   c, [hl]
     ld   h, $46
     ld   bc, $0000
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     add  hl, hl
     ld   bc, label_1A72
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     reti
     ld   de, label_10CE
     nop
@@ -7380,7 +7396,8 @@ label_8627F::
     add  hl, sp
     jp   nz, label_2C
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     reti
     ld   de, label_10CE
     nop
@@ -7785,7 +7802,8 @@ label_8645F::
     nop
     rst  $38
     ld   b, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     add  hl, hl
     ld   bc, $00A5
     dec  c
@@ -8557,7 +8575,8 @@ label_867E7::
     ld   bc, $0000
     adc  a, h
     ld   sp, label_2108
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $42
     nop
     nop
     adc  a, h
@@ -9082,7 +9101,8 @@ label_86A5F::
     dec  sp
     rst  $38
     ld   a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
     nop
     nop
     add  hl, sp
@@ -9152,7 +9172,8 @@ label_86AAF::
     dec  sp
     rst  $38
     ld   a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
     nop
     nop
     add  hl, sp
@@ -9427,12 +9448,14 @@ label_86BEF::
     ld   c, [hl]
     ld   h, $46
     ld   bc, $0000
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     add  hl, hl
     ld   bc, label_1A72
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     di
     ld   d, c
     ld   h, a
@@ -10647,7 +10670,8 @@ label_871DF::
     ld   c, [hl]
     ld   h, $46
     ld   bc, $0000
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     add  hl, hl
     ld   bc, label_1A72
     nop
@@ -10658,7 +10682,8 @@ label_871DF::
     add  hl, sp
     jp   nz, label_2C
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     call nz, label_2126
     dec  d
     nop
@@ -10707,7 +10732,8 @@ label_8722F::
     ld   c, [hl]
     ld   h, $46
     ld   bc, $0000
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     add  hl, hl
     ld   bc, label_1A72
     nop
@@ -10718,7 +10744,8 @@ label_8722F::
     add  hl, sp
     jp   nz, label_2C
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     call nz, label_2126
     dec  d
     nop
@@ -10768,7 +10795,8 @@ label_8727F::
     ld   c, [hl]
     ld   h, $46
     ld   bc, $0000
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     add  hl, hl
     ld   bc, label_1A72
     nop
@@ -10779,7 +10807,8 @@ label_8727F::
     add  hl, sp
     jp   nz, label_2C
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     call nz, label_2126
     dec  d
     nop
@@ -10831,7 +10860,8 @@ label_872CF::
     ld   c, [hl]
     ld   h, $46
     ld   bc, $0000
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     add  hl, hl
     ld   bc, label_1A72
     nop
@@ -10842,7 +10872,8 @@ label_872CF::
     add  hl, sp
     jp   nz, label_2C
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     call nz, label_2126
     dec  d
     nop
@@ -11411,7 +11442,8 @@ label_8756A::
     rst  $38
     ld   a, a
     adc  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $19
     ld   a, [hli]
     ld   e, a
     rla
@@ -11530,7 +11562,8 @@ label_875FB::
     rst  $38
     ld   a, a
     adc  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $19
     ld   a, [hli]
     ld   e, a
     rla
@@ -11657,7 +11690,8 @@ label_8767B::
     rra
     ld   c, e
     call c, label_F72D
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $44
     inc  b
     rst  $38
     ld   a, a
@@ -11670,7 +11704,8 @@ label_8767B::
     ld   c, e
     db   $0E
     ld   c, $F7
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $44
     inc  b
     rra
     ld   c, e
@@ -11685,7 +11720,8 @@ label_8767B::
     ld   e, [hl]
     add  hl, sp
     rst  $30
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $44
     inc  b
     rst  $38
     ld   a, a
@@ -12875,7 +12911,8 @@ label_87B20::
     nop
     nop
     jp   label_86010
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $B3
     ld   a, [hl]
     nop
     nop
@@ -12894,14 +12931,16 @@ label_87B20::
     nop
     nop
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0B
     add  hl, de
     or   e
     ld   a, [hl]
     nop
     nop
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $67
     ld   [label_87D68], sp
     ld   d, d
     ld   e, [hl]

--- a/src/disassembled-banks/Bank35.asm
+++ b/src/disassembled-banks/Bank35.asm
@@ -11556,7 +11556,7 @@ label_8F1BD::
     ld   [hl], h
     ld   [hl], h
     ld   [hl], h
-    jp   [hl]
+    jp   hl
     ld   a, h
     ld   a, h
     ld   a, h
@@ -11576,7 +11576,7 @@ label_8F1BD::
     ld   h, c
     ld   [hl], h
     ld   [hl], h
-    jp   [hl]
+    jp   hl
     ld   a, h
     ld   a, h
     ld   a, h
@@ -12902,7 +12902,7 @@ label_8F8F6::
     sbc  a, h
     sbc  a, [hl]
     cp   [hl]
-    jp   [hl]
+    jp   hl
     nop
     sbc  a, e
     ret  nz
@@ -12931,7 +12931,7 @@ label_8F8F6::
     inc  de
     sbc  a, [hl]
     cp   [hl]
-    jp   [hl]
+    jp   hl
     ld   sp, hl
     ei
     xor  h
@@ -13049,7 +13049,7 @@ label_8F9B6::
     sbc  a, e
     nop
     inc  de
-    jp   [hl]
+    jp   hl
     ld   sp, hl
     ei
     xor  h
@@ -13200,7 +13200,7 @@ label_8F9B6::
     sbc  a, h
     sbc  a, [hl]
     cp   [hl]
-    jp   [hl]
+    jp   hl
     ld   sp, hl
     ei
     xor  h
@@ -13399,7 +13399,7 @@ label_8FA76::
     sbc  a, h
     sbc  a, [hl]
     cp   [hl]
-    jp   [hl]
+    jp   hl
     nop
     sbc  a, c
     jr   nz, label_8FB36
@@ -13430,7 +13430,7 @@ label_8FB36::
     sbc  a, h
     sbc  a, [hl]
     cp   [hl]
-    jp   [hl]
+    jp   hl
     ld   sp, hl
     ei
     xor  h

--- a/src/disassembled-banks/Bank36.asm
+++ b/src/disassembled-banks/Bank36.asm
@@ -12135,11 +12135,14 @@ label_933ED::
     ld   [hl], l
 
 label_933F9::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DC
     jr   nc, label_933D9
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DC
     jr   nc, label_933DD
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DC
     jr   nc, label_933E1
     ld   a, [$DBA5]
     and  a
@@ -12590,7 +12593,8 @@ label_9362E::
     nop
     ld   bc, label_302
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
     inc  d
@@ -12840,7 +12844,8 @@ label_93711::
     ld   [hl], e
     call z, label_1075
     ld   d, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $56
     rst  $38
 
 label_93780::
@@ -13026,7 +13031,8 @@ label_93854::
     nop
     nop
     jp   label_92010
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $B3
     ld   a, [hl]
     nop
     nop
@@ -13045,14 +13051,16 @@ label_93854::
     nop
     nop
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0B
     add  hl, de
     or   e
     ld   a, [hl]
     nop
     nop
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $67
     ld   [label_93EB3], sp
     nop
     nop
@@ -13118,12 +13126,14 @@ label_93854::
     nop
     nop
     ld   sp, $AB0D
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $B3
     ld   a, [hl]
     nop
     nop
     xor  e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $46
     inc  b
     or   e
     ld   a, [hl]
@@ -13144,7 +13154,8 @@ label_93854::
     nop
     nop
     xor  e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $45
     dec  e
     or   e
     ld   a, [hl]
@@ -13161,7 +13172,8 @@ label_93854::
     and  b
     inc  e
     xor  e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $B3
     ld   a, [hl]
     nop
     nop
@@ -13212,7 +13224,8 @@ label_9392B::
     nop
     ret  nz
     jr   nz, label_9390C
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $B3
     ld   a, [hl]
     nop
     nop
@@ -13688,7 +13701,8 @@ label_93B46::
     dec  sp
     rst  $38
     ld   a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
     nop
     nop
     add  hl, sp

--- a/src/disassembled-banks/Bank36.asm
+++ b/src/disassembled-banks/Bank36.asm
@@ -8351,7 +8351,7 @@ label_92329::
     rlca
     nop
     sbc  a, h
-    jp   [hl]
+    jp   hl
     ld   c, c
     ld   bc, label_99D
     ld   c, c
@@ -8657,7 +8657,7 @@ label_924F3::
     ld   b, [hl]
     ld   [bc], a
     sbc  a, b
-    jp   [hl]
+    jp   hl
     ld   b, [hl]
     ld   [bc], a
     nop
@@ -11010,7 +11010,7 @@ label_92F31::
     ld   [hl], h
     ld   [hl], h
     ld   [hl], h
-    jp   [hl]
+    jp   hl
     ld   a, h
     ld   a, h
     ld   a, h
@@ -11033,7 +11033,7 @@ label_92F31::
     ld   a, a
     ld   [hl], h
     ld   [hl], h
-    jp   [hl]
+    jp   hl
     ld   a, h
     ld   a, h
     ld   a, h
@@ -12452,7 +12452,7 @@ label_93547::
     ld   l, a
     pop  de
     ld   a, e
-    jp   [hl]
+    jp   hl
 
 label_9358B::
     sbc  a, l

--- a/src/disassembled-banks/Bank38.asm
+++ b/src/disassembled-banks/Bank38.asm
@@ -3788,7 +3788,8 @@ label_98FB1::
     rst  $38
     ld   b, h
     dec  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $19
     jr   nc, label_9902C
     dec  de
     dec  h
@@ -3915,7 +3916,8 @@ label_9902C::
     ld   d, c
     dec  de
     ld   a, [de]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     dec  h
     ld   h, $27
     dec  de
@@ -12052,7 +12054,8 @@ label_9B368::
     db   $FC ; Undefined instruction
     jr   c, label_9B411
     ld   a, [de]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $19
     ld   c, $0E
     rst  $38
     rst  $38
@@ -13113,13 +13116,16 @@ label_9B896::
     ld   de, label_1B1B
     dec  de
     ld   a, [de]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $37
     ld   a, [bc]
     ld   a, [bc]
     or   [hl]
     dec  d
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $16
     inc  b
 
 label_9B8B8::
@@ -13167,12 +13173,14 @@ label_9B8B8::
     ld   c, $0E
     ld   c, $0E
     ld   a, [de]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     add  hl, de
     ld   c, $1A
     add  hl, de
     ld   c, $1A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     inc  b
     inc  b
     ld   de, label_180E
@@ -13219,7 +13227,8 @@ label_9B8B8::
     dec  h
     ld   h, $0B
     cp   $37
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $19
     ld   c, $12
     inc  b
     daa
@@ -14168,8 +14177,10 @@ label_9BD41::
 
 label_9BD59::
     ld   a, [de]
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     ld   h, $0A
 
 label_9BD60::
@@ -14210,8 +14221,10 @@ label_9BD8A::
     inc  b
     inc  b
     dec  d
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $39
     db   $3A ; ldd  a, [hl]
     db   $3A ; ldd  a, [hl]
     db   $3A ; ldd  a, [hl]
@@ -14231,7 +14244,8 @@ label_9BD9D::
     ld   a, [bc]
     ld   a, [bc]
     ld   a, [bc]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $19
     call nc, label_270A
     add  hl, hl
     ld   h, $0A
@@ -14239,7 +14253,8 @@ label_9BD9D::
     ld   a, [bc]
     inc  b
     dec  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     add  hl, de
     daa
     jr   z, label_9BD8A
@@ -14249,7 +14264,8 @@ label_9BD9D::
     inc  d
     ld   b, h
     dec  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     add  hl, de
     ld   a, [bc]
     daa

--- a/src/disassembled-banks/Bank38.asm
+++ b/src/disassembled-banks/Bank38.asm
@@ -2101,18 +2101,18 @@ label_987C5::
     db   $3A ; ldd  a, [hl]
     ld   a, $3A
     ccf
-    jp   [hl]
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
+    jp   hl
     ld   a, $3A
     dec  de
     dec  de
     add  hl, sp
     db   $3A ; ldd  a, [hl]
     dec  sp
-    jp   [hl]
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
+    jp   hl
     add  hl, sp
     db   $3A ; ldd  a, [hl]
     dec  de
@@ -2173,7 +2173,7 @@ label_987C5::
     dec  de
     db   $3A ; ldd  a, [hl]
     ccf
-    jp   [hl]
+    jp   hl
     ld   a, $3A
     db   $3A ; ldd  a, [hl]
     ld   d, e
@@ -2182,13 +2182,13 @@ label_987C5::
     dec  de
     db   $3A ; ldd  a, [hl]
     dec  sp
-    jp   [hl]
+    jp   hl
     add  hl, sp
     db   $3A ; ldd  a, [hl]
     db   $3A ; ldd  a, [hl]
 
 label_9889E::
-    jp   [hl]
+    jp   hl
     dec  sp
     dec  de
     dec  de
@@ -2201,18 +2201,18 @@ label_9889E::
     dec  de
     dec  a
     ld   c, b
-    jp   [hl]
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
+    jp   hl
     ld   c, c
     inc  a
     ld   c, $1B
     cpl
     ld   c, [hl]
     db   $3A ; ldd  a, [hl]
-    jp   [hl]
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
+    jp   hl
     db   $3A ; ldd  a, [hl]
     ld   l, $2F
     cpl
@@ -2243,7 +2243,7 @@ label_988C9::
     ld   a, $3A
     ld   [$FF3F], a
     add  hl, sp
-    jp   [hl]
+    jp   hl
     db   $3A ; ldd  a, [hl]
     dec  sp
     dec  de
@@ -2263,21 +2263,21 @@ label_988C9::
     dec  de
     dec  a
     cpl
-    jp   [hl]
+    jp   hl
     cpl
-    jp   [hl]
+    jp   hl
     cpl
-    jp   [hl]
+    jp   hl
     cpl
     cpl
     cpl
     ld   c, [hl]
     db   $3A ; ldd  a, [hl]
-    jp   [hl]
+    jp   hl
     db   $3A ; ldd  a, [hl]
-    jp   [hl]
+    jp   hl
     db   $3A ; ldd  a, [hl]
-    jp   [hl]
+    jp   hl
     db   $3A ; ldd  a, [hl]
     db   $3A ; ldd  a, [hl]
     scf
@@ -3298,18 +3298,18 @@ label_98D06::
     db   $3A ; ldd  a, [hl]
     ccf
     db   $3A ; ldd  a, [hl]
-    jp   [hl]
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
+    jp   hl
     db   $3A ; ldd  a, [hl]
     ld   a, $3A
     db   $3A ; ldd  a, [hl]
     db   $3A ; ldd  a, [hl]
     ccf
     db   $3A ; ldd  a, [hl]
-    jp   [hl]
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
+    jp   hl
     db   $3A ; ldd  a, [hl]
     ld   a, $3A
     db   $3A ; ldd  a, [hl]
@@ -3363,21 +3363,21 @@ label_98D06::
     db   $3A ; ldd  a, [hl]
     ccf
     db   $3A ; ldd  a, [hl]
-    jp   [hl]
+    jp   hl
     db   $3A ; ldd  a, [hl]
-    jp   [hl]
+    jp   hl
     db   $3A ; ldd  a, [hl]
-    jp   [hl]
+    jp   hl
     db   $3A ; ldd  a, [hl]
     db   $3A ; ldd  a, [hl]
     db   $3A ; ldd  a, [hl]
     ccf
     db   $3A ; ldd  a, [hl]
-    jp   [hl]
+    jp   hl
     db   $3A ; ldd  a, [hl]
-    jp   [hl]
+    jp   hl
     db   $3A ; ldd  a, [hl]
-    jp   [hl]
+    jp   hl
     db   $3A ; ldd  a, [hl]
     db   $3A ; ldd  a, [hl]
     db   $3A ; ldd  a, [hl]
@@ -4466,9 +4466,9 @@ label_992F9::
     ld   c, $0E
     ld   c, $3D
     ld   c, [hl]
-    jp   [hl]
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
+    jp   hl
     ld   c, c
     inc  a
 
@@ -4476,9 +4476,9 @@ label_99303::
     ld   c, $0E
     ld   c, $38
     ccf
-    jp   [hl]
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
+    jp   hl
     db   $3A ; ldd  a, [hl]
     ld   l, $2F
     cpl
@@ -4531,8 +4531,8 @@ label_9931C::
     ld   c, $0E
     ld   c, $3D
     ld   c, b
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
     ld   c, c
     cpl
     cpl
@@ -4541,8 +4541,8 @@ label_9931C::
     cpl
     ld   c, [hl]
     db   $3A ; ldd  a, [hl]
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
     db   $3A ; ldd  a, [hl]
     db   $3A ; ldd  a, [hl]
     db   $3A ; ldd  a, [hl]
@@ -5567,11 +5567,11 @@ label_997B9::
     jr   c, label_99801
 
 label_997C2::
-    jp   [hl]
+    jp   hl
 
 label_997C3::
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
     db   $3A ; ldd  a, [hl]
     ld   a, $3A
     db   $3A ; ldd  a, [hl]
@@ -5579,11 +5579,11 @@ label_997C3::
     jr   c, label_99807
 
 label_997CC::
-    jp   [hl]
+    jp   hl
 
 label_997CD::
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
     db   $3A ; ldd  a, [hl]
     ld   a, $3A
     db   $3A ; ldd  a, [hl]
@@ -5633,28 +5633,28 @@ label_997F1::
     db   $EB ; Undefined instruction
     db   $EB ; Undefined instruction
     jr   c, label_997E7
-    jp   [hl]
+    jp   hl
     dec  hl
     inc  l
 
 label_99801::
     inc  l
     dec  l
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
     dec  hl
     jr   c, label_997F1
-    jp   [hl]
+    jp   hl
     ld   l, $2F
     cpl
     ld   c, [hl]
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
     ld   l, $3A
     ccf
     db   $3A ; ldd  a, [hl]
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
     db   $3A ; ldd  a, [hl]
     db   $3A ; ldd  a, [hl]
     db   $3A ; ldd  a, [hl]
@@ -5663,8 +5663,8 @@ label_99801::
     db   $3A ; ldd  a, [hl]
     ccf
     db   $3A ; ldd  a, [hl]
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
     db   $3A ; ldd  a, [hl]
     db   $3A ; ldd  a, [hl]
     db   $3A ; ldd  a, [hl]
@@ -6739,14 +6739,14 @@ label_99CB9::
 label_99CBF::
     scf
     jr   c, label_99CAB
-    jp   [hl]
+    jp   hl
 
 label_99CC3::
     ld   a, $3A
     db   $3A ; ldd  a, [hl]
     ccf
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
 
 label_99CC9::
     add  hl, sp
@@ -9267,17 +9267,17 @@ label_9A7BA::
     dec  l
     jr   c, label_9A81C
     ld   c, [hl]
-    jp   [hl]
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
+    jp   hl
     ld   l, $2F
     cpl
     ld   c, [hl]
     jr   c, label_9A831
     ccf
-    jp   [hl]
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
+    jp   hl
     ld   a, $3A
     db   $3A ; ldd  a, [hl]
     ccf
@@ -10393,17 +10393,17 @@ label_9ACA8::
     inc  b
     db   $3A ; ldd  a, [hl]
     ccf
-    jp   [hl]
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
+    jp   hl
     ld   a, $3A
     db   $3A ; ldd  a, [hl]
     ccf
     jr   c, label_9AC9C
     ccf
-    jp   [hl]
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
+    jp   hl
 
 label_9ACBF::
     ld   a, $3A

--- a/src/disassembled-banks/Bank39.asm
+++ b/src/disassembled-banks/Bank39.asm
@@ -583,7 +583,8 @@ label_9C28C::
     jr   label_9C2B3
     inc  d
     dec  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     add  hl, hl
     ld   h, $6E
     ld   e, h
@@ -636,7 +637,8 @@ label_9C2CA::
     ld   a, [bc]
     dec  h
     dec  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     inc  de
     rrca
     rla
@@ -11013,7 +11015,8 @@ label_9F27C::
     nop
     ld   [label_20F], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     ld   [bc], a
     nop
     jr   label_9F2B6
@@ -11029,10 +11032,12 @@ label_9F27C::
     stop
     ld   d, c
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   d, e
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   d, l
     nop
 
@@ -11040,7 +11045,8 @@ label_9F2A4::
     nop
     ld   [label_20F], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     ld   [bc], a
     nop
     jr   label_9F2DE
@@ -11056,16 +11062,19 @@ label_9F2A4::
     stop
     ld   h, c
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   h, e
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   h, l
     nop
     nop
     ld   [$010E], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1E
     ld   bc, $0008
     ld   h, b
     ld   [bc], a
@@ -11248,19 +11257,23 @@ label_9F3B8::
     call label_9F240
     ret
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     ld   bc, label_1800
     inc  b
     ld   bc, label_1818
     inc  c
     dec  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     dec  bc
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   a, [bc]
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
 
 label_9F3F7::
     add  hl, bc
@@ -11273,7 +11286,8 @@ label_9F3F7::
     ld   b, $06
     ld   [label_508], sp
     ld   b, $00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $02
     ld   b, $00
     ld   [label_601], sp
     nop
@@ -11288,7 +11302,8 @@ label_9F3F7::
     jr   label_9F3F7
     dec  c
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D8
     dec  l
     inc  bc
     nop
@@ -11311,7 +11326,8 @@ label_9F3F7::
     jr   label_9F443
     dec  de
     dec  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1D
     ld   a, [de]
     ld   bc, label_1510
 
@@ -11326,7 +11342,8 @@ label_9F443::
     jr   label_9F469
     ld   [bc], a
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
     ld   b, $04
     ld   [label_613], sp
     ld    hl, sp+$10
@@ -11334,7 +11351,8 @@ label_9F443::
     ld   b, $FC
     ld   [label_611], sp
     ld    hl, sp+$00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $06
 
 label_9F469::
     jr   nz, label_9F4BB
@@ -11347,7 +11365,8 @@ label_9F46B::
     jr   label_9F44B
     dec  c
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D8
     dec  l
     inc  bc
     rst  $38
@@ -11379,7 +11398,8 @@ label_9F46B::
     jr   label_9F4C9
     ld   [bc], a
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $24
     ld   b, $00
     nop
     inc  hl
@@ -11405,7 +11425,8 @@ label_9F4C9::
     jr   label_9F4A3
     dec  c
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D8
     dec  l
     inc  bc
 
@@ -11472,7 +11493,8 @@ label_9F513::
     inc  bc
     ld   [label_610], sp
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   [bc], a
     ld   [bc], a
     jr   nc, label_9F540
@@ -11553,7 +11575,8 @@ label_9F57C::
     nop
     jr   nz, label_9F535
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   [de], a
     ld   [bc], a
     jr   nc, label_9F5B0
@@ -11624,7 +11647,8 @@ label_9F5E4::
     nop
     jr   nz, label_9F5A5
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ldi  [hl], a
     ld   [bc], a
     jr   nc, label_9F61C
@@ -11709,7 +11733,8 @@ label_9F65C::
     ret
 
 label_9F676::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $25
     ld   [de], a
     inc  b
     jr   nc, label_9F697
@@ -11747,7 +11772,8 @@ label_9F697::
 label_9F69D::
     inc  bc
     ld   b, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $34
     inc  bc
     ld   b, b
     ld   [label_332], sp
@@ -11784,19 +11810,23 @@ label_9F6CC::
 
 label_9F6D0::
     jr   label_9F6D3
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
 
 label_9F6D4::
     ld   d, $07
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
 
 label_9F6D8::
     inc  d
     ld   bc, label_1010
 
 label_9F6DC::
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
+    db   $10
+    db   $08
 
 label_9F6E0::
     ld   c, $01
@@ -11813,7 +11843,8 @@ label_9F6E4::
 label_9F6F0::
     ld   b, $01
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $04
 
 label_9F6F5::
     ld   bc, label_800
@@ -11833,13 +11864,16 @@ label_9F700::
 label_9F708::
     ld   c, b
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1C
     ld   b, [hl]
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
     ld   b, h
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
 
 label_9F714::
     ld   b, d
@@ -11855,13 +11889,16 @@ label_9F718::
     jr   nz, label_9F72C
     ld   e, b
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1C
     ld   d, [hl]
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
     ld   d, h
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
 
 label_9F72C::
     ld   d, d
@@ -11879,13 +11916,16 @@ label_9F734::
     jr   nz, label_9F744
     ld   l, b
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1C
     ld   h, [hl]
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
     ld   h, h
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
 
 label_9F744::
     ld   h, d
@@ -11943,7 +11983,8 @@ label_9F76E::
     ld   h, c
     inc  b
     ld   a, [bc]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
     inc  bc
     ld   a, [bc]
     ld   [label_365], sp
@@ -11955,7 +11996,8 @@ label_9F76E::
     ld    hl, sp+$63
     inc  bc
     ld   [de], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $70
     inc  b
     ld   [de], a
     ld   [label_46F], sp
@@ -11975,7 +12017,8 @@ label_9F76E::
     ld   h, c
     inc  b
     ld   a, [bc]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
     inc  bc
     ld   a, [bc]
     ld   [label_365], sp
@@ -11987,7 +12030,8 @@ label_9F76E::
     ld    hl, sp+$63
     inc  bc
     ld   [de], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $74
     inc  b
     ld   [de], a
     ld   [label_473], sp
@@ -12007,7 +12051,8 @@ label_9F76E::
     ld   h, c
     inc  b
     ld   a, [bc]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
     inc  bc
     ld   a, [bc]
     ld   [label_365], sp
@@ -12019,7 +12064,8 @@ label_9F76E::
     ld    hl, sp+$63
     inc  bc
     ld   [de], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $78
     inc  b
     ld   [de], a
     ld   [label_477], sp
@@ -12039,7 +12085,8 @@ label_9F76E::
     ld   h, c
     inc  b
     ld   a, [bc]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
     inc  bc
     ld   a, [bc]
     ld   [label_365], sp

--- a/src/disassembled-banks/Bank4.asm
+++ b/src/disassembled-banks/Bank4.asm
@@ -513,7 +513,8 @@ label_1036D::
     jp   label_2385
 
 label_10370::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
     jr   label_10394
     jr   z, label_103A6
     jr   c, label_103B8
@@ -1166,19 +1167,23 @@ label_10713::
 label_1074D::
     stop
     ld   e, $01
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   e, $61
     stop
     ld   e, $01
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   e, $61
     stop
     ld   e, $01
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   e, $61
     stop
     ld   e, $01
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   e, $61
     ld   [label_3000], sp
     ld   bc, label_808
@@ -1223,15 +1228,18 @@ label_107B2::
     ld   [label_12130], sp
     stop
     ld   e, $01
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   e, $61
     stop
     ld   e, $01
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   e, $61
     stop
     ld   e, $01
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   e, $61
     ld   a, [$FF00+C]
     jr   nc, label_107D2
@@ -1266,7 +1274,8 @@ label_107B2::
     nop
     ld   [label_10130], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $30
     ld   hl, $F8F0
     ldd  [hl], a
     ld   bc, $00F0
@@ -1289,7 +1298,8 @@ label_1081E::
 label_10826::
     ld   [$0132], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $32
     ld   h, c
 
 label_1082D::
@@ -1795,7 +1805,8 @@ label_10B52::
     ld   c, e
 
 label_10B5C::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
     ld   b, $02
     ld   a, [$FFF4]
     ld   a, [label_10FE]
@@ -1804,9 +1815,11 @@ label_10B5C::
     ld   a, [$FFF4]
     ld   a, [label_2FE]
     ld   b, $0C
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $02
     ld   b, $0C
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     ld   a, [$F0F4]
     cp   $FA
     db   $F4 ; Undefined instruction
@@ -1909,7 +1922,8 @@ label_10BDD::
     nop
     ld   [label_2372], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6E
     inc  hl
     nop
     jr   label_10C70
@@ -1961,7 +1975,8 @@ label_10BDD::
     nop
     ld   [label_2372], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6E
     inc  hl
     nop
     jr   label_10CB8
@@ -2015,7 +2030,8 @@ label_10C70::
     nop
     ld   [label_366], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
     inc  hl
     nop
     jr   label_10CF0
@@ -2138,7 +2154,8 @@ label_10CF0::
     nop
     ld   [label_237A], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
     inc  bc
     nop
     jr   label_10D7E
@@ -2187,7 +2204,8 @@ label_10CF0::
     nop
     ld   [label_237C], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
     inc  bc
     nop
     jr   label_10DBE
@@ -2416,7 +2434,8 @@ label_10E83::
     ld   c, a
 
 label_10E94::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
     nop
     db   $F4 ; Undefined instruction
     ld   a, [$FFF4]
@@ -2426,7 +2445,8 @@ label_10E94::
 label_10E9C::
     nop
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
     nop
     db   $F4 ; Undefined instruction
     ld   a, [$FFF4]
@@ -2601,7 +2621,8 @@ label_10FAE::
     nop
     ld   [label_2366], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $64
     inc  hl
     ld   a, [$FFF8]
     ld   l, b
@@ -2625,7 +2646,8 @@ label_10FAE::
     nop
     ld   [label_2366], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6C
     inc  hl
 
 label_10FEE::
@@ -3614,7 +3636,8 @@ label_115D8::
     ret
 
 label_115F3::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $12
     ld   de, label_1013
     ld   [de], a
     ld   de, label_1413
@@ -3955,7 +3978,8 @@ label_117F2::
     ld    hl, sp+$08
     ld   h, d
     jr   nz, label_117F7
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_1180B
     ld    hl, sp+$64
     nop
@@ -3963,7 +3987,8 @@ label_117F2::
     nop
     ld   [label_12608], sp
     jr   nz, label_11817
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $64
     jr   nz, label_1180B
     ld    hl, sp+$60
     nop
@@ -3973,7 +3998,8 @@ label_117F2::
     ld    hl, sp+$08
     ld   h, d
     jr   nz, label_11817
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_1182B
     ld    hl, sp+$6C
     nop
@@ -3992,7 +4018,8 @@ label_117F2::
     ld    hl, sp+$08
     ld   h, d
     jr   nz, label_11837
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_1184B
     ld    hl, sp+$68
     ld   b, b
@@ -4011,7 +4038,8 @@ label_117F2::
     ld    hl, sp+$08
     ld   h, d
     jr   nz, label_11857
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_1186B
     ld    hl, sp+$60
     ld   b, b
@@ -4070,7 +4098,8 @@ label_117F2::
     ld    hl, sp+$08
     ld   l, d
     jr   nz, label_118B7
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     jr   nz, label_118CB
     ld    hl, sp+$60
     ld   b, b
@@ -4089,7 +4118,8 @@ label_117F2::
     ld    hl, sp+$08
     ld   h, d
     jr   nz, label_118D7
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_118EB
     ld    hl, sp+$60
     ld   b, b
@@ -4097,7 +4127,8 @@ label_117F2::
     ld   b, b
     ld   [label_12E08], sp
     jr   nz, label_118F7
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6C
     jr   nz, label_11963
     nop
     ld   [hl], b
@@ -5341,7 +5372,8 @@ label_1204C::
 
 label_12074::
     ld   b, $16
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   c, label_120B2
     add  hl, sp
     add  hl, sp
@@ -5369,7 +5401,8 @@ label_1207E::
     inc  d
 
 label_1209B::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld    hl, sp+$10
     nop
     nop
@@ -5415,7 +5448,8 @@ label_120CA::
 label_120CB::
     nop
     ld   a, $1E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $30
     ld   a, $02
     ld   [$FFA1], a
     ld   hl, $C2C0
@@ -6049,7 +6083,8 @@ label_12497::
     jr   label_124E0
 
 label_12499::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     call label_1279B
     ld   hl, $C2B0
     add  hl, bc
@@ -7336,7 +7371,8 @@ label_12C2D::
     inc  hl
 
 label_12C4D::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0E
     inc  c
     ld   b, $00
     ld   a, [$F2F4]
@@ -8716,7 +8752,8 @@ label_134C1::
     rst  $38
     rst  $38
     sbc  a, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A6
     inc  d
     adc  a, [hl]
     ld   d, $86
@@ -9316,8 +9353,10 @@ label_137D3::
 label_137DC::
     nop
     nop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
+    db   $10
+    db   $80
     stop
     nop
 
@@ -9916,9 +9955,12 @@ label_13B5A::
     ld   d, $FF
     rst  $38
     sub  a, b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $AE
+    db   $10
+    db   $A0
+    db   $10
+    db   $2A
     ld   b, c
     ld   a, [hli]
     ld   h, c

--- a/src/disassembled-banks/Bank4.asm
+++ b/src/disassembled-banks/Bank4.asm
@@ -482,7 +482,7 @@ label_10336::
     ld   b, e
     sbc  a, a
     ld   b, h
-    jp   [hl]
+    jp   hl
     ld   b, h
     rla
     ld   b, l
@@ -2737,7 +2737,7 @@ label_11067::
     ld   d, b
     pop  hl
     ld   d, b
-    jp   [hl]
+    jp   hl
     ld   d, b
     call label_C05
     ld   [hl], $80

--- a/src/disassembled-banks/Bank40.asm
+++ b/src/disassembled-banks/Bank40.asm
@@ -4439,7 +4439,7 @@ label_A160C::
     push hl
     and  $E7
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     ld   [$ECEB], a
     ld   b, h
     ld   b, c
@@ -5119,7 +5119,7 @@ label_A1901::
     push hl
     and  $E7
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     ld   [$ECEB], a
     db   $E4 ; Undefined instruction
     ld   de, label_1312
@@ -6518,7 +6518,7 @@ label_A1EC4::
     and  $E7
     db   $E8 ; add  sp, d
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     nop
     nop
     nop
@@ -7930,7 +7930,7 @@ label_A2411::
     sbc  a, $E5
     and  $E7
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     ld   [$ECEB], a
     db   $ED ; Undefined instruction
     db   $E3 ; Undefined instruction
@@ -8403,7 +8403,7 @@ label_A2667::
     ld   e, h
     and  $E7
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     ld   e, l
     ld   e, [hl]
     ld   e, a
@@ -9227,7 +9227,7 @@ label_A2A0F::
     push hl
     and  $E7
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     ld   [$ECEB], a
     db   $ED ; Undefined instruction
     ld   a, [$FF00+C]
@@ -9900,7 +9900,7 @@ label_A2C4F::
     push hl
     and  $E7
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     ld   [$ECEB], a
     db   $ED ; Undefined instruction
     xor  $EF
@@ -11846,7 +11846,7 @@ label_A34BF::
     xor  a
     and  $E7
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     or   b
     or   c
     or   d
@@ -13063,7 +13063,7 @@ label_A39E0::
     push hl
     and  $E7
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     ld   [$ECEB], a
     db   $ED ; Undefined instruction
     xor  $EF

--- a/src/disassembled-banks/Bank40.asm
+++ b/src/disassembled-banks/Bank40.asm
@@ -385,7 +385,8 @@ label_A0259::
     add  a, b
     inc  b
     ld   [label_201], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     inc  b
     ld   [$0000], sp
     nop
@@ -718,7 +719,8 @@ label_A0450::
     inc  bc
     adc  a, b
     ld   [hl], b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $04
     adc  a, b
     ld   a, b
     ld   [de], a
@@ -948,7 +950,8 @@ label_A0561::
 label_A0566::
     adc  a, b
     ld   [hl], b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $04
     adc  a, b
     ld   a, b
     ld   [de], a
@@ -2311,7 +2314,8 @@ label_A0DC0::
 
 label_A0DD1::
     ld   d, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
     ld   bc, label_1850
     ld   d, $01
     ld   d, b
@@ -2362,7 +2366,8 @@ label_A0E16::
     ld   bc, label_A1A4E
     ld   a, $01
     ld   d, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
     ld   bc, label_1850
     ld   d, $01
     ld   d, b
@@ -4418,7 +4423,8 @@ label_A160C::
     dec  c
     ld   a, [bc]
     dec  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D0
     pop  de
     jp   nc, label_D4D3
     push de
@@ -4430,7 +4436,8 @@ label_A160C::
     ld   [hl], d
     ld   h, b
     ld   h, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     ld   [$FFE1], a
     ld  [$FF00+C], a
@@ -5818,7 +5825,8 @@ label_A1BCD::
     ld   c, e
     ld   c, h
     sbc  a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9F
     nop
     sbc  a, a
     ld   bc, $9F9F
@@ -6275,7 +6283,8 @@ label_A1BCD::
 
 label_A1DF9::
     ld   h, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     inc  de
     inc  d
     dec  d
@@ -7042,7 +7051,8 @@ label_A1F21::
     pop  bc
     pop  bc
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     pop  bc
     pop  bc
     pop  bc
@@ -7702,7 +7712,8 @@ label_A2330::
     ld   c, $FE
     cp   $FE
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
     cp   $08
@@ -8580,7 +8591,8 @@ label_A269C::
     inc  c
     dec  c
     ld   c, $0F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1E
     ld   e, $1E
     ld   e, $1E
     ld   de, label_1E12
@@ -9142,7 +9154,8 @@ label_A2985::
     sbc  a, e
     sbc  a, h
     sbc  a, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
     add  a, c
@@ -9660,19 +9673,25 @@ label_A2B00::
     nop
     ld   [bc], a
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     dec  d
     ld   d, $10
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $19
     ld   a, [de]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     dec  e
     ld   e, $10
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     jr   nz, label_A2C1D
     inc  hl
     jr   nz, label_A2C1E
@@ -10329,7 +10348,8 @@ label_A2C4F::
     rlca
     rlca
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $07
     rlca
     rlca
     rlca
@@ -10393,7 +10413,8 @@ label_A2EE7::
     rlca
     rlca
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $07
     rlca
     rlca
     rlca
@@ -13002,7 +13023,8 @@ label_A39E0::
     ld   de, label_A3F7F
     ld   a, a
     ld   a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7E
     ld   a, [hl]
     ret
     ld   a, [hl]
@@ -13020,7 +13042,8 @@ label_A39E0::
     ld   a, [hl]
     ld   a, [hl]
     ld   a, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     ld   a, [hl]
     ret  nc
     pop  de
@@ -13069,7 +13092,8 @@ label_A39E0::
     xor  $EF
     ld   a, [hl]
     ld   a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7E
     ld   a, [hl]
     ld   a, [hl]
     ld   a, [hl]
@@ -13087,7 +13111,8 @@ label_A39E0::
     ld   a, [hl]
     ld   a, [hl]
     ld   a, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     or   c
     ld   a, a
     ld   a, a
@@ -13123,17 +13148,24 @@ label_A39E0::
     ld   de, label_E0D
     rrca
     ld   a, a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     ld   [de], a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $12
     nop
     ld   bc, label_1012
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [de], a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     ld   a, a
     or   e
     ld   a, a
@@ -13168,16 +13200,24 @@ label_A39E0::
     ld   de, label_E0D
     rrca
     ld   a, a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     ld   [de], a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $12
     ld   [label_1209], sp
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $12
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     ld   a, a
     or   l
     ld   a, a
@@ -13212,17 +13252,24 @@ label_A39E0::
     ld   de, label_E0D
     rrca
     ld   a, a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     ld   [de], a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $12
     nop
     ld   bc, label_1012
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [de], a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     nop
     nop
     nop

--- a/src/disassembled-banks/Bank41.asm
+++ b/src/disassembled-banks/Bank41.asm
@@ -6272,7 +6272,7 @@ label_A5B63::
     inc  b
     cp   l
     inc  bc
-    jp   [hl]
+    jp   hl
     rla
     rst  $20
     ld   e, $DF
@@ -9685,7 +9685,7 @@ label_A6B00::
     nop
     ret  nc
     nop
-    jp   [hl]
+    jp   hl
     ld   bc, label_1F1
     or   $BC
     cp   $1E
@@ -10027,7 +10027,7 @@ label_A6CD6::
     ld   bc, $010F
     dec  b
     inc  bc
-    jp   [hl]
+    jp   hl
     rst  $10
     rst  $38
     ret  nz
@@ -10889,8 +10889,8 @@ label_A7002::
     nop
     jp   label_ECC3
     db   $EC ; Undefined instruction
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
     di
     ld   a, [$FF00+C]
     call nc, label_D8DF
@@ -11135,7 +11135,7 @@ label_A71C6::
     ld   a, [hli]
     ld   a, [hl]
     jr   z, label_A71C6
-    jp   [hl]
+    jp   hl
     db   $FC ; Undefined instruction
     inc  a
     rst  $28
@@ -11243,9 +11243,9 @@ label_A71FF::
     add  hl, de
     dec  h
     call label_F5CD
-    jp   [hl]
+    jp   hl
     ld   sp, hl
-    jp   [hl]
+    jp   hl
     ld   sp, hl
     ld   b, b
     ld   b, b
@@ -13803,7 +13803,7 @@ label_A7CF1::
     sbc  a, a
     db   $E8 ; add  sp, d
     rra
-    jp   [hl]
+    jp   hl
     rra
     db   $EB ; Undefined instruction
     ld   e, $EF

--- a/src/disassembled-banks/Bank41.asm
+++ b/src/disassembled-banks/Bank41.asm
@@ -1101,9 +1101,12 @@ label_A44C7::
     ld   [rIE], a
     sub  a, b
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $3F
+    db   $10
+    db   $2F
     jr   label_A44EE
     jr   label_A44A1
     ld   b, b
@@ -1251,7 +1254,8 @@ label_A457A::
     ld   h, b
     cpl
     jr   nc, label_A45B6
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     nop
     rst  $38
     inc  bc
@@ -1264,7 +1268,8 @@ label_A457A::
     jr   label_A4594
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   nc, label_A457A
     pop  de
     ccf
@@ -1306,7 +1311,8 @@ label_A45B6::
 label_A45C8::
     scf
     jr   label_A460A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7D
     jr   nz, label_A45C8
     ld   b, b
     rrca
@@ -1314,9 +1320,12 @@ label_A45C8::
     sbc  a, b
     adc  a, a
     jr   label_A4576
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $BF
+    db   $10
+    db   $BF
+    db   $10
+    db   $1F
     jr   nc, label_A45FE
     jr   nc, label_A45A1
     ld   b, b
@@ -1937,9 +1946,11 @@ label_A482F::
     ld   a, a
     ccf
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  c
     inc  bc
     inc  bc
@@ -2984,7 +2995,8 @@ label_A4CAD::
     inc  b
     rst  $38
     ld    hl, sp+$FF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     ret  nz
     push hl
     ld   e, d
@@ -3416,7 +3428,8 @@ label_A4E63::
     ld   a, a
     ld   a, a
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3C
     jp   label_A609F
     adc  a, $31
     db   $E3 ; Undefined instruction
@@ -3480,7 +3493,8 @@ label_A4E63::
     sbc  a, $29
     rst  $38
     stop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     rst  $38
     rst  $38
     rst  $38
@@ -3715,10 +3729,12 @@ label_A503E::
     inc  bc
     inc  c
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     add  hl, hl
     jr   nz, label_A5067
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     inc  bc
     ld   c, $0E
     ld    hl, sp+$F8
@@ -3914,7 +3930,8 @@ label_A510B::
     inc  bc
     inc  c
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     inc  h
     jr   nz, label_A510B
     ret  nz
@@ -4213,7 +4230,8 @@ label_A521A::
     and  $32
     xor  $A8
     cp   b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     nop
@@ -4300,7 +4318,8 @@ label_A52BA::
     rst  $18
     ld   [$FFEF], a
     jr   nc, label_A52CA
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -4408,7 +4427,8 @@ label_A534A::
     rst  $38
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9F
     ld   h, d
     rst  $38
     rst  $38
@@ -4423,7 +4443,8 @@ label_A534A::
     rst  $38
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EB
     sub  a, h
     rst  $38
     rst  $38
@@ -4486,7 +4507,8 @@ label_A5392::
     ld   c, h
     rst  $38
     jr   c, label_A539C
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     add  a, b
@@ -4541,7 +4563,8 @@ label_A53A4::
     ld   [hl], $E6
     add  hl, de
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     sbc  a, a
     sbc  a, h
@@ -5104,7 +5127,8 @@ label_A55D1::
     rst  $38
     ld   bc, label_7FF
     ld   a, [$F308]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E4
     inc  hl
     ld   [$FF27], a
     ret  nc
@@ -5276,7 +5300,8 @@ label_A56DE::
     or   e
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C2
     dec  a
     inc  e
     inc  e
@@ -5900,7 +5925,8 @@ label_A5984::
     ret  nz
     ccf
     jr   nz, label_A59F4
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [label_80F], sp
     rlca
     inc  b
@@ -6030,7 +6056,8 @@ label_A59F4::
     rst  $38
     add  a, b
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ldi  [hl], a
     rst  $38
     nop
@@ -6056,13 +6083,15 @@ label_A59F4::
     dec  bc
     inc  c
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     jr   nz, label_A5B0B
     ld   b, c
     xor  $91
     ld   a, a
     ld   a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     ld   a, [$FF0F]
     db   $FC ; Undefined instruction
     inc  bc
@@ -6260,7 +6289,8 @@ label_A5B63::
     dec  bc
     inc  c
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $09
     ldd  [hl], a
     ld   l, e
     ld   d, b
@@ -6438,8 +6468,10 @@ label_A5C17::
     db   $F4 ; Undefined instruction
     nop
     db   $EB ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $AF
+    db   $10
+    db   $F0
     rrca
     ld   a, b
     add  a, a
@@ -6719,7 +6751,8 @@ label_A5C17::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     rst  $38
     rst  $38
     rst  $38
@@ -6749,7 +6782,8 @@ label_A5C17::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     rst  $38
     rst  $38
     rst  $38
@@ -6779,7 +6813,8 @@ label_A5C17::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   h, b
     rst  $38
     or   b
@@ -7139,7 +7174,8 @@ label_A5F17::
     db   $FD ; Undefined instruction
     ld   [bc], a
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $AB
     ld   d, h
     rst  $20
     jr   label_A5F02
@@ -7639,7 +7675,8 @@ label_A60C3::
     rrca
     ld   sp, hl
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     nop
     rst  $38
 
@@ -7893,7 +7930,8 @@ label_A6271::
     add  hl, bc
     ld   [label_1833], sp
     rst  $30
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C0
     nop
     and  b
     nop
@@ -7998,7 +8036,8 @@ label_A62C2::
     ld   h, b
     sub  a, a
     jr   label_A62C2
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9F
     jr   nc, label_A62B6
     jr   nc, label_A6338
     ld   sp, label_3967
@@ -8094,7 +8133,8 @@ label_A6374::
     inc  c
     sub  a, b
     jr   label_A638B
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     jr   nc, label_A63A0
     jr   nz, label_A63A0
     rra
@@ -8117,8 +8157,10 @@ label_A638B::
     ld   b, b
     ld   l, b
     jr   nz, label_A63C9
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $0A
     ld   [label_808], sp
 
 label_A63A0::
@@ -8253,10 +8295,13 @@ label_A643E::
     ld   [$C500], sp
     add  a, $28
     ld   [label_1010], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     sub  a, b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $28
     jr   label_A645E
     rlca
     nop
@@ -8828,7 +8873,8 @@ label_A665A::
     pop  hl
     nop
     ld   sp, hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     jr   nz, label_A6700
     nop
     rst  $38
@@ -8862,8 +8908,10 @@ label_A665A::
     inc  de
 
 label_A6723::
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
+    db   $10
+    db   $7F
     ccf
     and  c
     ld   a, a
@@ -8891,7 +8939,8 @@ label_A672A::
 label_A673D::
     ccf
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E2
     ld   b, $86
     inc  b
     ld   c, $04
@@ -8975,7 +9024,8 @@ label_A6777::
     jr   nz, label_A6807
     jr   nz, label_A67C9
     jr   nz, label_A67DB
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   [label_3133], sp
     nop
     nop
@@ -9146,12 +9196,16 @@ label_A6869::
 label_A6875::
     jr   nz, label_A6896
     jr   nc, label_A6898
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $13
     dec  e
     db   $FC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E8
     jr   nc, label_A6875
     jr   nz, label_A6867
     jr   nz, label_A6869
@@ -9270,7 +9324,8 @@ label_A68ED::
 label_A6912::
     inc  a
     jr   label_A6945
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $50
     jr   nc, label_A68B9
     ld   h, b
     ld   [$FFE0], a
@@ -9412,7 +9467,8 @@ label_A6954::
     ld    hl, sp+$0F
     ld   [label_101F], sp
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $BF
     and  b
     ld   l, a
     ld   a, a
@@ -9547,8 +9603,10 @@ label_A6A55::
     cp   b
     jr   c, label_A6ABA
     rla
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $0F
     ld   [label_80F], sp
     rrca
     inc  b
@@ -9559,8 +9617,10 @@ label_A6A55::
     ld    hl, sp+$D0
     jr   c, label_A6AB4
     ret  c
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D8
+    db   $10
+    db   $EC
     ld   [label_4F7], sp
     di
     ld   [bc], a
@@ -9634,7 +9694,8 @@ label_A6ABA::
     cp   $01
     db   $FC ; Undefined instruction
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     add  hl, bc
     db   $FC ; Undefined instruction
     inc  b
@@ -10041,7 +10102,8 @@ label_A6CD6::
     adc  a, a
     rrca
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $80
     rst  $38
     cp   $01
     rst  $38
@@ -10057,7 +10119,8 @@ label_A6CD6::
     ret  nz
     rst  $38
     jr   nz, label_A6D03
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ret  c
     ccf
     ld   l, b
@@ -10143,7 +10206,8 @@ label_A6D4C::
     ld   a, [$FFF1]
     sub  a, c
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     jr   nz, label_A6DB3
     ld   hl, label_3F3F
     jr   nz, label_A6DB2
@@ -10166,7 +10230,8 @@ label_A6D4C::
 
 label_A6D90::
     jr   label_A6D91
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   [$88FF], sp
     rst  $38
     ld   c, c
@@ -10200,7 +10265,8 @@ label_A6DB3::
     ld   l, a
     sbc  a, b
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FD
     ldi  [hl], a
     ld   [hl], a
     ret  z
@@ -10292,8 +10358,10 @@ label_A6DE4::
     db   $FC ; Undefined instruction
     rst  0
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $30
     ld   sp, label_3131
     ld   sp, label_A6939
     rst  $38
@@ -10320,7 +10388,8 @@ label_A6DE4::
     ld   e, c
     scf
     jr   label_A6E98
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     ld   d, b
     ld   l, l
     ld   a, [$FF00+C]
@@ -10855,8 +10924,10 @@ label_A7002::
     ld   a, l
     nop
     ld   a, l
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $BB
+    db   $10
+    db   $B0
     add  a, b
     cp   l
     adc  a, l
@@ -11252,11 +11323,16 @@ label_A71FF::
     and  b
     and  b
     ret  nc
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D0
+    db   $10
+    db   $D0
+    db   $10
+    db   $D0
+    db   $10
+    db   $B0
+    db   $10
+    db   $B0
     stop
 
 label_A7251::
@@ -11420,7 +11496,8 @@ label_A72CF::
     nop
     rrca
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     daa
     jr   nz, label_A72CA
     call nz, label_EEF5
@@ -11485,8 +11562,10 @@ label_A72FF::
     ld   [hl], c
     pop  af
     or   b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $B0
+    db   $10
+    db   $F0
     ld   d, b
     and  b
     ld   [rNR41], a
@@ -11705,12 +11784,18 @@ label_A742E::
     nop
     nop
     or   b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $B0
+    db   $10
+    db   $70
+    db   $10
+    db   $70
+    db   $10
+    db   $70
+    db   $10
+    db   $70
+    db   $10
+    db   $A0
     and  b
     ld   h, b
     ld   h, b
@@ -13112,7 +13197,8 @@ label_A7A0E::
     ld   h, b
     rra
     jr   nc, label_A7A27
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [label_807], sp
     rlca
     inc  b
@@ -13441,7 +13527,8 @@ label_A7AFC::
     rst  0
     jp   label_9FC3
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9F
     and  $F9
     ld   [$FF9F], a
     add  a, b

--- a/src/disassembled-banks/Bank42.asm
+++ b/src/disassembled-banks/Bank42.asm
@@ -145,7 +145,8 @@ label_A8062::
     nop
     nop
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
 
 label_A809A::
     rrca
@@ -384,13 +385,15 @@ label_A816C::
     add  a, a
     rlca
     ld   [label_1008], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     stop
     nop
     ld   h, b
     ld   h, b
     jr   nz, label_A81D4
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     add  a, b
     ld   b, b
@@ -422,7 +425,8 @@ label_A81D4::
     ld   [$FFE0], a
 
 label_A81DC::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $30
 
 label_A81DE::
     jr   label_A81F8
@@ -972,9 +976,12 @@ label_A845A::
     jr   nc, label_A8483
 
 label_A8464::
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
     jr   nc, label_A84AB
     sub  a, b
     ld   a, a
@@ -1389,7 +1396,8 @@ label_A8608::
     ld   a, [hl]
     and  c
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $BF
     jr   nc, label_A85EB
     jr   nc, label_A85ED
     ld   sp, $E39F
@@ -1544,7 +1552,8 @@ label_A86DB::
     nop
     rst  $38
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     ld   bc, label_FF7
     ld    hl, sp+$FF
     nop
@@ -1627,14 +1636,22 @@ label_A86DB::
     rst  $38
     ret  nz
     sbc  a, a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9F
+    db   $10
+    db   $9F
+    db   $10
+    db   $9F
+    db   $10
+    db   $9F
+    db   $10
+    db   $9F
+    db   $10
+    db   $9F
+    db   $10
+    db   $9F
+    db   $10
+    db   $E4
     jp   label_E0D0
     db   $EC ; Undefined instruction
     ld   a, [$FFF8]
@@ -1703,7 +1720,8 @@ label_A87BB::
     rlca
     nop
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C8
     nop
     rst  $38
     add  a, a
@@ -1730,7 +1748,8 @@ label_A87D8::
     ld   [hl], b
     sbc  a, a
     jr   c, label_A87BB
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     adc  a, b
     rst  $30
     add  a, b
@@ -1874,7 +1893,8 @@ label_A887F::
     xor  [hl]
     or   b
     sbc  a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $BF
     ld   de, label_21BF
     cp   a
     ld   hl, label_213F
@@ -2001,9 +2021,12 @@ label_A891F::
     ld   a, b
     ld   [label_878], sp
     ld   [hl], b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
+    db   $10
+    db   $F0
+    db   $10
+    db   $E0
     jr   nz, label_A891D
     jr   nz, label_A891F
     jr   nz, label_A8940
@@ -2251,8 +2274,10 @@ label_A8A01::
     ei
     ld    hl, sp+$13
     ld   a, [$FFF3]
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
+    db   $10
+    db   $F7
     ld   de, label_21E7
     ret  nz
     ld   b, b
@@ -2547,7 +2572,8 @@ label_A8A01::
     rst  $38
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -2604,7 +2630,8 @@ label_A8A01::
     ld   b, b
     ccf
     jr   nz, label_A8C3C
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [$E0FF], sp
     rst  $38
     inc  a
@@ -2726,8 +2753,10 @@ label_A8C3C::
     rst  $38
     ld   [label_10FF], sp
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $EF
     inc  l
     rst  $38
     ld  [$FF00+C], a
@@ -2943,7 +2972,8 @@ label_A8CF4::
     ld    hl, sp+$FF
     ld    hl, sp+$FF
     ld   a, [$FF1F]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $BF
     nop
     cp   a
     nop
@@ -3073,7 +3103,8 @@ label_A8DE7::
     or   b
     ld   d, b
     or   b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   d, b
     or   b
     ld   h, b
@@ -3131,7 +3162,8 @@ label_A8DE7::
     nop
     ccf
     jr   nz, label_A8E72
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [label_407], sp
     inc  bc
     ld   [bc], a
@@ -3235,7 +3267,8 @@ label_A8E72::
     ld   c, a
     adc  a, b
     sub  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     jr   nz, label_A8F1D
     ld   b, b
     add  a, b
@@ -3587,7 +3620,8 @@ label_A904B::
     adc  a, [hl]
     ld   [hl], c
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $87
     ld   a, b
     ld   [hl], a
     adc  a, b
@@ -3800,10 +3834,14 @@ label_A912E::
     ld   [bc], a
     ld   bc, $8040
     jr   nz, label_A9104
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     jr   nz, label_A910E
     ld   b, b
     add  a, b
@@ -4073,7 +4111,8 @@ label_A9199::
     ld   [label_101F], sp
     rra
     jr   nc, label_A928B
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     jr   nz, label_A92AF
     ld   bc, label_2FF
     rst  $38
@@ -4778,7 +4817,8 @@ label_A95A4::
     ld   h, b
     ld   a, a
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     ld   [label_C07], sp
     ld   bc, rIE
     rst  $38
@@ -4879,7 +4919,8 @@ label_A95A4::
     jr   z, label_A9629
     ld   [label_10FF], sp
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   bc, label_3FE
     db   $FC ; Undefined instruction
     ld   [bc], a
@@ -4917,7 +4958,8 @@ label_A9657::
     rrca
     inc  c
     cp   a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FC
     jr   nz, label_A9657
     ld   b, b
     nop
@@ -5057,8 +5099,10 @@ label_A9657::
     rst  $38
     cp   $FF
     cp   $FF
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
     jr   nz, label_A9705
     jr   nz, label_A9707
     jr   nz, label_A9709
@@ -6056,7 +6100,8 @@ label_A9B6F::
     rst  $38
     ld   [label_10FF], sp
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     rra
     rst  $38
     ld   hl, $DBFF
@@ -6209,9 +6254,12 @@ label_A9C40::
     ld   a, [bc]
     rst  $38
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $17
+    db   $10
+    db   $17
     cp   a
     and  b
     ld   a, a
@@ -6256,7 +6304,8 @@ label_A9CAC::
     ld   a, [de]
     ld   hl, label_110E
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $07
     ld   [label_877], sp
     ei
     inc  b
@@ -6440,7 +6489,8 @@ label_A9D34::
     add  a, b
     ld   [$FFE0], a
     ld   [hl], b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   [label_8F8], sp
     nop
     nop
@@ -6652,8 +6702,10 @@ label_A9D34::
     ld   [rIF], a
     ld   [label_101F], sp
     rra
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $3E
     ld   hl, label_213F
     ld   a, a
     ld   b, e
@@ -7634,10 +7686,14 @@ label_AA2E3::
     nop
     rst  $38
     ld   a, [$FF1F]
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $DF
+    db   $10
+    db   $DF
+    db   $10
+    db   $D0
     rra
     nop
     nop
@@ -8464,7 +8520,8 @@ label_AA6AF::
     sub  a, d
     ld   [bc], a
     inc  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
     nop
     ld   c, h
     inc  b
@@ -8473,7 +8530,8 @@ label_AA6AF::
     ld   c, b
     nop
     jp   label_3240
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0A
     ld   [label_3C6], sp
     call nz, label_C403
     ld   bc, $0008
@@ -8712,10 +8770,12 @@ label_AA7C4::
     nop
     rst  $38
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $8B
     nop
     adc  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0B
     jr   nz, label_AA7FB
     nop
     pop  hl
@@ -9037,7 +9097,8 @@ label_AA8D0::
     nop
     ld   bc, label_E01
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     jr   nz, label_AA989
     ld   b, b
     ld   a, a
@@ -9108,7 +9169,8 @@ label_AA989::
     ld   b, b
     ld   b, b
     jr   nz, label_AA9BA
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [label_808], sp
     ld   [$0000], sp
     nop
@@ -9284,7 +9346,8 @@ label_AAA16::
     ld   [hl], b
     ccf
     jr   nz, label_AAA86
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [$880F], sp
     add  a, a
     ld   b, h
@@ -9477,8 +9540,10 @@ label_AAA86::
     ld   [hl], b
     jr   nc, label_AAB84
     ret  c
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D8
+    db   $10
+    db   $EC
     ld   [label_8CC], sp
     db   $3A ; ldd  a, [hl]
     inc  a
@@ -9576,8 +9641,10 @@ label_AAB92::
     ld   [label_8B0], sp
     or   b
     ld   [$8830], sp
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $88
+    db   $10
+    db   $88
     jr   nc, label_AAB66
     jr   nc, label_AAB68
     nop
@@ -9709,8 +9776,10 @@ label_AAC5C::
     ld   a, l
     ld   a, a
     ld   hl, label_3E3F
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7C
+    db   $10
+    db   $FD
     ld   [$FF79], a
     ret  nz
     di
@@ -11610,7 +11679,8 @@ label_AB45D::
     pop  bc
     inc  e
     db   $E3 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     nop
     rst  $38
     nop
@@ -11656,13 +11726,17 @@ label_AB478::
     rrca
     rrca
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $02
     ld   [bc], a
     ld   [de], a
     ld   [de], a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     ld   b, $00
     ld   [$FFF0], a
     ld    hl, sp+$08
@@ -11870,8 +11944,10 @@ label_AB55B::
     inc  b
     inc  b
     sbc  a, a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $90
+    db   $10
+    db   $CF
     adc  a, a
     ld   a, [$FF60]
     ld   e, a
@@ -12712,7 +12788,8 @@ label_AB91E::
     ld   a, b
     pop  af
     jr   c, label_AB91A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C3
     jr   nz, label_AB91E
     jr   nz, label_AB900
     ld   b, b
@@ -12941,9 +13018,12 @@ label_ABA1A::
     ld   a, [$FF20]
     db   $FC ; Undefined instruction
     jr   nz, label_ABAB5
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3E
+    db   $10
+    db   $7F
+    db   $10
+    db   $7F
     ld   [$00FF], sp
     ccf
     nop
@@ -13655,7 +13735,8 @@ label_ABD75::
     rst  $38
 
 label_ABD7E::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     nop
     nop
@@ -13758,7 +13839,8 @@ label_ABDB7::
     inc  a
     cp   $10
     db   $FC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   [label_7FF], sp
 
 label_ABDFE::
@@ -13815,7 +13897,8 @@ label_ABDFE::
     jr   c, label_ABE35
 
 label_ABE35::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $70
     nop
     ld   [rTMA], a
     ld   [rJOYP], a
@@ -13860,7 +13943,8 @@ label_ABE35::
     rst  $38
     ld   bc, $00FF
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld  [$FF00+C], a
     rst  $38
     ld   a, [$FF00+C]
@@ -13899,7 +13983,8 @@ label_ABE35::
     rst  8
     call nz, label_89F
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   h, b
     rst  $38
     add  a, b

--- a/src/disassembled-banks/Bank42.asm
+++ b/src/disassembled-banks/Bank42.asm
@@ -5526,7 +5526,7 @@ label_A9913::
     rst  8
     ld   a, l
     rst  8
-    jp   [hl]
+    jp   hl
     ld   e, a
     pop  af
     ld   e, a
@@ -5584,7 +5584,7 @@ label_A9913::
     ccf
     rst  $10
     ccf
-    jp   [hl]
+    jp   hl
     rra
     call nz, label_FA3F
     rlca
@@ -7400,7 +7400,7 @@ label_AA19C::
     ccf
     pop  bc
     rra
-    jp   [hl]
+    jp   hl
     ld   h, b
     rst  $38
     add  a, b
@@ -7617,7 +7617,7 @@ label_AA2E3::
     ccf
     ret
     rra
-    jp   [hl]
+    jp   hl
     rst  $38
     rst  $38
     ld   a, [$FF00]
@@ -9301,7 +9301,7 @@ label_AAA16::
     cp   $01
     rst  $38
     rlca
-    jp   [hl]
+    jp   hl
     ld   e, $F7
     ld   a, c
     cp   $00
@@ -10244,9 +10244,9 @@ label_AAE3C::
     add  a, d
     db   $FD ; Undefined instruction
     sub  a, [hl]
-    jp   [hl]
+    jp   hl
     sub  a, [hl]
-    jp   [hl]
+    jp   hl
     ld   a, h
     ld   bc, $00FF
     cp   l

--- a/src/disassembled-banks/Bank43.asm
+++ b/src/disassembled-banks/Bank43.asm
@@ -460,7 +460,8 @@ label_AC1BB::
     ld   a, a
     ld   h, b
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [$0000], sp
     nop
     nop
@@ -546,7 +547,8 @@ label_AC22B::
     ld   b, $81
     jp   label_E1C0
     jr   nz, label_AC22B
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     ld   [label_C78], sp
     rlca
     rlca
@@ -677,7 +679,8 @@ label_AC2A1::
     ld   b, c
     ld    hl, sp+$20
     db   $FC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     ld   [label_4FF], sp
     rst  $38
     inc  b
@@ -1178,7 +1181,8 @@ label_AC4FC::
     jp   label_EE7F
     ld   sp, label_10FF
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     ld   [label_4FC], sp
     inc  b
     db   $FC ; Undefined instruction
@@ -1578,7 +1582,8 @@ label_AC64C::
     ccf
     ld   [label_103F], sp
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $30
     rra
     nop
     nop
@@ -1705,7 +1710,8 @@ label_AC64C::
     sbc  a, a
     nop
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     call z, label_E39F
     rst  $30
     ld   sp, hl
@@ -2022,7 +2028,8 @@ label_AC88C::
     ld   h, b
     rst  $38
     ld   [$FF9F], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $40
     nop
     add  a, b
     nop
@@ -2237,7 +2244,8 @@ label_AC984::
     cpl
     ld   [label_80F], sp
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   [rSB], a
     nop
     rst  $38
@@ -2342,10 +2350,14 @@ label_ACA24::
     rst  $38
     ld   [$FF2F], a
     jr   nc, label_ACA84
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $07
     ld   [label_601], sp
     rst  $38
     ld   bc, $00FF
@@ -2530,7 +2542,8 @@ label_ACAF0::
     nop
     add  a, b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     ld   b, b
     nop
     ccf
@@ -3373,8 +3386,10 @@ label_ACC7C::
     rlca
     rst  $38
     ld   [label_10F1], sp
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
+    db   $10
+    db   $F0
     nop
     ccf
     ld   [label_3F40], sp
@@ -4060,8 +4075,10 @@ label_AD176::
     ld   d, b
     or   b
     jr   nc, label_AD116
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $90
+    db   $10
+    db   $B0
     ld   [$FFE0], a
     ret  nz
     ret  nz
@@ -4140,8 +4157,10 @@ label_AD1C5::
     ld   d, b
     or   b
     jr   nc, label_AD176
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $90
+    db   $10
+    db   $B0
     ld   [$FFE0], a
     nop
     nop
@@ -4275,7 +4294,8 @@ label_AD216::
     ld   d, b
     or   b
     or   b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $58
     cp   b
     ld    hl, sp+$F8
     ld   [$FF60], a
@@ -4348,7 +4368,8 @@ label_AD2AE::
     ld   d, b
     or   b
     or   b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $58
     cp   b
     ld    hl, sp+$F8
     ld   [$FF60], a
@@ -4502,7 +4523,8 @@ label_AD371::
     nop
     rrca
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     daa
     jr   nz, label_AD3EA
     ld   b, h
@@ -4515,7 +4537,8 @@ label_AD371::
     nop
     nop
     ld   [$FFE0], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ret  z
     ld   [label_AC4E4], sp
     ld   d, h
@@ -4528,7 +4551,8 @@ label_AD371::
     nop
     rrca
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     cpl
     cpl
     ld   e, a
@@ -4544,7 +4568,8 @@ label_AD3BE::
     nop
     nop
     ld   [$FFE0], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     db   $E8 ; add  sp, d
     db   $E8 ; add  sp, d
     db   $F4 ; Undefined instruction
@@ -5519,7 +5544,8 @@ label_AD7E2::
     rrca
     ld    hl, sp+$FF
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $50
     cp   a
     ret  z
     rst  8
@@ -5548,7 +5574,8 @@ label_AD7E2::
     ei
     inc  de
     db   $FC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ccf
     rst  $38
     ld   b, d
@@ -5727,7 +5754,8 @@ label_AD7E2::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     rst  $38
     nop
     add  a, c
@@ -5740,8 +5768,10 @@ label_AD7E2::
     rst  $38
     ld   b, b
     ld   b, b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $EF
     rst  $38
     nop
     add  a, c
@@ -5753,7 +5783,8 @@ label_AD7E2::
     rst  $38
     ld   [$FF50], a
     ld   e, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     nop
     nop
@@ -6313,7 +6344,8 @@ label_AD9E6::
     ld   bc, $BB45
     rst  $38
     ld   bc, $EF11
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     rst  $38
     nop
     add  a, c
@@ -6324,8 +6356,10 @@ label_AD9E6::
     ld   a, [hl]
     rst  $38
     nop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
+    db   $10
+    db   $EF
     ld   [$FFF7], sp
     nop
     add  a, c
@@ -7440,7 +7474,8 @@ label_AE048::
     cp   $03
     cp   $03
     cp   $EF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E7
     jr   label_AE048
     inc  e
     pop  af
@@ -8051,8 +8086,10 @@ label_AE2E2::
     ld    hl, sp+$4F
     or   b
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $F7
     jr   c, label_AE2E2
     inc  a
     rst  $38
@@ -9357,7 +9394,8 @@ label_AE876::
 
 label_AE89C::
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
     ld   [label_12CA], sp
     ld   h, e
     add  hl, bc
@@ -9601,7 +9639,8 @@ label_AE997::
     ld   c, $08
     jr   label_AE9C4
     add  hl, de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $33
     jr   nz, label_AE9F8
     ld   hl, label_2E3E
     add  hl, de
@@ -9697,7 +9736,8 @@ label_AE9F8::
     sbc  a, [hl]
     nop
     cp   h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E8
     rlca
     rlca
     ccf
@@ -10000,14 +10040,17 @@ label_AEB39::
     nop
     ld   a, [bc]
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     inc  d
     dec  de
     ld    hl, sp+$16
     ld   a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
     jr   label_AEB7C
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     rrca
 
 label_AEB80::
@@ -10228,7 +10271,8 @@ label_AEBF7::
     ld   [$F8FC], sp
     db   $FC ; Undefined instruction
     jr   nc, label_AEC6B
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     rst  $38
     rst  $38
     rst  $38
@@ -10463,7 +10507,8 @@ label_AECCC::
     nop
     cp   $10
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   label_AEDE6
     ld   [label_C7F], sp
     ld   a, a
@@ -11312,7 +11357,8 @@ label_AF0BA::
     ld   [rNR41], a
     and  b
     jr   nz, label_AF06F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $40
     ld   b, b
     ld   b, b
     ld   b, b
@@ -11325,9 +11371,11 @@ label_AF0BA::
     ld   b, b
     ld   b, b
     jr   nz, label_AF10E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     ld   [$889F], sp
     adc  a, a
     add  a, h
@@ -11522,12 +11570,18 @@ label_AF187::
     nop
     ret  nz
     nop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     ld   [label_C08], sp
     inc  c
     inc  c
@@ -11552,7 +11606,8 @@ label_AF187::
     add  a, b
     ld   h, b
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [label_608], sp
     ld   b, $01
     ld   bc, $0000
@@ -11580,7 +11635,8 @@ label_AF187::
     nop
     sbc  a, c
     ld   h, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [$C0F0], sp
     jr   c, label_AF241
     nop
@@ -11862,8 +11918,10 @@ label_AF34F::
     ld   b, b
     jr   nz, label_AF378
     jr   nz, label_AF37A
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     ld   [$E408], sp
     nop
     db   $76 ; Halt
@@ -12067,9 +12125,12 @@ label_AF449::
     jr   nz, label_AF42A
 
 label_AF44B::
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9F
+    db   $10
+    db   $DF
+    db   $10
+    db   $04
     inc  b
     inc  b
     inc  b
@@ -12115,7 +12176,8 @@ label_AF44B::
     rst  $38
     rrca
     ld   sp, hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $BE
     adc  a, [hl]
     db   $F4 ; Undefined instruction
     ld   [hl], h
@@ -12169,7 +12231,8 @@ label_AF44B::
     ld   h, b
     rst  $38
     jr   nz, label_AF4CE
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -12717,7 +12780,8 @@ label_AF712::
     inc  b
     inc  b
     ld   [label_1408], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $AE
     rst  $38
     xor  [hl]
     rst  $38
@@ -12946,7 +13010,8 @@ label_AF809::
     ld   bc, label_301
     ld   [bc], a
     dec  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3C
     jr   nz, label_AF8A7
     ld   b, b
     db   $FC ; Undefined instruction
@@ -12959,13 +13024,16 @@ label_AF809::
     rra
     inc  de
     rra
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $0F
     ld   [label_80F], sp
     rrca
     ld   [label_80F], sp
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $80
     add  a, b
     ld   b, d
     ld   b, b
@@ -12974,9 +13042,12 @@ label_AF809::
     jr   nz, label_AF878
     inc  hl
     jr   nz, label_AF86C
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $60
     rra
     ld   d, b
     cpl
@@ -13015,9 +13086,12 @@ label_AF878::
     inc  b
     ld    hl, sp+$08
     ei
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
+    db   $10
+    db   $F0
+    db   $10
+    db   $07
     ld   bc, label_207
     rra
     inc  b
@@ -13161,8 +13235,10 @@ label_AF912::
     ret  nz
     xor  $00
     sbc  a, a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $8F
     add  hl, bc
     rlca
     dec  b
@@ -13188,7 +13264,8 @@ label_AF912::
     ret  z
 
 label_AF950::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [label_408], sp
     inc  b
     ld   b, $06
@@ -13226,7 +13303,8 @@ label_AF950::
     inc  l
     inc  bc
     db   $FC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  c
     cp   $02
     rst  $38
@@ -13400,7 +13478,8 @@ label_AF9BB::
     rrca
     ld   [label_101F], sp
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -13419,7 +13498,8 @@ label_AFA62::
     rst  0
     call nz, label_80F
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     jr   nz, label_AFAEA
     ld   b, b
     rst  $38
@@ -13471,8 +13551,10 @@ label_AFA62::
     ld   a, a
     ld   h, b
     rra
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $77
     nop
     cp   e
     nop
@@ -13586,7 +13668,8 @@ label_AFAFF::
     nop
     ld   [label_808], sp
     ld   [label_1010], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   nc, label_AFB6A
     ld   a, b
     ld   l, b
@@ -13595,10 +13678,14 @@ label_AFAFF::
     adc  a, h
     add  a, b
     rra
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $3F
     jr   nz, label_AFBCA
     ld   b, b
     ld   a, a
@@ -13751,7 +13838,8 @@ label_AFBEF::
     ld   c, h
     pop  bc
     ld   [rSB], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $80
     ld   [$807F], sp
     cp   $00
     db   $ED ; Undefined instruction
@@ -13808,8 +13896,10 @@ label_AFBEF::
     jr   nz, label_AFC6A
 
 label_AFC4B::
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $17
     stop
     add  a, c
     nop
@@ -14012,12 +14102,18 @@ label_AFCEB::
     nop
     nop
     inc  de
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $30
+    db   $10
+    db   $30
+    db   $10
+    db   $30
+    db   $10
+    db   $30
+    db   $10
+    db   $60
     jr   nz, label_AFD2F
     ld   h, b
     cp   $00
@@ -14084,8 +14180,10 @@ label_AFCEB::
     rra
     ld   [label_81F], sp
     ccf
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
+    db   $10
+    db   $3F
     stop
     nop
     nop
@@ -14194,8 +14292,10 @@ label_AFDFC::
     db   $EB ; Undefined instruction
     inc  b
     jp   nz, label_ED0C
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
+    db   $10
+    db   $1E
     ld   [$FF7F], a
     add  a, b
     rst  $38

--- a/src/disassembled-banks/Bank43.asm
+++ b/src/disassembled-banks/Bank43.asm
@@ -1188,7 +1188,7 @@ label_AC4FC::
     di
     sbc  a, [hl]
     ld   a, a
-    jp   [hl]
+    jp   hl
     ld   e, $FB
     inc  e
     ld   [hl], a
@@ -4042,7 +4042,7 @@ label_AD14B::
     dec  de
     rst  $38
     rst  $38
-    jp   [hl]
+    jp   hl
     pop  af
     push bc
     db   $E4 ; Undefined instruction
@@ -4124,7 +4124,7 @@ label_AD1C5::
     inc  bc
     ld   bc, rSB
     rst  $38
-    jp   [hl]
+    jp   hl
     pop  af
     push bc
     db   $E4 ; Undefined instruction
@@ -12356,7 +12356,7 @@ label_AF5A0::
     rst  $38
     db   $EB ; Undefined instruction
     rst  $38
-    jp   [hl]
+    jp   hl
     rst  $38
     ld   sp, hl
     rst  $38
@@ -12524,7 +12524,7 @@ label_AF660::
     set  7, a
     set  7, a
     set  7, a
-    jp   [hl]
+    jp   hl
     rst  $38
     ld   l, c
     rst  $38

--- a/src/disassembled-banks/Bank44.asm
+++ b/src/disassembled-banks/Bank44.asm
@@ -3182,7 +3182,7 @@ label_B0D77::
     ld   e, h
     ld   e, h
     ld   a, [$FF00+C]
-    jp   [hl]
+    jp   hl
     xor  c
     push hl
     dec  h
@@ -4320,9 +4320,9 @@ label_B1279::
     ld   sp, hl
     rst  $28
     rst  $38
-    jp   [hl]
+    jp   hl
     rst  $38
-    jp   [hl]
+    jp   hl
     rst  $38
     rst  $38
     nop
@@ -4522,7 +4522,7 @@ label_B13B2::
     rst  $38
     nop
     rst  $38
-    jp   [hl]
+    jp   hl
     rra
     add  hl, bc
     db   $FD ; Undefined instruction
@@ -12291,7 +12291,7 @@ label_B34AD::
     rlca
     dec  de
     inc  bc
-    jp   [hl]
+    jp   hl
     ld   bc, label_5F3
     di
     dec  h
@@ -12372,7 +12372,7 @@ label_B34AD::
     inc  bc
     push af
     dec  c
-    jp   [hl]
+    jp   hl
     rla
     dec  de
     db   $DB

--- a/src/disassembled-banks/Bank44.asm
+++ b/src/disassembled-banks/Bank44.asm
@@ -14,7 +14,8 @@ label_B0007::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
     jr   label_B002E
     dec  c
     rla
@@ -355,7 +356,8 @@ label_B012F::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     nop
@@ -663,7 +665,8 @@ label_B02CA::
     ld   e, e
     ld   a, a
     jr   nz, label_B030D
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     nop
     nop
     nop
@@ -880,7 +883,8 @@ label_B03BD::
     ld   [rLCDC], a
     ld   [hl], b
     jr   nz, label_B03EF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     nop
     nop
     nop
@@ -1000,7 +1004,8 @@ label_B03EF::
     nop
     rrca
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     daa
     ccf
     jr   z, label_B0487
@@ -1029,7 +1034,8 @@ label_B044C::
     nop
     nop
     ld   [$FFE0], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ret  z
     ld    hl, sp+$28
     ld    hl, sp+$C8
@@ -1234,7 +1240,8 @@ label_B04F8::
     ld   [label_1916], sp
     add  hl, de
     ld   d, $1F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     add  hl, de
     add  hl, de
     ld   d, $0F
@@ -1305,7 +1312,8 @@ label_B04F8::
     ld    hl, sp+$38
     sub  a, b
     ld   [hl], b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [$FFE0], a
     ret  nz
     ld   b, b
@@ -1666,8 +1674,10 @@ label_B0746::
     inc  c
     rst  $20
     jr   label_B073C
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -1681,8 +1691,10 @@ label_B0754::
     jr   label_B0754
     ld   [label_8F7], sp
     rst  $28
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
+    db   $10
+    db   $E7
     jr   label_B075A
     inc  c
     ld    hl, sp+$07
@@ -1991,7 +2003,8 @@ label_B0878::
     ld   [hl], $3E
     ld   [label_808], sp
     ld   [label_1010], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [label_1C08], sp
     inc  e
     db   $3A ; ldd  a, [hl]
@@ -2391,7 +2404,8 @@ label_B0A35::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   c, label_B0A8E
     ld   a, h
     ld   b, h
@@ -2405,7 +2419,8 @@ label_B0A35::
     cp   $44
     ld   a, h
     jr   z, label_B0AB4
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     nop
@@ -2436,7 +2451,8 @@ label_B0A8E::
     add  a, $54
     ld   l, h
     jr   z, label_B0AD6
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     nop
@@ -2453,7 +2469,8 @@ label_B0A8E::
     ld   b, b
     ld   a, a
     jr   nz, label_B0AF1
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
 
 label_B0AB4::
     ld   [label_40F], sp
@@ -2968,7 +2985,8 @@ label_B0C80::
     ld   d, d
     inc  a
     inc  a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   label_B0CD8
     nop
     nop
@@ -3011,7 +3029,8 @@ label_B0CDF::
     ld   d, b
     ld   h, h
     jr   nz, label_B0D26
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     rrca
@@ -3310,7 +3329,8 @@ label_B0E41::
     daa
     ld   [hl], e
     jr   nz, label_B0E41
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FC
     inc  c
     ld   a, a
     inc  bc
@@ -3324,7 +3344,8 @@ label_B0E41::
     call c, label_1E10
 
 label_B0E59::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3E
     jr   nz, label_B0E59
     ret  nz
     ld    hl, sp+$00
@@ -4408,7 +4429,8 @@ label_B1279::
     ld   bc, label_1FF
     rst  $38
     call label_F838
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $61
     jr   nc, label_B137D
     ld   hl, label_372B
     ccf
@@ -5003,7 +5025,8 @@ label_B15A4::
     ld   [bc], a
     ld   bc, label_E11
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     jr   nz, label_B163A
     jr   nz, label_B167C
     jr   nz, label_B165E
@@ -5248,10 +5271,14 @@ label_B16EA::
     ld   b, b
     ld   e, a
     jr   nz, label_B1744
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $2F
+    db   $10
+    db   $5F
     jr   nz, label_B175E
     ld   b, b
     nop
@@ -5263,7 +5290,8 @@ label_B16EA::
 label_B1726::
     ld   e, b
     and  [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EE
     nop
     ld   a, h
     nop
@@ -5279,7 +5307,8 @@ label_B1726::
     nop
     inc  e
     jr   label_B1760
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2E
     ldi  [hl], a
     inc  e
     nop
@@ -5480,7 +5509,8 @@ label_B1806::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
     jr   label_B182E
     dec  c
     rla
@@ -5607,7 +5637,8 @@ label_B188F::
     rrca
     ld   bc, $001F
     ld   [rJOYP], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ret  z
     ld   a, [$FF24]
 
@@ -5725,7 +5756,8 @@ label_B18FD::
     nop
     ld   h, b
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     adc  a, b
     ld   [hl], b
     call nz, label_C4B8
@@ -5780,7 +5812,8 @@ label_B18FD::
     nop
     ld   h, b
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
 
 label_B1968::
     adc  a, b
@@ -5816,12 +5849,14 @@ label_B1968::
     cpl
     ld   e, a
     jr   nz, label_B19C0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
     dec  de
     scf
     rrca
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   c, $1F
     nop
     ccf
@@ -5839,7 +5874,8 @@ label_B1968::
     cp   h
     ret  nc
     db   $EC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DE
     inc  l
     sbc  a, $6C
     cp   h
@@ -5950,7 +5986,8 @@ label_B1A19::
     or   b
     ret  nc
     ld   [$FFE8], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $48
 
 label_B1A37::
     or   b
@@ -6081,9 +6118,11 @@ label_B1ABD::
     inc  bc
     inc  de
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6F
     ld   e, $F7
     ld   c, $7F
     nop
@@ -6118,7 +6157,8 @@ label_B1ABD::
     ld   c, b
     or   b
     db   $E8 ; add  sp, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   h, b
     ld   a, [$FFC0]
     ld    hl, sp+$00
@@ -6159,7 +6199,8 @@ label_B1B27::
     cp   b
     ret  nz
     db   $E8 ; add  sp, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     ret  nc
     ld   c, b
     or   b
@@ -6343,11 +6384,14 @@ label_B1C06::
     ld   [label_1907], sp
     rlca
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     rla
     ccf
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
+    db   $10
+    db   $3F
     inc  b
     cpl
     dec  d
@@ -6373,7 +6417,8 @@ label_B1C06::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
     jr   label_B1C63
     dec  c
     ld   [hl], $0D
@@ -6720,7 +6765,8 @@ label_B1D76::
     add  a, b
     jr   nz, label_B1D76
     ld   a, [$FFE0]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [rJOYP], a
     ld   [$FFC0], a
     ld   a, [$FF00]
@@ -6809,7 +6855,8 @@ label_B1E1D::
     ld   b, $1F
     ld   b, $2F
     ld   d, $2F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     ld   d, $27
     jr   label_B1E47
     rrca
@@ -6971,7 +7018,8 @@ label_B1EE2::
     inc  a
     inc  de
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3B
     inc  d
     sbc  a, a
     add  a, e
@@ -6991,8 +7039,10 @@ label_B1EE2::
     dec  sp
     inc  b
     cpl
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
+    db   $10
+    db   $2F
     dec  d
     cpl
 
@@ -7026,7 +7076,8 @@ label_B1F25::
     db   $F4 ; Undefined instruction
     xor  b
     call nc, label_E8E8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   a, [$FFE8]
     ld   a, [$FF78]
     add  a, b
@@ -7214,7 +7265,8 @@ label_B2000::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $67
     jr   label_B200E
     ld   c, l
     rst  $30
@@ -7242,7 +7294,8 @@ label_B2026::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
 
 label_B202D::
     jr   label_B202E
@@ -7282,7 +7335,8 @@ label_B2048::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
     jr   label_B20D0
     nop
     ld   a, a
@@ -7327,7 +7381,8 @@ label_B2048::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
 
 label_B208F::
     nop
@@ -7383,7 +7438,8 @@ label_B20C8::
     ccf
     inc  d
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   b, b
 
 label_B20D0::
@@ -7757,7 +7813,8 @@ label_B222D::
     inc  [hl]
     ld   a, l
     ld   b, $3F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     rra
     scf
     inc  e
@@ -8179,7 +8236,8 @@ label_B246A::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $67
     ld   e, b
     ld   a, a
     ld   l, l
@@ -8393,7 +8451,8 @@ label_B2532::
     nop
     nop
     ld   [rJOYP], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ret  z
     ld   a, [$FF24]
     ret  c
@@ -8969,9 +9028,12 @@ label_B2807::
     nop
     ld   [$FF1F], a
     rst  $28
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
+    db   $10
+    db   $EF
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -8988,11 +9050,16 @@ label_B2807::
     ei
     inc  b
     rst  $28
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
+    db   $10
+    db   $EF
+    db   $10
+    db   $EF
+    db   $10
+    db   $EF
+    db   $10
+    db   $E0
     rra
     rst  $38
     nop
@@ -9021,11 +9088,16 @@ label_B2807::
     rst  $38
     rrca
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -9041,9 +9113,12 @@ label_B2807::
     rst  $38
     inc  b
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $F0
+    db   $10
+    db   $F0
     rra
     ld   a, [$FF1F]
     rst  $38
@@ -9071,13 +9146,20 @@ label_B2807::
     rst  $38
     rrca
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
     ld    hl, sp+$FF
     inc  b
     rst  $38
@@ -10223,7 +10305,8 @@ label_B2D53::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     ld   l, h
     rst  $28
     ld   l, h
@@ -10279,7 +10362,8 @@ label_B2DA6::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     jr   z, label_B2DA6
     ld   l, h
     rst  $28
@@ -10332,7 +10416,8 @@ label_B2DE4::
     cp   l
     ld   b, d
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     jr   z, label_B2DE4
     jr   z, label_B2DE6
     ld   l, h
@@ -10677,7 +10762,8 @@ label_B2F2D::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     jr   label_B2F79
     nop
     rst  $38
@@ -10780,7 +10866,8 @@ label_B2F9D::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     jr   label_B2FE9
     nop
     rst  $38
@@ -11647,7 +11734,8 @@ label_B334D::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   l, h
     ld   l, h
     ld   l, h
@@ -11703,7 +11791,8 @@ label_B334D::
     jp   label_B3E81
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   z, label_B33DE
     ld   l, h
     ld   l, h
@@ -11761,7 +11850,8 @@ label_B33DE::
     add  a, c
     cp   l
     ld   b, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   z, label_B341C
     jr   z, label_B341E
     ld   l, h
@@ -13828,7 +13918,8 @@ label_B3C01::
     ret  nz
     rra
     jr   nz, label_B3CDE
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     rst  $38
     cp   [hl]
     pop  bc
@@ -14061,7 +14152,8 @@ label_B3CEC::
     rrca
     sub  a, b
     dec  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nc, label_B3DD6
     ld   a, [$FF0D]
     ld   [$FF3F], a
@@ -14168,7 +14260,8 @@ label_B3E37::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     db   $FD ; Undefined instruction
     nop
 

--- a/src/disassembled-banks/Bank45.asm
+++ b/src/disassembled-banks/Bank45.asm
@@ -3512,7 +3512,7 @@ label_B5008::
     dec  b
     dec  b
     ld   sp, hl
-    jp   [hl]
+    jp   hl
     inc  de
     ld   de, label_317
     rst  8
@@ -4848,7 +4848,7 @@ label_B557C::
     dec  b
     dec  b
     ld   sp, hl
-    jp   [hl]
+    jp   hl
     inc  de
     ld   de, label_317
     rst  8
@@ -5410,7 +5410,7 @@ label_B557C::
     pop  af
     rrca
     rrca
-    jp   [hl]
+    jp   hl
     add  hl, bc
     rst  $38
     rst  $38
@@ -5728,7 +5728,7 @@ label_B59EB::
     dec  b
     dec  b
     ld   sp, hl
-    jp   [hl]
+    jp   hl
     inc  de
     ld   de, label_317
     rst  8
@@ -6590,7 +6590,7 @@ label_B5C7C::
     dec  b
     dec  b
     ld   sp, hl
-    jp   [hl]
+    jp   hl
     inc  de
     ld   de, label_317
     rst  8
@@ -6882,7 +6882,7 @@ label_B5F6D::
     ld   [hl], c
     db   $FD ; Undefined instruction
     inc  bc
-    jp   [hl]
+    jp   hl
     ld   e, a
     or   $4E
     db   $F4 ; Undefined instruction
@@ -7994,7 +7994,7 @@ label_B6475::
     ld   b, h
     ld   sp, hl
     inc  b
-    jp   [hl]
+    jp   hl
     inc  d
     ld   a, c
     add  a, h
@@ -8531,7 +8531,7 @@ label_B66FF::
     dec  b
     dec  b
     ld   sp, hl
-    jp   [hl]
+    jp   hl
     inc  de
     ld   de, label_317
     rst  8
@@ -10543,7 +10543,7 @@ label_B6FFF::
     sbc  a, a
     rst  $10
     rrca
-    jp   [hl]
+    jp   hl
     rlca
     rrca
     rst  $38
@@ -12235,7 +12235,7 @@ label_B778E::
     sbc  a, a
     rst  $10
     rrca
-    jp   [hl]
+    jp   hl
     rlca
     nop
     rst  $38
@@ -12403,7 +12403,7 @@ label_B784F::
     rrca
     dec  bc
     rlca
-    jp   [hl]
+    jp   hl
     rlca
     ld   a, c
     add  a, a
@@ -12430,7 +12430,7 @@ label_B784F::
     rrca
     dec  bc
     rlca
-    jp   [hl]
+    jp   hl
     rlca
     ld   a, c
     add  a, a
@@ -13716,7 +13716,7 @@ label_B7E3F::
     ld   e, $11
     inc  l
     set  1, [hl]
-    jp   [hl]
+    jp   hl
     xor  $E9
     db   $E8 ; add  sp, d
     rst  $28
@@ -14029,7 +14029,7 @@ label_B7F77::
     xor  l
     db   $DB
     rst  $18
-    jp   [hl]
+    jp   hl
     rst  $18
     rst  $20
     cpl

--- a/src/disassembled-banks/Bank45.asm
+++ b/src/disassembled-banks/Bank45.asm
@@ -509,12 +509,18 @@ label_B413E::
     rst  $38
     rra
     nop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     rst  $38
     rst  $38
     rst  $38
@@ -717,11 +723,16 @@ label_B413E::
     ld   bc, $0101
     ld   bc, $0101
     ld   bc, label_F10
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     rra
     nop
     rst  $38
@@ -1185,7 +1196,8 @@ label_B450E::
     rst  $10
     jr   c, label_B44F6
     ld   a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   c, label_B4567
     ld   a, h
     rst  $38
@@ -2265,7 +2277,8 @@ label_B4A32::
     nop
     nop
     jr   label_B4A49
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [$C007], sp
     rlca
     and  b
@@ -2308,7 +2321,8 @@ label_B4A49::
 
 label_B4A77::
     jp   nz, label_E003
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [label_18F0], sp
     ld   [rJOYP], a
     nop
@@ -2321,7 +2335,8 @@ label_B4A77::
     ld   a, e
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   [bc], a
     rst  $38
     rst  $38
@@ -2559,7 +2574,8 @@ label_B4ACB::
     rst  $38
     ld   [bc], a
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     add  a, h
@@ -2676,7 +2692,8 @@ label_B4C18::
     nop
     ld   b, h
     jr   z, label_B4C8B
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $50
     nop
     stop
     sub  a, c
@@ -2712,8 +2729,10 @@ label_B4C32::
     db   $FC ; Undefined instruction
     ld   [label_10FB], sp
     rst  $30
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -2721,14 +2740,16 @@ label_B4C32::
     nop
     rst  $38
     ld   [$FF3F], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     ld   [label_8EF], sp
     rst  $28
 
 label_B4C5F::
     ld   [label_10F7], sp
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F4
     jr   label_B4C5F
     rrca
     rst  $38
@@ -2827,7 +2848,8 @@ label_B4CCE::
 
 label_B4CD4::
     inc  a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F4
     inc  h
     rst  $20
     rst  0
@@ -2837,7 +2859,8 @@ label_B4CD4::
     ld   a, a
     ld   [de], a
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $BF
     ld   de, label_103F
     ld   a, a
     jr   c, label_B4CEA
@@ -2889,7 +2912,8 @@ label_B4D12::
     add  a, b
     nop
     pop  af
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $71
     ld   h, b
     nop
     nop
@@ -2916,7 +2940,8 @@ label_B4D32::
 
 label_B4D3A::
     inc  h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2C
     inc  b
     inc  e
     jr   label_B4D40
@@ -2930,8 +2955,10 @@ label_B4D3A::
     db   $FC ; Undefined instruction
     ld   [label_10FB], sp
     rst  $30
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -2939,14 +2966,16 @@ label_B4D3A::
     nop
     rst  $38
     ld   [$FF3F], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     ld   [label_8EF], sp
     rst  $28
 
 label_B4D5F::
     ld   [label_10F7], sp
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F4
     jr   label_B4D5F
     rrca
     rst  $38
@@ -2977,7 +3006,8 @@ label_B4D84::
     inc  e
     ld   c, c
     jr   z, label_B4DD9
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6F
     jr   nz, label_B4D9D
     rrca
     inc  l
@@ -3146,8 +3176,10 @@ label_B4DF8::
     db   $FC ; Undefined instruction
     ld   [label_10FB], sp
     rst  $30
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -3155,14 +3187,16 @@ label_B4DF8::
     nop
     rst  $38
     ld   [$FF3F], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     ld   [label_8EF], sp
     rst  $28
 
 label_B4E5F::
     ld   [label_10F7], sp
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F4
     jr   label_B4E5F
     rrca
     rst  $38
@@ -3200,7 +3234,8 @@ label_B4E6F::
     ld   sp, hl
     inc  b
     rst  $20
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [label_FF0], sp
 
 label_B4E96::
@@ -3234,7 +3269,8 @@ label_B4E96::
     add  a, $C6
     add  hl, sp
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $22
     nop
     ld   a, $00
     ld  [$FF00+C], a
@@ -3347,8 +3383,10 @@ label_B4F3A::
     db   $FC ; Undefined instruction
     ld   [label_10FB], sp
     rst  $30
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -3356,14 +3394,16 @@ label_B4F3A::
     nop
     rst  $38
     ld   [$FF3F], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     ld   [label_8EF], sp
     rst  $28
 
 label_B4F5F::
     ld   [label_10F7], sp
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F4
     jr   label_B4F5F
     rrca
     rst  $38
@@ -3462,8 +3502,10 @@ label_B4FD6::
     ld   a, a
     db   $FC ; Undefined instruction
     ld    hl, sp+$B8
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FA
+    db   $10
+    db   $FC
     db   $FC ; Undefined instruction
     ccf
     ccf
@@ -3807,7 +3849,8 @@ label_B5168::
     ld   h, a
     sbc  a, b
     rst  8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9F
     jr   nz, label_B51BC
     ld   b, b
     ld   a, [hl]
@@ -3819,7 +3862,8 @@ label_B5168::
     call nz, label_E627
     add  hl, de
     rst  8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9F
     jr   nz, label_B51CC
     ld   b, b
     ld   a, [hl]
@@ -3830,7 +3874,8 @@ label_B5168::
     ld   b, d
     jp   label_E724
     jr   label_B5168
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9F
     jr   nz, label_B51DC
     ld   b, b
     ld   a, [hl]
@@ -6538,7 +6583,8 @@ label_B5C7C::
     ret  nz
     jr   nz, label_B5DF4
     ld   d, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A8
     ld   [$A414], sp
     ld   a, [bc]
     or   d
@@ -6631,9 +6677,12 @@ label_B5C7C::
     nop
     ld   [$FF1F], a
     rst  $28
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
+    db   $10
+    db   $EF
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -6650,11 +6699,16 @@ label_B5C7C::
     ei
     inc  b
     rst  $28
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
+    db   $10
+    db   $EF
+    db   $10
+    db   $EF
+    db   $10
+    db   $EF
+    db   $10
+    db   $E0
     rra
     rst  $38
     nop
@@ -6679,13 +6733,20 @@ label_B5C7C::
     rst  $38
     rrca
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
     ld    hl, sp+$FF
     inc  b
     rst  $38
@@ -7069,8 +7130,10 @@ label_B602D::
     db   $FC ; Undefined instruction
     ld   [label_10FB], sp
     rst  $30
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -7078,14 +7141,16 @@ label_B602D::
     nop
     rst  $38
     ld   [$FF3F], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     ld   [label_8EF], sp
     rst  $28
 
 label_B605F::
     ld   [label_10F7], sp
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F4
     jr   label_B605F
     rrca
     rst  $38
@@ -7127,7 +7192,8 @@ label_B608A::
     or   $0F
 
 label_B6096::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     rra
     ld   [$FF67], a
     sbc  a, b
@@ -7171,7 +7237,8 @@ label_B609E::
     ld   a, a
     jr   label_B60F6
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $09
     ld   a, [$FF84]
     ld   b, b
     ld   [bc], a
@@ -7281,8 +7348,10 @@ label_B6125::
     db   $FC ; Undefined instruction
     ld   [label_10FB], sp
     rst  $30
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -7290,14 +7359,16 @@ label_B6125::
     nop
     rst  $38
     ld   [$FF3F], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     ld   [label_8EF], sp
     rst  $28
 
 label_B615F::
     ld   [label_10F7], sp
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F4
     jr   label_B615F
     rrca
     rst  $38
@@ -7504,8 +7575,10 @@ label_B623A::
     db   $FC ; Undefined instruction
     ld   [label_10FB], sp
     rst  $30
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -7513,14 +7586,16 @@ label_B623A::
     nop
     rst  $38
     ld   [$FF3F], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     ld   [label_8EF], sp
     rst  $28
 
 label_B625F::
     ld   [label_10F7], sp
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F4
     jr   label_B625F
     rrca
     rst  $38
@@ -7632,7 +7707,8 @@ label_B62CB::
     nop
     ldd  [hl], a
     inc  h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $06
     ld   a, [$FF0A]
     ld   a, [$FF44]
     jr   c, label_B6319
@@ -7644,7 +7720,8 @@ label_B62CB::
     ld   b, h
     dec  d
     ldi  [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
     ld   e, d
     inc  h
     nop
@@ -7686,7 +7763,8 @@ label_B630A::
     ld   bc, label_B4088
     ret  nz
     jr   nz, label_B6339
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $12
     ld   [label_2098], sp
     jr   c, label_B6360
     ld   b, h
@@ -7731,8 +7809,10 @@ label_B6339::
     db   $FC ; Undefined instruction
     ld   [label_10FB], sp
     rst  $30
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -7740,7 +7820,8 @@ label_B6339::
     nop
     rst  $38
     ld   [$FF3F], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     ld   [label_8EF], sp
     rst  $28
 
@@ -7749,7 +7830,8 @@ label_B635F::
 
 label_B6362::
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F4
     jr   label_B635F
     rrca
     rst  $38
@@ -7949,8 +8031,10 @@ label_B6434::
     db   $FC ; Undefined instruction
     ld   [label_10FB], sp
     rst  $30
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -7958,14 +8042,16 @@ label_B6434::
     nop
     rst  $38
     ld   [$FF3F], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     ld   [label_8EF], sp
     rst  $28
 
 label_B645F::
     ld   [label_10F7], sp
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F4
     jr   label_B645F
     rrca
     rst  $38
@@ -8019,7 +8105,8 @@ label_B6496::
     ld   a, a
     nop
     ld   l, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7E
     ld   bc, label_57A
 
 label_B64A8::
@@ -8036,7 +8123,8 @@ label_B64A8::
     ld   a, e
     inc  b
     ld   l, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     nop
     ld   a, a
     nop
@@ -8046,8 +8134,10 @@ label_B64A8::
     adc  a, a
     ld   l, c
     sub  a, b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $60
     add  hl, bc
     jr   nc, label_B6513
     add  hl, sp
@@ -8090,7 +8180,8 @@ label_B64A8::
     inc  b
     ld   h, $08
     ld   c, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $98
     jr   nz, label_B6539
     ld   b, b
     ld   h, h
@@ -8103,7 +8194,8 @@ label_B64A8::
     jr   nz, label_B6573
 
 label_B6513::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $32
     ld   [label_499], sp
     ld   c, h
     ld   [bc], a
@@ -8118,7 +8210,8 @@ label_B651D::
     ld   b, b
     ret  z
     jr   nz, label_B6589
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $32
     ld   [label_499], sp
     ld   c, h
     ld   [bc], a
@@ -8131,7 +8224,8 @@ label_B651D::
     inc  b
     ld   h, $08
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $19
 
 label_B6539::
     jr   nz, label_B656D
@@ -8151,8 +8245,10 @@ label_B6539::
     db   $FC ; Undefined instruction
     ld   [label_10FB], sp
     rst  $30
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -8160,14 +8256,16 @@ label_B6539::
     nop
     rst  $38
     ld   [$FF3F], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     ld   [label_8EF], sp
     rst  $28
 
 label_B655F::
     ld   [label_10F7], sp
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F4
     jr   label_B655F
     rrca
     rst  $38
@@ -8220,7 +8318,8 @@ label_B6596::
     ld   [hl], $40
     sbc  a, [hl]
     jr   nz, label_B6569
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E6
     ld   [$00F6], sp
     ld   h, a
     ld   [label_473], sp
@@ -8362,8 +8461,10 @@ label_B6605::
     db   $FC ; Undefined instruction
     ld   [label_10FB], sp
     rst  $30
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -8371,14 +8472,16 @@ label_B6605::
     nop
     rst  $38
     ld   [$FF3F], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     ld   [label_8EF], sp
     rst  $28
 
 label_B665F::
     ld   [label_10F7], sp
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F4
     jr   label_B665F
     rrca
     rst  $38
@@ -8489,7 +8592,8 @@ label_B66BD::
     adc  a, c
     rlca
     call nz, label_B6809
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $48
     jr   nc, label_B671F
     ld   c, b
     jp   label_B4304
@@ -9421,7 +9525,8 @@ label_B6B0C::
     ld   bc, $0100
     nop
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0E
     jr   nz, label_B6B31
     ld   b, b
     ld   e, b
@@ -9464,8 +9569,10 @@ label_B6B0C::
     db   $FC ; Undefined instruction
     ld   [label_10FB], sp
     rst  $30
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -9473,14 +9580,16 @@ label_B6B0C::
     nop
     rst  $38
     ld   [$FF3F], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     ld   [label_8EF], sp
     rst  $28
 
 label_B6B5F::
     ld   [label_10F7], sp
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F4
     jr   label_B6B5F
     rrca
     rst  $38
@@ -9576,7 +9685,8 @@ label_B6B96::
     ld    hl, sp+$F8
     ld    hl, sp+$90
     cp   c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $67
     ldi  [hl], a
     ld   h, a
     ldi  [hl], a
@@ -9593,7 +9703,8 @@ label_B6B96::
     add  a, e
     add  a, c
     cp   h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7E
     jr   c, label_B6BF4
     ld   h, [hl]
     ld   [$FFC0], a
@@ -11078,7 +11189,8 @@ label_B7281::
     sub  a, h
     ld   h, e
     jr   z, label_B7261
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   h, [hl]
     sbc  a, c
     adc  a, d
@@ -11944,7 +12056,8 @@ label_B7658::
     ld   a, h
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     inc  a
     jp   label_B76FF
     rst  $38
@@ -11958,7 +12071,8 @@ label_B7668::
     ld   a, h
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     inc  a
     jp   label_B76FF
     rst  $38
@@ -11972,7 +12086,8 @@ label_B7678::
     ld   a, h
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     inc  a
     jp   label_B76FF
     rst  $38
@@ -11986,7 +12101,8 @@ label_B7688::
     ld   a, h
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     inc  a
     jp   label_B6FFF
     db   $FC ; Undefined instruction
@@ -12097,7 +12213,8 @@ label_B76FF::
     rst  $38
     inc  c
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     ldi  [hl], a
     dec  a
     dec  h
@@ -13351,7 +13468,8 @@ label_B7C81::
     sub  a, h
     ld   h, e
     jr   z, label_B7C81
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   h, [hl]
     sbc  a, c
     adc  a, d
@@ -13740,7 +13858,8 @@ label_B7E3F::
     jr   c, label_B7ECD
     rst  $30
     jr   label_B7E6F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     rst  $38
     rst  $38
     ld   a, a

--- a/src/disassembled-banks/Bank46.asm
+++ b/src/disassembled-banks/Bank46.asm
@@ -1657,7 +1657,7 @@ label_B87AC::
     ld   d, l
     xor  e
     ld   d, h
-    jp   [hl]
+    jp   hl
     ld   d, [hl]
     cp   h
     ld   b, e

--- a/src/disassembled-banks/Bank46.asm
+++ b/src/disassembled-banks/Bank46.asm
@@ -85,7 +85,8 @@ section "bank46",romx,bank[$2E]
     rla
     ld   [label_1827], sp
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
     inc  e
     inc  hl
     inc  e
@@ -382,7 +383,8 @@ label_B81C2::
     nop
     ld   [hl], c
     jr   nz, label_B8206
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     inc  d
     rrca
@@ -399,7 +401,8 @@ label_B81CE::
     rra
     nop
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6F
     jr   nc, label_B81CE
     ld   b, c
     jp   label_101
@@ -497,7 +500,8 @@ label_B824E::
     ld   a, [hl]
     ld   bc, label_1C23
     jr   nz, label_B8277
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   hl, label_231E
     inc  e
     ccf
@@ -616,7 +620,8 @@ label_B8295::
     rrca
     rrca
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     jr   nz, label_B8317
     cpl
     daa
@@ -680,7 +685,8 @@ label_B8317::
     ld   [$FFB8], a
     ret  nc
     db   $FC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EE
     or   h
     rst  $38
     add  a, $DF
@@ -732,7 +738,8 @@ label_B8317::
     cp   $EC
     rst  $38
     cp   $EE
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DC
     ld   [$FFCC], a
 
 label_B836D::
@@ -1213,7 +1220,8 @@ label_B858B::
 label_B85A5::
     add  a, b
     jr   nz, label_B8568
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
 
 label_B85AA::
     ld   [hl], b
@@ -1265,7 +1273,8 @@ label_B85AA::
     ld   b, b
     add  a, b
     jr   nz, label_B85AA
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [hl], b
     add  a, b
     ld   [$C8F0], sp
@@ -1343,7 +1352,8 @@ label_B8617::
     nop
     ld   e, a
     jr   nz, label_B8674
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     ccf
     nop
@@ -1740,7 +1750,8 @@ label_B87AC::
     rla
     rrca
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
     rla
     rra
     ld   b, $1F
@@ -1871,8 +1882,10 @@ label_B887B::
     ld   [$FFF0], a
     ld   [$FFF0], a
     nop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     jr   nz, label_B887A
 
 label_B88BA::
@@ -1919,7 +1932,8 @@ label_B88BA::
     add  a, b
     sub  a, b
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     jr   nz, label_B88BA
     ld   [rJOYP], a
     ld   a, [$FFE0]
@@ -1972,7 +1986,8 @@ label_B88BA::
     ld   a, [$FF40]
     ld   a, b
     jr   nz, label_B8975
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1C
     ld   [$0008], sp
     nop
     nop
@@ -2373,7 +2388,8 @@ label_B8AE5::
     nop
     rrca
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  e
     inc  bc
     ld   a, $1D
@@ -2661,7 +2677,8 @@ label_B8C3C::
     ccf
     ld   c, c
     ld   [hl], $EF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E6
     ld   e, c
     ld   [hl], b
 
@@ -2890,7 +2907,8 @@ label_B8D48::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
     jr   label_B8D90
     dec  c
     scf
@@ -3053,7 +3071,8 @@ label_B8D48::
     scf
     jr   c, label_B8E27
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     ld   [label_277F], sp
     ld   [hl], a
     jr   z, label_B8E4C
@@ -3246,9 +3265,12 @@ label_B8E9B::
     inc  bc
     add  hl, bc
     rlca
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     inc  c
     inc  bc
     inc  bc
@@ -3267,7 +3289,8 @@ label_B8E9B::
     ld   l, $3F
 
 label_B8F0B::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     dec  d
     ld   e, a
     dec  l
@@ -3302,7 +3325,8 @@ label_B8F2B::
     ld   sp, hl
     and  $F9
     add  a, $EE
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7C
     ret  c
     cp   h
     ret  c
@@ -3323,7 +3347,8 @@ label_B8F2B::
     jr   nz, label_B8F6B
     jr   nc, label_B8F5D
     jr   nz, label_B8F6F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_B8F73
     jr   nz, label_B8F75
     jr   nc, label_B8F67
@@ -3399,7 +3424,8 @@ label_B8F7D::
     nop
     ld   h, b
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     inc  e
     ld   [rDIV], a
     ld    hl, sp+$74
@@ -3416,7 +3442,8 @@ label_B8F7D::
     inc  e
     cp   h
     ld   b, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [$F8F0], sp
     nop
     nop
@@ -3454,7 +3481,8 @@ label_B8F7D::
     nop
     ld   h, b
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     inc  e
     ld   [rDIV], a
     ld    hl, sp+$74
@@ -3836,7 +3864,8 @@ label_B9174::
     rlca
     ld   [hl], a
     jr   label_B91DC
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     inc  bc
     nop
@@ -3935,7 +3964,8 @@ label_B91DC::
 
 label_B9202::
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3B
     rla
 
 label_B9206::
@@ -4497,9 +4527,12 @@ label_B9375::
     ld   b, c
     ccf
     jr   nz, label_B94B1
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     ld   sp, label_BBF0E
     ld   bc, $003F
     nop
@@ -4634,7 +4667,8 @@ label_B9529::
     nop
     rrca
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_B9565
     jr   nz, label_B9567
     scf
@@ -4644,7 +4678,8 @@ label_B9529::
     ld   e, a
     dec  [hl]
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     jr   label_B9584
     rra
 
@@ -4757,7 +4792,8 @@ label_B95C6::
     dec  [hl]
     nop
     dec  a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     dec  d
     scf
     dec  e
@@ -4876,8 +4912,10 @@ label_B961D::
     ld   c, b
     scf
     jr   nc, label_B9663
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     inc  e
     inc  bc
     rra
@@ -4928,7 +4966,8 @@ label_B9663::
     inc  de
     inc  l
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     rrca
     nop
     rrca
@@ -5245,8 +5284,10 @@ label_B9806::
     inc  de
     inc  c
     cpl
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
+    db   $10
+    db   $5E
     ld   hl, label_235D
     ld   e, l
     inc  hl
@@ -5326,8 +5367,10 @@ label_B9846::
     inc  de
     inc  c
     cpl
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
+    db   $10
+    db   $7E
     ld   bc, label_337D
     db   $FD ; Undefined instruction
     ld   a, e
@@ -5593,7 +5636,8 @@ label_B9996::
     ld   d, b
     cpl
     ld   l, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $33
     rrca
     rra
     nop
@@ -5704,8 +5748,10 @@ label_B9A10::
     ret  nz
     nop
     jr   nz, label_B99E4
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
 
 label_B9A28::
     call c, label_FE20
@@ -5768,7 +5814,8 @@ label_B9A57::
     ld   [$FF88], a
     ld   a, [$FF08]
     ld   a, [$FFE8]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     ld   b, b
     rst  $38
     ld   b, $3D
@@ -6266,7 +6313,8 @@ label_B9C6D::
     ld   l, e
     ld   a, a
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     rra
     nop
     nop
@@ -6275,7 +6323,8 @@ label_B9C6D::
     nop
     and  b
     ret  nz
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [label_38F0], sp
     ret  nz
     inc  b
@@ -6320,7 +6369,8 @@ label_B9C6D::
     nop
     and  b
     ret  nz
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [label_38F0], sp
     ret  nz
     inc  b
@@ -6452,8 +6502,10 @@ label_B9CFD::
     ld   a, a
     nop
     ld   a, a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
+    db   $10
+    db   $7F
     jr   label_B9DD6
     ld   [$003F], sp
     ld   d, a
@@ -6811,10 +6863,14 @@ label_B9EFF::
     ld   b, c
     ccf
     jr   nz, label_B9F71
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     rrca
     nop
     nop
@@ -7181,7 +7237,8 @@ label_BA06D::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [de], a
     ld   [de], a
     inc  e
@@ -7704,7 +7761,8 @@ label_BA33A::
     ld   b, h
     cp   b
     call nz, label_E838
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $BF
     ld   h, b
     ld   a, a
     jr   label_BA3A4
@@ -7899,7 +7957,8 @@ label_BA3A8::
     nop
     ld   a, a
     jr   nz, label_BA4A8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   d, b
     rst  $38
 
@@ -8272,7 +8331,8 @@ label_BA571::
     ld   a, h
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jp   label_A7FF
     rst  $38
     push hl
@@ -8715,11 +8775,16 @@ label_BA7AE::
     ret  nz
     nop
     jr   nz, label_BA7AE
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     jr   nc, label_BA7BA
     ld   [hl], b
     add  a, b
@@ -8740,7 +8805,8 @@ label_BA7AE::
     di
     inc  c
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     add  a, b
@@ -8970,7 +9036,8 @@ label_BA900::
     nop
     stop
     inc  a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3E
     inc  e
     rst  $38
     ld   c, $FF
@@ -9686,7 +9753,8 @@ label_BABED::
     ld   [rJOYP], a
     ld   a, [$FF60]
     ld   a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1C
     ld   [label_40E], sp
     ld   c, $04
     rrca
@@ -9728,7 +9796,8 @@ label_BABED::
     ld   [$FFBF], a
     rrca
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     jr   z, label_BACA5
     ld   d, e
     ld   a, a
@@ -9863,8 +9932,10 @@ label_BACD2::
     ld   e, $60
     sbc  a, a
     jr   nc, label_BACC7
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
+    db   $10
+    db   $EF
     sbc  a, c
     ld   h, [hl]
     rst  $38
@@ -9950,7 +10021,8 @@ label_BAD42::
     db   $FC ; Undefined instruction
     jp   label_BFCC
     jr   nz, label_BAD42
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [label_9F8], sp
     ld   sp, hl
     ld   b, $FF
@@ -10020,7 +10092,8 @@ label_BAD42::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   nz, label_BADC3
     ret  nz
     rst  $38
@@ -11175,7 +11248,8 @@ label_BB23D::
     nop
     rrca
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     jr   nz, label_BB309
     daa
     ccf
@@ -11287,7 +11361,8 @@ label_BB334::
     ld   b, b
     ld   c, h
     jr   nz, label_BB35F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     ld   [$0000], sp
     nop
     nop
@@ -11306,7 +11381,8 @@ label_BB334::
     rlca
     nop
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
     ld   [label_204], sp
     ld   [bc], a
     ld   bc, $0001
@@ -11419,7 +11495,8 @@ label_BB3AC::
     nop
     inc  c
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $07
     nop
     ld   [$0007], sp
     ld   [$0000], sp
@@ -11483,7 +11560,8 @@ label_BB409::
     ld   bc, label_304
     ld   [label_1006], sp
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0B
     ld   hl, label_2316
     inc  d
     ld   b, a
@@ -11588,10 +11666,12 @@ label_BB459::
     ld   [bc], a
     ld   [label_806], sp
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
 
 label_BB498::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $09
     jr   nc, label_BB4A7
     ld   sp, label_330E
     inc  c
@@ -11886,7 +11966,8 @@ label_BB59E::
     inc  bc
     inc  b
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     inc  h
     jr   nc, label_BB614
     jr   nz, label_BB59E
@@ -12344,7 +12425,8 @@ label_BB7CF::
     ld   a, h
     db   $FC ; Undefined instruction
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     jr   nz, label_BB79A
     ld   b, b
     add  a, b
@@ -12870,7 +12952,8 @@ label_BBA04::
     stop
     jr   c, label_BBA34
     add  hl, sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3B
     ld   de, label_193
     add  a, a
     inc  bc
@@ -13125,7 +13208,8 @@ label_BBB41::
     rlca
     inc  d
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     nop
     nop
     nop
@@ -13162,7 +13246,8 @@ label_BBB8A::
     ld   c, [hl]
     add  hl, sp
     ld   h, $1D
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  a
     inc  bc
     ld   a, a
@@ -13352,10 +13437,12 @@ label_BBC3D::
     rrca
     ccf
     jr   label_BBCA8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     dec  de
     ld   e, $07
     ccf
@@ -13999,7 +14086,8 @@ label_BBF53::
     ld   h, b
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     jr   nc, label_BBF53
 
 label_BBF65::

--- a/src/disassembled-banks/Bank47.asm
+++ b/src/disassembled-banks/Bank47.asm
@@ -1308,7 +1308,7 @@ label_BC545::
     add  a, b
     nop
     ld   [rJOYP], a
-    jp   [hl]
+    jp   hl
     nop
     ld   a, l
     nop
@@ -1428,7 +1428,7 @@ label_BC545::
     inc  bc
     db   $E3 ; Undefined instruction
     inc  bc
-    jp   [hl]
+    jp   hl
     ld   a, [$FFE3]
     ret  nz
     rst  $28
@@ -3524,8 +3524,8 @@ label_BCF23::
     add  hl, bc
     add  hl, bc
     add  hl, bc
-    jp   [hl]
-    jp   [hl]
+    jp   hl
+    jp   hl
     nop
     nop
     ld   [de], a
@@ -5965,7 +5965,7 @@ label_BD927::
     ld   bc, $8387
     db   $EC ; Undefined instruction
     db   $E4 ; Undefined instruction
-    jp   [hl]
+    jp   hl
     ld   [$FFE3], a
     pop  hl
     rst  $20
@@ -7721,7 +7721,7 @@ label_BE0DE::
 
 label_BE0DF::
     nop
-    jp   [hl]
+    jp   hl
     jr   label_BE0CC
     jr   label_BE0D0
     jr   label_BE0DE
@@ -8054,7 +8054,7 @@ label_BE259::
     ld   sp, hl
     ld   a, $F8
     rst  $38
-    jp   [hl]
+    jp   hl
     rst  $38
     ld   b, [hl]
     ld   [rIE], a
@@ -9083,7 +9083,7 @@ label_BE6FF::
     sbc  a, a
     or   e
     or   e
-    jp   [hl]
+    jp   hl
     xor  c
     call nz, label_6C4
     ld   b, $05
@@ -9780,7 +9780,7 @@ label_BE912::
 
 label_BEA0B::
     or   a
-    jp   [hl]
+    jp   hl
     cp   a
     db   $E4 ; Undefined instruction
     cp   e
@@ -10052,7 +10052,7 @@ label_BEA0B::
     pop  hl
     pop  de
     pop  hl
-    jp   [hl]
+    jp   hl
     ld   sp, label_1F1F
     ld   a, [$FB87]
     add  a, a
@@ -10829,7 +10829,7 @@ label_BEECB::
     call z, label_ABBB
     db   $DB
     sbc  a, e
-    jp   [hl]
+    jp   hl
     adc  a, c
     or   l
     call label_BEC54
@@ -11185,7 +11185,7 @@ label_BF042::
     rst  $38
     ld   a, c
     rst  $38
-    jp   [hl]
+    jp   hl
     rst  $18
     jr   label_BF092
     rst  $10
@@ -11513,7 +11513,7 @@ label_BF1BF::
     db   $FD ; Undefined instruction
     ld   c, c
     db   $FD ; Undefined instruction
-    jp   [hl]
+    jp   hl
     db   $FD ; Undefined instruction
     add  hl, sp
     rst  $38
@@ -13624,7 +13624,7 @@ label_BFB92::
     sbc  a, a
     rra
     ld   [rJOYP], a
-    jp   [hl]
+    jp   hl
     rst  $38
     ret
     ld   a, a

--- a/src/disassembled-banks/Bank47.asm
+++ b/src/disassembled-banks/Bank47.asm
@@ -973,7 +973,8 @@ label_BC3FF::
     nop
     rst  $38
     jr   nc, label_BC426
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   label_BC42A
     sbc  a, b
     rst  $38
@@ -2228,7 +2229,8 @@ label_BC910::
     adc  a, $CE
     ld   d, e
     ld   d, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     sub  a, e
     sub  a, e
     ld   de, label_BD111
@@ -2508,8 +2510,10 @@ label_BCAC8::
 
 label_BCACA::
     jr   nc, label_BCB03
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
+    db   $10
+    db   $07
     nop
     nop
     ld   [rNR10], a
@@ -2719,9 +2723,12 @@ label_BCB3E::
     ld   a, a
     inc  bc
     ld   a, a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $07
+    db   $10
+    db   $07
+    db   $10
+    db   $07
     jr   z, label_BCBCF
     jr   z, label_BCBD1
     dec  hl
@@ -3562,12 +3569,15 @@ label_BCF23::
 
 label_BCF80::
     ld   [$FFE0], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     ld   [$FFE0], a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     ld   [$FFE0], a
     nop
     nop
@@ -3622,9 +3632,11 @@ label_BCF9E::
     ld   e, a
     sub  a, b
     sub  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   e, $1E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     sub  a, b
     sub  a, b
     ld   e, a
@@ -6732,7 +6744,8 @@ label_BDC14::
     rrca
 
 label_BDC66::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     inc  hl
     inc  a
     daa
@@ -7112,7 +7125,8 @@ label_BDE17::
 label_BDE21::
     rst  $38
     ld   a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F9
     jr   nz, label_BDE17
     ld   [$FF1F], a
     ld   d, b
@@ -7195,7 +7209,8 @@ label_BDE77::
     ld   a, $FF
     rst  $38
     ld   a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F9
     jr   nz, label_BDE77
     ld   [$FF1F], a
     ld   d, b
@@ -7400,7 +7415,8 @@ label_BDF6A::
     inc  e
     db   $E8 ; add  sp, d
     ld   a, [$FF3E]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9E
     ld   [$B43C], sp
 
 label_BDF76::
@@ -7614,7 +7630,8 @@ label_BE010::
     nop
     adc  a, a
     ld   a, [$FFEF]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -7817,14 +7834,22 @@ label_BE146::
     dec  bc
     and  $09
     rst  0
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C7
+    db   $10
+    db   $A3
+    db   $10
+    db   $A3
+    db   $10
+    db   $A3
+    db   $10
+    db   $C7
+    db   $10
+    db   $C3
+    db   $10
+    db   $C3
+    db   $10
+    db   $C3
     ld   [label_8C3], sp
     db   $E3 ; Undefined instruction
     ld   [label_8C3], sp
@@ -8084,7 +8109,8 @@ label_BE259::
     ld   a, [$FFFE]
     and  b
     sbc  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
     rlca
     db   $E8 ; add  sp, d
     rrca
@@ -8131,7 +8157,8 @@ label_BE288::
     inc  de
     db   $E8 ; add  sp, d
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D7
 
 label_BE2B9::
     ld   [$C837], sp
@@ -8176,7 +8203,8 @@ label_BE2C4::
     jp   label_8604
     add  hl, bc
     adc  a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_BE30B
     ld   b, c
     inc  l
@@ -8252,7 +8280,8 @@ label_BE32F::
     ld   [hl], c
     rst  $38
     or   c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D7
     jr   nc, label_BE3A3
     ld   sp, label_3FCF
     and  a
@@ -8480,7 +8509,8 @@ label_BE3FA::
     ld   [hl], b
     sub  a, c
     sub  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     sbc  a, h
     inc  e
     ld   a, a
@@ -8532,7 +8562,8 @@ label_BE486::
     ld   a, [hl]
     add  hl, hl
     add  hl, sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
 
 label_BE490::
     rst  $38
@@ -8704,7 +8735,8 @@ label_BE53A::
     db   $E4 ; Undefined instruction
     rrca
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [$FFE0], a
     jp   nz, label_C040
     ld   b, b
@@ -8736,7 +8768,8 @@ label_BE53A::
     db   $FD ; Undefined instruction
     rst  0
     ld   [de], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     jr   z, label_BE5C4
     daa
     ccf
@@ -9366,7 +9399,8 @@ label_BE6FF::
     rst  $28
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     inc  bc
     cp   l
     ld   b, $FA
@@ -11582,7 +11616,8 @@ label_BF216::
 
 label_BF236::
     jr   nz, label_BF218
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     adc  a, h
     ld   a, h
     jp   nz, label_C23E
@@ -11615,7 +11650,8 @@ label_BF236::
     jr   c, label_BF261
     jr   c, label_BF263
     jr   c, label_BF265
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     inc  b
     rst  $38
     rra
@@ -11735,7 +11771,8 @@ label_BF2D2::
     jr   c, label_BF2E1
     jr   c, label_BF2E3
     jr   c, label_BF2E5
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     ld   hl, label_BC3FE
@@ -11850,7 +11887,8 @@ label_BF309::
     ld   h, d
     adc  a, $50
     add  a, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $62
     ld   d, l
     adc  a, h
     xor  [hl]
@@ -11958,7 +11996,8 @@ label_BF3D2::
     rst  $38
     ld   [$00FF], sp
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     adc  a, h
     ld   a, a
     jp   nz, label_E23F
@@ -12075,7 +12114,8 @@ label_BF472::
     jr   nc, label_BF48C
     jr   c, label_BF487
     ld   a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $BF
     ld   d, b
     ccf
     ret  c
@@ -12888,7 +12928,8 @@ label_BF774::
 
 label_BF83A::
     or   b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   a, [$FF20]
     ld   h, b
     ld   bc, $0101
@@ -13021,7 +13062,8 @@ label_BF84A::
     rrca
     rrca
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     jr   nz, label_BF917
     cpl
     daa
@@ -13080,7 +13122,8 @@ label_BF8F4::
     dec  de
     dec  b
     ld   de, label_2608
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EA
     inc  d
     db   $EB ; Undefined instruction
     inc  [hl]
@@ -13103,8 +13146,10 @@ label_BF938::
     ld   d, $0C
     jr   label_BF94C
     inc  e
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $33
+    db   $10
+    db   $33
     jr   nz, label_BF988
     inc  hl
 
@@ -13143,7 +13188,8 @@ label_BF94C::
     add  a, b
     db   $E8 ; add  sp, d
     jr   nc, label_BF98B
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     ld   [label_4C4], sp
 
 label_BF978::
@@ -13358,7 +13404,8 @@ label_BFA46::
     add  a, e
     add  a, e
     add  a, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     pop  af
     ld   a, [$FFB0]
     ld   h, c
@@ -13782,7 +13829,8 @@ label_BFC49::
     rrca
 
 label_BFC66::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     inc  hl
     inc  a
     daa
@@ -13932,8 +13980,10 @@ label_BFCFF::
     ld   a, a
     ld   h, b
     ccf
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
+    db   $10
+    db   $1F
     jr   label_BFD2B
     ld   [label_C0F], sp
     rlca
@@ -14208,7 +14258,8 @@ label_BFDA7::
     rrca
 
 label_BFE66::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     inc  hl
     inc  a
     daa
@@ -14408,10 +14459,14 @@ label_BFF10::
     rst  $38
     sub  a, d
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
     jr   c, label_BFF4C
     ld   bc, rIE
     and  l

--- a/src/disassembled-banks/Bank48.asm
+++ b/src/disassembled-banks/Bank48.asm
@@ -1463,7 +1463,7 @@ label_C06A6::
     rra
     call label_EB0F
     rrca
-    jp   [hl]
+    jp   hl
     dec  bc
     call z, label_1609
     jr   label_C06A6
@@ -1472,7 +1472,7 @@ label_C06A6::
     set  5, d
     set  5, d
     ret
-    jp   [hl]
+    jp   hl
     set  5, b
     add  a, e
     call c, label_DC87
@@ -5568,7 +5568,7 @@ label_C192D::
     jr   nz, label_C190E
     jr   nz, label_C19AA
     ei
-    jp   [hl]
+    jp   hl
 
 label_C1933::
     rst  8
@@ -5584,7 +5584,7 @@ label_C1939::
     rst  $18
     jr   nz, label_C18C8
     ld   b, a
-    jp   [hl]
+    jp   hl
     db   $EB ; Undefined instruction
     add  hl, de
     rst  $18
@@ -7480,7 +7480,7 @@ label_C21DB::
     rst  $38
 
 label_C21EA::
-    jp   [hl]
+    jp   hl
     rst  $30
 
 label_C21EC::
@@ -10792,7 +10792,7 @@ label_C301D::
     rlca
     ei
     rlca
-    jp   [hl]
+    jp   hl
     rla
     ld   a, l
     inc  bc
@@ -11010,7 +11010,7 @@ label_C3121::
     rst  $38
     push bc
     inc  hl
-    jp   [hl]
+    jp   hl
     rlca
     jp   label_C170F
     rrca
@@ -13069,7 +13069,7 @@ label_C3AAE::
     ret  nz
     cp   a
     ld   a, [$FFFF]
-    jp   [hl]
+    jp   hl
 
 label_C3AB3::
     rst  $38
@@ -13423,7 +13423,7 @@ label_C3C03::
     rst  $38
     ld   sp, hl
     rst  $38
-    jp   [hl]
+    jp   hl
     rst  $28
     pop  af
     rst  $38
@@ -13881,7 +13881,7 @@ label_C3D8F::
     ld   [$FFFE], a
     ld   sp, hl
     db   $EC ; Undefined instruction
-    jp   [hl]
+    jp   hl
     sbc  a, $F0
     db   $FC ; Undefined instruction
     ret  nz

--- a/src/disassembled-banks/Bank48.asm
+++ b/src/disassembled-banks/Bank48.asm
@@ -1528,8 +1528,10 @@ label_C06A6::
     ld   bc, $FC43
     ld   hl, label_10DE
     sbc  a, [hl]
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $FE
     cp   $FF
     rst  $38
     rst  $38
@@ -1770,7 +1772,8 @@ label_C079B::
     nop
     ccf
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $14
     dec  e
     ld   [de], a
     inc  c
@@ -2346,7 +2349,8 @@ label_C0AE5::
     ld   b, h
     rst  $38
     jr   z, label_C0AF8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_C0AFC
     ld   b, h
 
@@ -2495,7 +2499,8 @@ label_C0B98::
     add  a, b
     rst  $20
     jr   label_C0B8C
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     inc  a
     jp   label_807F
@@ -2749,7 +2754,8 @@ label_C0C6C::
     nop
     nop
     ld   hl, label_2F00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $23
     inc  e
     ld   h, c
     ld   e, $C0
@@ -3440,7 +3446,8 @@ label_C0FA4::
     ld   b, h
     rst  $38
     jr   z, label_C0FB8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_C0FBC
     ld   b, h
     rst  $38
@@ -4507,13 +4514,15 @@ label_C144F::
     ld   [$FFC0], a
     ld   [$FFC0], a
     ld   [rJOYP], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
 
 label_C147E::
     ld   a, [$FF00]
     ld   bc, label_1E00
     ld   bc, label_F10
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   d, $09
     rrca
     ld   [bc], a
@@ -4723,7 +4732,8 @@ label_C1577::
     ld   b, h
     ld   b, h
     jr   z, label_C15B0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   z, label_C15B4
     ld   b, h
     ld   b, h
@@ -4736,7 +4746,8 @@ label_C1577::
     ld   b, h
     ld   b, h
     jr   z, label_C15C0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   z, label_C15C4
     ld   b, h
     ld   b, h
@@ -4749,7 +4760,8 @@ label_C1577::
     ld   b, h
     ld   b, h
     jr   z, label_C15D0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
 
 label_C15AA::
     jr   z, label_C15D4
@@ -4768,7 +4780,8 @@ label_C15B4::
     ld   b, h
     ld   b, h
     jr   z, label_C15E0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   z, label_C15E4
     ld   b, h
     ld   b, h
@@ -5013,7 +5026,8 @@ label_C16A0::
     ld   h, b
     jr   nz, label_C16CA
     jr   nc, label_C16DC
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   label_C16C8
     ld   [label_C08], sp
     inc  c
@@ -5133,14 +5147,16 @@ label_C171B::
     ld   [hl], b
     inc  b
     inc  a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1C
     ld   [label_40E], sp
     rlca
     inc  b
     rlca
     inc  b
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1E
     ldi  [hl], a
     ld   a, $00
     jr   c, label_C173F
@@ -6600,8 +6616,10 @@ label_C1DD3::
     ret  nz
     nop
     jr   nz, label_C1E31
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
     ld   [label_80F], sp
     rrca
     inc  b
@@ -6954,8 +6972,10 @@ label_C1F90::
     ld   a, a
     jr   nz, label_C1FD7
     jr   nz, label_C1FD9
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
     ld   [$810F], sp
     add  a, c
     add  a, c
@@ -7125,7 +7145,8 @@ label_C1FD9::
     db   $FC ; Undefined instruction
     rst  $38
     jr   nc, label_C20D5
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     ret  nc
     ld   a, [$FF30]
     db   $F0
@@ -7592,9 +7613,12 @@ label_C2235::
     jr   nc, label_C2265
     jr   nc, label_C2267
     jr   nc, label_C2269
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
     ld   hl, label_21FF
     rst  $38
     rla
@@ -7639,10 +7663,14 @@ label_C2235::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
     inc  de
     rst  $38
     sub  a, c
@@ -8043,7 +8071,8 @@ label_C2466::
     jr   nc, label_C2483
     sub  a, [hl]
     ld   bc, label_33C
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   c, label_C2483
     rst  $38
     nop
@@ -8638,7 +8667,8 @@ label_C26BE::
     jr   nz, label_C272B
     jr   nc, label_C271D
     jr   nz, label_C272F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_C2733
     jr   nz, label_C2735
     jr   nc, label_C2727
@@ -8732,7 +8762,8 @@ label_C2749::
     dec  bc
     dec  de
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [label_707], sp
     nop
     add  a, b
@@ -8754,7 +8785,8 @@ label_C2749::
     inc  b
     ld    hl, sp+$F8
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [rJOYP], a
 
 label_C27A0::
@@ -9999,7 +10031,8 @@ label_C2CAE::
     ld   [de], a
     nop
     add  hl, sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     stop
     nop
     nop
@@ -10308,7 +10341,8 @@ label_C2E0D::
     nop
     stop
     add  hl, hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6F
     jr   nc, label_C2E9C
     inc  hl
     ld   [hl], e
@@ -10378,7 +10412,8 @@ label_C2E3F::
     inc  e
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     sub  a, $DF
     nop
     rst  $38
@@ -10429,7 +10464,8 @@ label_C2E9D::
     nop
     nop
     add  hl, hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6F
     jr   nc, label_C2F1C
     inc  hl
     ld   [hl], e
@@ -10495,7 +10531,8 @@ label_C2E9D::
     inc  e
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     sub  a, $DF
     nop
     rst  $38
@@ -10545,7 +10582,8 @@ label_C2F07::
 label_C2F1C::
     stop
     ld   bc, label_2900
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6F
     jr   nc, label_C2F9C
     inc  hl
     ld   [hl], e
@@ -10611,7 +10649,8 @@ label_C2F5E::
     inc  e
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     sub  a, $DF
     nop
     rst  $38
@@ -10662,7 +10701,8 @@ label_C2F9D::
     nop
     nop
     add  hl, hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6F
     jr   nc, label_C301C
     inc  hl
     ld   [hl], e
@@ -10722,7 +10762,8 @@ label_C2F9D::
     inc  e
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     sub  a, $DF
     nop
     rst  $38
@@ -10909,7 +10950,8 @@ label_C30A8::
     db   $FD ; Undefined instruction
     push de
     jr   z, label_C30A8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     nop
     rst  $38
@@ -11199,7 +11241,8 @@ label_C31CA::
     sbc  a, d
     pop  af
     ld   c, $EF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     jr   nz, label_C31BE
     ld   b, [hl]
     or   a
@@ -11638,7 +11681,8 @@ label_C3406::
     rst  $38
     nop
     db   $EB ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D7
     jr   nz, label_C340C
     nop
     ld   e, a
@@ -11657,7 +11701,8 @@ label_C3406::
     rst  $38
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
     nop
     rst  $38
     nop
@@ -11936,7 +11981,8 @@ label_C3564::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $30
     nop
@@ -12016,7 +12062,8 @@ label_C3582::
     rst  $38
     ld   [label_20F7], sp
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     inc  bc
     ld   a, h
     add  a, a
@@ -12086,7 +12133,8 @@ label_C35E6::
     rst  $38
     ld   h, b
     sbc  a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     rrca
     ld   a, [$FF81]
     ld   a, [hl]
@@ -12973,7 +13021,8 @@ label_C39BD::
     ld   [bc], a
     ld   e, b
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     nop
     ccf
     rrca

--- a/src/disassembled-banks/Bank49.asm
+++ b/src/disassembled-banks/Bank49.asm
@@ -201,10 +201,14 @@ label_C40BF::
     scf
     ret  c
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $AF
     ld   e, b
     scf
     adc  a, $13
@@ -482,7 +486,8 @@ label_C41C0::
     cp   h
     ld   b, b
     call c, label_EC20
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     nop
     call c, label_CC20
     ld   [hl], b
@@ -495,7 +500,8 @@ label_C423C::
 
 label_C4242::
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     nop
     ccf
     nop
@@ -565,7 +571,8 @@ label_C4282::
     rst  $38
     ld   c, a
     ld   a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     dec  d
     jr   c, label_C42A9
     ccf
@@ -590,7 +597,8 @@ label_C4282::
     cp   $7C
     rst  $38
     sbc  a, $FE
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     ret  nc
     ld   a, h
     or   b
@@ -618,7 +626,8 @@ label_C4282::
     jr   z, label_C430C
     rrca
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     dec  d
     db   $3A ; ldd  a, [hl]
     dec  d
@@ -1058,7 +1067,8 @@ label_C44A1::
     ld   b, $07
     nop
     ld   [rJOYP], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     call c, label_F2E0
     db   $EC ; Undefined instruction
     ld   sp, hl
@@ -1620,7 +1630,8 @@ label_C4746::
     db   $FC ; Undefined instruction
     ld   [label_8FC], sp
     db   $EC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E4
     ld    hl, sp+$FC
     nop
     rra
@@ -1697,7 +1708,8 @@ label_C47D0::
     rra
     cpl
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     rrca
     nop
     dec  e
@@ -1745,7 +1757,8 @@ label_C47D0::
     rrca
     nop
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     rra
     nop
@@ -1800,7 +1813,8 @@ label_C483F::
     rrca
     nop
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     inc  c
     rra
     dec  bc
@@ -1941,7 +1955,8 @@ label_C48DD::
     add  hl, hl
     ld   d, $27
     jr   label_C4938
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     ld   [$001F], sp
     ld   a, a
     ld   bc, label_C41BF
@@ -1993,7 +2008,8 @@ label_C4938::
     rra
     nop
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3B
     inc  b
     ccf
     inc  b
@@ -2250,8 +2266,10 @@ label_C4A3D::
     rst  $18
     and  b
     db   $E8 ; add  sp, d
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E8
+    db   $10
+    db   $F8
     nop
     rst  $38
     ret  nz
@@ -2302,7 +2320,8 @@ label_C4A82::
     ld   e, $FE
     inc  c
     db   $EC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E4
     ret  c
     ld   a, [$FEEC]
     db   $F4 ; Undefined instruction
@@ -2359,9 +2378,12 @@ label_C4A82::
 
 label_C4AF0::
     inc  l
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2C
+    db   $10
+    db   $2C
+    db   $10
+    db   $6E
     ld   d, d
     rst  $28
     sub  a, c
@@ -2701,7 +2723,8 @@ label_C4C6C::
     nop
     rrca
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  hl
     rra
     dec  sp
@@ -2741,7 +2764,8 @@ label_C4C6C::
     inc  d
     db   $E8 ; add  sp, d
     db   $E8 ; add  sp, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $70
     add  a, b
     ld   [rLCDC], a
     ret  nc
@@ -2778,7 +2802,8 @@ label_C4CBF::
     rra
     nop
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $4F
     jr   nc, label_C4C6C
     ld   a, h
     add  a, d
@@ -2842,7 +2867,8 @@ label_C4CBF::
     nop
     ld   a, c
     jr   nc, label_C4D6E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9F
     ld   [$8BFE], sp
     or   [hl]
     ld   c, c
@@ -3060,7 +3086,8 @@ label_C4E14::
     db   $E4 ; Undefined instruction
     ret  c
     db   $E8 ; add  sp, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $30
     ret  nz
     jr   label_C4E14
     ld   a, b
@@ -3752,7 +3779,8 @@ label_C50F8::
     ld   b, b
     add  a, b
     jr   nz, label_C50E6
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     adc  a, b
     ld   [hl], b
     ld   b, h
@@ -3796,7 +3824,8 @@ label_C514F::
     ld   [label_814], sp
     jr   z, label_C5168
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     ccf
     ld   a, a
     nop
@@ -3816,8 +3845,10 @@ label_C5168::
     db   $D3 ; Undefined instruction
     jr   nz, label_C51BD
     jr   nz, label_C5197
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
+    db   $10
+    db   $14
     ld   [label_814], sp
     ld   [$FE00], sp
     nop
@@ -3832,7 +3863,8 @@ label_C5168::
     nop
     dec  bc
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   hl, label_C431F
     ld   a, $47
     inc  a
@@ -3931,7 +3963,8 @@ label_C51F0::
     inc  hl
     rra
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5F
     jr   nz, label_C5289
 
 label_C520B::
@@ -4235,7 +4268,8 @@ label_C534C::
     rla
     ld   [label_1F20], sp
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     nop
     daa
     jr   label_C53AA
@@ -4343,7 +4377,8 @@ label_C53AA::
     nop
     ld   e, $00
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6F
     ld   sp, label_215F
     rst  $38
     nop
@@ -4483,7 +4518,8 @@ label_C53DC::
     ld    hl, sp+$04
     ld    hl, sp+$38
     ret  nz
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     or   b
     ld   b, b
     ld   a, [$FF00]
@@ -4876,7 +4912,8 @@ label_C564F::
     ld   c, h
     add  hl, sp
     ld   h, $1F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   a, [bc]
     dec  c
     dec  bc
@@ -5001,7 +5038,8 @@ label_C56E0::
     nop
 
 label_C56E2::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     ret  nz
@@ -5123,7 +5161,8 @@ label_C5750::
     ld   bc, $011F
     ld   l, $11
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $37
     jr   label_C57B0
     inc  e
     ld   l, $1F
@@ -5646,8 +5685,10 @@ label_C59A3::
     ld   e, $FF
     add  hl, de
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $6F
     add  hl, de
     ld   [hl], a
     rrca
@@ -5745,17 +5786,20 @@ label_C5A12::
 label_C5A42::
     jr   c, label_C5A54
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $37
     rrca
     inc  hl
     rra
 
 label_C5A4A::
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
     inc  d
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $22
 
 label_C5A51::
     dec  e
@@ -6142,7 +6186,8 @@ label_C5BFB::
     ld   b, $0E
     dec  b
     ld   d, $0D
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  e
     dec  bc
     rla
@@ -6162,7 +6207,8 @@ label_C5BFB::
     ld   b, $0E
     dec  b
     ld   d, $0D
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     rra
 
 label_C5C2B::
@@ -6198,7 +6244,8 @@ label_C5C2B::
     rlca
     ld   de, label_110F
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   a, [de]
     dec  b
     db   $3A ; ldd  a, [hl]
@@ -6216,7 +6263,8 @@ label_C5C2B::
     rlca
     ld   de, label_110F
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [de], a
     dec  c
     ld   a, [de]
@@ -6332,13 +6380,15 @@ label_C5CAC::
     ret  nz
     nop
     jr   nz, label_C5CAC
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [$88F0], sp
     ld   [hl], b
     db   $E8 ; add  sp, d
     ld   d, b
     db   $E8 ; add  sp, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A6
     jr   label_C5D1A
     ld   e, $1D
     ld   [bc], a
@@ -6406,8 +6456,10 @@ label_C5D1A::
     inc  c
     ccf
     jr   label_C5D8A
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
+    db   $10
+    db   $3F
     nop
     ld   a, a
     ld   a, $7F
@@ -6634,8 +6686,10 @@ label_C5E1E::
     jr   nz, label_C5E73
     ld   l, $11
     cpl
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
+    db   $10
+    db   $17
     ld   [label_708], sp
     rlca
     nop
@@ -6884,11 +6938,13 @@ label_C5F52::
     ld   b, b
     add  a, b
     jr   nz, label_C5F26
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ret  nc
     jr   nz, label_C5EFB
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     jr   nz, label_C5F30
     inc  hl
     ret  nz
@@ -6908,11 +6964,13 @@ label_C5F52::
     ld   b, b
     add  a, b
     jr   nz, label_C5F46
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ret  nc
     jr   nz, label_C5F1B
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     jr   nz, label_C5F50
     jr   nz, label_C5F52
     ld   b, [hl]
@@ -7085,7 +7143,8 @@ label_C6013::
     ld   e, a
     ldd  [hl], a
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     jr   label_C6092
     inc  e
     ccf
@@ -7651,7 +7710,8 @@ label_C62D7::
     ld   [rJOYP], a
     ret  nc
     ld   [$FFE8], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     and  b
     db   $FC ; Undefined instruction
     ret  nc
@@ -7690,7 +7750,8 @@ label_C6305::
     ld   e, a
     jr   c, label_C634A
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     rrca
     nop
     ld   bc, $0100
@@ -8526,7 +8587,8 @@ label_C66E8::
     jr   nc, label_C6718
     inc  e
     jr   nz, label_C6717
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  c
     inc  bc
     inc  bc
@@ -8580,7 +8642,8 @@ label_C6718::
     or   [hl]
     ret  z
     db   $EC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FC
     ld   b, b
     xor  $DC
     cp   $C0
@@ -9008,7 +9071,8 @@ label_C68D5::
     rra
     ld   [$001F], sp
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     ld   c, $7F
     rra
     rst  $38
@@ -9029,7 +9093,8 @@ label_C693D::
     cp   $84
     cp   $34
     db   $FC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     ret  nz
     db   $FC ; Undefined instruction
     ld   b, b
@@ -9286,7 +9351,8 @@ label_C6A3F::
     inc  e
     adc  a, b
     ld   a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   h, b
     ld   [$FF80], a
     add  a, b
@@ -9557,7 +9623,8 @@ label_C6BA0::
     inc  bc
     ld   [de], a
     dec  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     rrca
     nop
     nop
@@ -9593,7 +9660,8 @@ label_C6BCD::
 label_C6BCF::
     add  a, b
     jr   nz, label_C6B92
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     adc  a, b
     ld   [hl], b
     ld   b, h
@@ -9666,7 +9734,8 @@ label_C6BFC::
     scf
     jr   c, label_C6C27
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     ld   [label_277F], sp
     ld   [hl], a
     jr   z, label_C6C4C
@@ -9713,7 +9782,8 @@ label_C6C2D::
     jr   nz, label_C6CCA
     jr   nz, label_C6CAC
     jr   nz, label_C6C8E
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
     jr   label_C6CD2
     inc  l
     ld   a, a
@@ -9990,7 +10060,8 @@ label_C6D5B::
 
 label_C6D9B::
     ld   l, $6F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     nop
     ld   a, [$FF00]
     ld    hl, sp+$00
@@ -10185,7 +10256,8 @@ label_C6E3A::
     jr   nz, label_C6E36
     jr   nz, label_C6E38
     jr   nz, label_C6E3A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     inc  e
     ld   [rNR12], a
     db   $EC ; Undefined instruction
@@ -10396,7 +10468,8 @@ label_C6F25::
     ld   a, [bc]
     inc  de
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [label_807], sp
     rlca
     inc  b
@@ -10516,7 +10589,8 @@ label_C6FB2::
     ld   b, b
     add  a, b
     jr   nz, label_C6FB2
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     rla
     ld   [$FF09], a
     or   $09
@@ -10651,8 +10725,10 @@ label_C703D::
     add  a, b
     and  b
     ret  nz
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     ld   [label_8F0], sp
     ld   a, [$FF04]
     ld    hl, sp+$04
@@ -10729,8 +10805,10 @@ label_C70C9::
     add  a, b
     and  b
     ret  nz
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     ld   [label_8F0], sp
     ld   a, [$FF06]
     ld   a, [$FA06]
@@ -10914,7 +10992,8 @@ label_C7122::
     call c, label_3F00
     ret  c
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $93
     ld   l, h
     swap h
     cp   $01
@@ -10943,10 +11022,12 @@ label_C7122::
     ret  nz
     ld   h, b
     ret  nz
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     sub  a, b
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     adc  a, b
     ld   [hl], b
     and  h
@@ -11027,7 +11108,8 @@ label_C723F::
     rrca
     ld   hl, label_201E
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
 
 label_C724E::
     inc  c
@@ -11760,7 +11842,8 @@ label_C758D::
     dec  de
     inc  sp
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   label_C759B
     inc  c
     inc  bc
@@ -11837,7 +11920,8 @@ label_C75E2::
     dec  a
     nop
     add  hl, sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     nop
     ld   b, h
     jr   c, label_C7573
@@ -12726,7 +12810,8 @@ label_C79B6::
     ld   e, $2C
     rra
     jr   nz, label_C79E7
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     rra
     nop
     ccf
@@ -13098,11 +13183,13 @@ label_C7B52::
     ld   b, b
     add  a, b
     jr   nz, label_C7B26
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ret  nc
     jr   nz, label_C7AFB
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     jr   nz, label_C7B30
     inc  hl
     ret  nz
@@ -13124,11 +13211,13 @@ label_C7B7D::
     ld   b, b
     add  a, b
     jr   nz, label_C7B46
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ret  nc
     jr   nz, label_C7B1B
     ld   h, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     jr   nz, label_C7B50
     jr   nz, label_C7B52
     ld   b, [hl]
@@ -13278,7 +13367,8 @@ label_C7BAC::
     db   $EB ; Undefined instruction
     or   $B9
     add  a, $EE
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FC
     ld   [$FFF0], a
     nop
     ld    hl, sp+$00
@@ -13292,7 +13382,8 @@ label_C7BAC::
     jr   nc, label_C7C86
     rrca
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     nop
     cp   a
     ld   b, b
@@ -13362,7 +13453,8 @@ label_C7C86::
     inc  bc
     ld   bc, $0007
     ld   [rJOYP], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   l, b
     sub  a, b
     inc  e
@@ -13418,7 +13510,8 @@ label_C7CCA::
     nop
     nop
     ld   [rJOYP], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   l, b
     sub  a, b
     inc  e
@@ -14005,9 +14098,12 @@ label_C7F3C::
     nop
     ld   [label_1607], sp
     rrca
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     add  hl, bc
     ld   b, $07
     ld   bc, label_205

--- a/src/disassembled-banks/Bank49.asm
+++ b/src/disassembled-banks/Bank49.asm
@@ -2499,7 +2499,7 @@ label_C4B2F::
     cp   $30
     ld   sp, hl
     or   [hl]
-    jp   [hl]
+    jp   hl
     or   $F9
     add  a, $BD
     jp   nz, label_827D
@@ -4365,7 +4365,7 @@ label_C53DC::
     nop
     ld   [hl], l
     inc  bc
-    jp   [hl]
+    jp   hl
     db   $76 ; Halt
     cp   e
     ld   b, h
@@ -4417,7 +4417,7 @@ label_C53DC::
     ld   [bc], a
     rst  8
     nop
-    jp   [hl]
+    jp   hl
     add  a, a
     ld   [hl], d
     rst  8
@@ -4461,7 +4461,7 @@ label_C53DC::
     ld  [$FF00+C], a
     db   $FD ; Undefined instruction
     ld   [de], a
-    jp   [hl]
+    jp   hl
     ld   [hl], $F1
     ld   c, $38
     nop
@@ -13933,7 +13933,7 @@ label_C7F24::
     dec  [hl]
     rst  $38
     add  hl, bc
-    jp   [hl]
+    jp   hl
     or   $60
     sbc  a, a
     ld   b, b
@@ -14098,4 +14098,4 @@ label_C7FE7::
     adc  a, $DA
     inc  a
     db   $F4 ; Undefined instruction
-    ld    hl, sp+$00
+    ld    hl, sp+$51

--- a/src/disassembled-banks/Bank5.asm
+++ b/src/disassembled-banks/Bank5.asm
@@ -8054,7 +8054,7 @@ label_16FCA::
     db   $E4 ; Undefined instruction
     push hl
     rst  $20
-    jp   [hl]
+    jp   hl
     db   $ED ; Undefined instruction
     pop  af
     or   $FB
@@ -8078,13 +8078,13 @@ label_16FCA::
     ei
     or   $F1
     db   $ED ; Undefined instruction
-    jp   [hl]
+    jp   hl
     rst  $20
     push hl
     db   $E4 ; Undefined instruction
     push hl
     rst  $20
-    jp   [hl]
+    jp   hl
     db   $ED ; Undefined instruction
     pop  af
     or   $FB

--- a/src/disassembled-banks/Bank5.asm
+++ b/src/disassembled-banks/Bank5.asm
@@ -1289,7 +1289,8 @@ label_14780::
     ld   bc, $0010
     ld   h, h
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   h, [hl]
     ld   [bc], a
     nop
@@ -1300,7 +1301,8 @@ label_14780::
     ld   bc, $0010
     ld   l, h
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   l, [hl]
     ld   [bc], a
     nop
@@ -1311,7 +1313,8 @@ label_14780::
     ld   hl, $0010
     ld   h, [hl]
     ldi  [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   h, h
     ldi  [hl], a
     nop
@@ -1322,7 +1325,8 @@ label_14780::
     ld   bc, $0010
     ld   l, h
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   l, [hl]
     ld   [bc], a
 
@@ -3868,7 +3872,8 @@ label_1579C::
     ld   a, [$FF08]
     ld   b, [hl]
     ld   d, $F0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $48
     ld   d, $F0
     jr   label_157FD
     ld   d, $00
@@ -3883,7 +3888,8 @@ label_1579C::
     ld   d, $00
     ld   [label_1652], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $54
     ld   d, $00
     jr   label_15821
     ld   d, $00
@@ -3895,7 +3901,8 @@ label_1579C::
     ld   e, h
     ld   d, $10
     ld   [label_165E], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   h, b
     ld   d, $10
     jr   label_15845
@@ -3919,7 +3926,8 @@ label_1579C::
     ld   d, $F0
 
 label_157FD::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $48
     ld   d, $F0
     jr   label_1584D
     ld   d, $00
@@ -3934,7 +3942,8 @@ label_157FD::
     ld   d, $00
     ld   [label_1652], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $54
     ld   d, $00
     jr   label_15871
     ld   d, $00
@@ -3950,7 +3959,8 @@ label_15821::
 label_15827::
     ld   d, $10
     ld   [label_165E], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   h, b
     ld   d, $10
     jr   label_15895
@@ -3980,7 +3990,8 @@ label_1584B::
     ld   d, $00
     ld   [label_1652], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $54
     ld   d, $00
     jr   label_158B5
     ld   d, $00
@@ -3992,12 +4003,14 @@ label_1584B::
     ld   d, $00
     ld   a, [$FF4C]
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     ld   h, h
     ld   d, $10
 
 label_15871::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     ld   d, $10
     jr   label_158D9
     ld   d, $10
@@ -4005,7 +4018,8 @@ label_15871::
     ld   e, h
     ld   d, $10
     ld   [label_165E], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     ld   e, d
     ld   d, $00
 
@@ -4037,7 +4051,8 @@ label_158A3::
     ld   d, $00
     ld   [label_1652], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $54
 
 label_158AB::
     ld   d, $00
@@ -4053,10 +4068,12 @@ label_158B5::
     ld   d, $00
     ld   a, [$FF68]
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     ld   l, h
     ld   d, $10
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     ld   d, $10
     jr   label_15929
     ld   d, $10
@@ -4064,7 +4081,8 @@ label_158B5::
     ld   e, h
     ld   d, $10
     ld   [label_165E], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     ld   e, d
     ld   d, $F0
     pop  af
@@ -4244,10 +4262,12 @@ label_159DD::
 label_159E4::
     ccf
     jr   label_15A26
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
     dec  de
     ld   [rJOYP], a
     ld   a, [$FFE0]
@@ -4351,7 +4371,8 @@ label_15A6F::
 
 label_15A7D::
     ret
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   hl, $C2B0
     add  hl, bc
     ld   a, [hl]
@@ -5372,16 +5393,20 @@ label_1606E::
     nop
     jr   nz, label_16103
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   h, b
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   h, d
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   h, h
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     ld   h, [hl]
     ld   [bc], a
     ld   a, [$FF18]
@@ -5407,16 +5432,20 @@ label_1606E::
     nop
     jr   nz, label_1613F
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   h, b
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   h, d
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   h, h
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     ld   h, [hl]
     ld   [bc], a
     rst  $38
@@ -5451,16 +5480,20 @@ label_160FD::
 label_16103::
     jr   nz, label_16175
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   h, b
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [hl], d
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   [hl], h
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     db   $76 ; Halt
     ld   [bc], a
     rst  $38
@@ -5532,13 +5565,16 @@ label_16139::
     stop
     ld   h, b
     ldi  [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     ld   h, d
     ldi  [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   h, h
     ldi  [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E8
     ld   h, [hl]
 
 label_16175::
@@ -5570,13 +5606,16 @@ label_16175::
     stop
     ld   h, b
     ldi  [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     ld   h, d
     ldi  [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   h, h
     ldi  [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E8
     ld   h, [hl]
     ldi  [hl], a
     rst  $38
@@ -5609,13 +5648,16 @@ label_16175::
     stop
     ld   h, b
     ldi  [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     ld   [hl], d
     ldi  [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [hl], h
     ldi  [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E8
     db   $76 ; Halt
     ldi  [hl], a
     rst  $38
@@ -5635,12 +5677,16 @@ label_161E2::
     inc  e
     inc  e
     ld   [label_140C], sp
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $F4
     inc  e
     ld   [$FC0C], sp
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $21
     add  a, b
     jp   label_F009
     pop  af
@@ -5933,9 +5979,11 @@ label_16390::
     ld   d, b
 
 label_16398::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   a, [$FFF0]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   a, [$FFF0]
 
 label_163A0::
@@ -6416,7 +6464,8 @@ label_16665::
     nop
     ld   [label_226A], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     ldi  [hl], a
     ld   a, [$FFF8]
     ld   h, [hl]
@@ -6444,7 +6493,8 @@ label_16665::
     nop
     ld   [label_226E], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6C
     ldi  [hl], a
     nop
     db   $FC ; Undefined instruction
@@ -6488,7 +6538,8 @@ label_16665::
     nop
     ld   [label_2276], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $74
     ldi  [hl], a
     nop
     ld    hl, sp+$70
@@ -6500,7 +6551,8 @@ label_16665::
     nop
     ld   [label_2272], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $70
     ldi  [hl], a
 
 label_166F5::
@@ -7306,7 +7358,8 @@ label_16B3C::
     inc  b
     ld   [label_206A], sp
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6C
     jr   nz, label_16BAC
     ld    hl, sp+$6C
     ld   b, b
@@ -7317,7 +7370,8 @@ label_16B3C::
     inc  d
     ld   [label_1606E], sp
     inc  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6C
     ld   h, b
     db   $FC ; Undefined instruction
     nop
@@ -7345,7 +7399,8 @@ label_16BAC::
     db   $EC ; Undefined instruction
 
 label_16BC4::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6C
     jr   nz, label_16BC4
     ld    hl, sp+$6C
     ld   b, b
@@ -7356,7 +7411,8 @@ label_16BC4::
     db   $FC ; Undefined instruction
     ld   [label_1606E], sp
     db   $FC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6C
     ld   h, b
 
 label_16BD7::
@@ -8099,7 +8155,8 @@ label_16FCA::
     inc  c
     ld   c, $10
     ld   de, label_1112
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0E
     inc  c
     ld   a, [bc]
     ld   b, $03
@@ -8268,7 +8325,8 @@ label_170DB::
     jr   nc, label_17153
 
 label_170E3::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     add  a, b
     add  a, b
 
@@ -8892,7 +8950,8 @@ label_17478::
     ret
 
 label_17481::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     inc  c
     ld   [label_304], sp
     ld   [bc], a
@@ -10025,7 +10084,8 @@ label_17B4B::
     ret
 
 label_17B51::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
 
 label_17B53::
     jr   label_17B3D
@@ -10044,7 +10104,8 @@ label_17B55::
     nop
     ld   [label_2060], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6A
     jr   nz, label_17B6A
 
 label_17B6A::
@@ -10064,7 +10125,8 @@ label_17B6E::
     nop
     ld   [label_2060], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6E
     jr   nz, label_17B82
 
 label_17B82::
@@ -10084,7 +10146,8 @@ label_17B86::
     nop
     ld   [label_2060], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
     jr   nz, label_17B9A
 
 label_17B9A::
@@ -10104,7 +10167,8 @@ label_17B9E::
     nop
     ld   [label_2062], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6A
     jr   nz, label_17BB2
 
 label_17BB2::
@@ -10124,7 +10188,8 @@ label_17BB6::
     nop
     ld   [label_2062], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6E
     jr   nz, label_17BCA
 
 label_17BCA::
@@ -10146,7 +10211,8 @@ label_17BD4::
     nop
     ld   [label_2062], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
 
 label_17BE0::
     jr   nz, label_17BE2

--- a/src/disassembled-banks/Bank50.asm
+++ b/src/disassembled-banks/Bank50.asm
@@ -1315,7 +1315,7 @@ label_C850B::
     ld   a, c
     ld   a, $C7
     ld   a, b
-    jp   [hl]
+    jp   hl
     ld   d, [hl]
     adc  a, e
     ld   [hl], l
@@ -1362,7 +1362,7 @@ label_C8642::
     ld   a, c
     ld   a, $C7
     ld   a, b
-    jp   [hl]
+    jp   hl
     ld   d, [hl]
     adc  a, e
     ld   [hl], l
@@ -1378,7 +1378,7 @@ label_C8642::
     nop
     push hl
     ld   [bc], a
-    jp   [hl]
+    jp   hl
     ld   b, $D5
     ld   c, $EF
     ld   e, $FD
@@ -1802,7 +1802,7 @@ label_C8857::
     ld    hl, sp+$1E
     ld   [rBGPD], a
     sub  a, [hl]
-    jp   [hl]
+    jp   hl
     ld   d, $FF
 
 label_C8879::
@@ -1912,7 +1912,7 @@ label_C88E2::
     ld    hl, sp+$B2
     ld   e, h
     ld   a, [$FF00+C]
-    jp   [hl]
+    jp   hl
     ld   [hl], $F1
     xor  $F1
     sbc  a, $F3
@@ -3764,7 +3764,7 @@ label_C9108::
     ccf
     jp   label_2FFF
     or   $D9
-    jp   [hl]
+    jp   hl
     or   $00
     nop
     nop
@@ -4013,7 +4013,7 @@ label_C9149::
     cp   $07
     cp   $0F
     or   $19
-    jp   [hl]
+    jp   hl
     or   $00
     nop
     nop
@@ -12980,7 +12980,7 @@ label_CB938::
     ld   [hl], e
     db   $EC ; Undefined instruction
     inc  [hl]
-    jp   [hl]
+    jp   hl
     ld   a, c
     xor  l
     cp   c

--- a/src/disassembled-banks/Bank50.asm
+++ b/src/disassembled-banks/Bank50.asm
@@ -97,7 +97,8 @@ label_C8050::
     inc  c
     daa
     jr   label_C80A0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5F
     jr   nz, label_C80D4
     jr   nz, label_C80D6
     jr   nz, label_C8044
@@ -121,7 +122,8 @@ label_C8050::
 label_C808B::
     ret  nz
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D7
     jr   c, label_C8050
     ld   a, b
     ld   a, e
@@ -231,13 +233,15 @@ label_C8103::
     inc  c
     daa
     jr   label_C8140
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5F
     jr   nz, label_C8164
     jr   nc, label_C8192
     inc  b
     rst  8
     jr   nc, label_C811A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $AF
     ld   e, b
     or   a
     ld   c, a
@@ -532,7 +536,8 @@ label_C823C::
     ld   a, [$FAFC]
     adc  a, h
     ld   a, [$EC04]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FC
     nop
     ld    hl, sp+$80
     jr   nc, label_C823C
@@ -882,7 +887,8 @@ label_C83F3::
     rla
     rrca
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     rla
     dec  de
     rlca
@@ -1100,7 +1106,8 @@ label_C850B::
     dec  hl
     rla
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     dec  c
     rra
     dec  c
@@ -1348,7 +1355,8 @@ label_C850B::
 
 label_C8642::
     dec  a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     jr   label_C8674
     ld   a, [de]
     dec  de
@@ -1750,9 +1758,12 @@ label_C8825::
     add  a, b
     jr   nz, label_C87E8
     jr   nz, label_C87EA
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     ld   [label_8F0], sp
     ld   a, [$FF08]
     ld   a, [$FF8E]
@@ -1765,7 +1776,8 @@ label_C8825::
     dec  c
     ld   b, $08
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   a, h
     inc  bc
     db   $FC ; Undefined instruction
@@ -1793,8 +1805,10 @@ label_C8857::
     ret  nz
     nop
     jr   nz, label_C8824
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     ld   [label_8F0], sp
     ld   a, [$FF04]
     ld    hl, sp+$04
@@ -1815,7 +1829,8 @@ label_C8879::
     nop
     inc  de
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
 
 label_C8886::
     rla
@@ -1905,7 +1920,8 @@ label_C88CF::
 label_C88E2::
     ret  c
     jr   nc, label_C88CD
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E4
     sbc  a, b
     db   $E4 ; Undefined instruction
     jr   label_C88CF
@@ -2019,8 +2035,10 @@ label_C8911::
     rrca
     ld   [label_80F], sp
     rra
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
     stop
     nop
     nop
@@ -2158,7 +2176,8 @@ label_C8A0A::
     ccf
     jr   nz, label_C8A54
     jr   nz, label_C8A36
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  c
     inc  bc
     inc  bc
@@ -2201,7 +2220,8 @@ label_C8A36::
     rrca
     ld   [label_101F], sp
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     ld   h, b
     rst  $38
     add  a, b
@@ -2234,9 +2254,12 @@ label_C8A54::
     jr   nz, label_C8AAA
     jr   nz, label_C8AAC
     jr   nz, label_C8A8E
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $0F
     ld   [label_80F], sp
     rlca
     inc  b
@@ -2302,18 +2325,30 @@ label_C8AAC::
     ret  nz
     ccf
     jr   nz, label_C8ADC
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $0F
     ld   [label_80F], sp
     rlca
     inc  b
@@ -2585,7 +2620,8 @@ label_C8BE5::
     ld   c, $00
     dec  d
     ld   a, [bc]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   e, $01
     rst  8
     ld   b, $E5
@@ -2743,7 +2779,8 @@ label_C8CAE::
     dec  c
     ld   b, $10
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     dec  e
     ld   [bc], a
     rrca
@@ -2885,7 +2922,8 @@ label_C8D1F::
     dec  b
     rrca
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     dec  hl
     inc  d
     ld   a, [hli]
@@ -3086,7 +3124,8 @@ label_C8E14::
     rst  $38
     nop
     jr   nz, label_C8E02
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [label_4F0], sp
     ld    hl, sp+$04
     ld    hl, sp+$02
@@ -3612,7 +3651,8 @@ label_C906C::
     rlca
     ld   [hl], a
     jr   label_C90DC
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     inc  bc
     nop
@@ -3948,7 +3988,8 @@ label_C9149::
     add  a, b
     nop
     ld   [rJOYP], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   a, [$FF00]
     nop
     nop
@@ -4174,7 +4215,8 @@ label_C926C::
     rrca
     ld   d, $0F
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
     add  hl, de
     cpl
 
@@ -4280,8 +4322,10 @@ label_C936B::
     cpl
     ld   e, a
     ld   l, $2F
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
+    db   $10
+    db   $1F
     dec  b
     ld   l, a
     dec  b
@@ -4330,8 +4374,10 @@ label_C93A3::
     cpl
     ld   e, a
     ld   l, $2F
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
+    db   $10
+    db   $1F
     rlca
     rrca
     inc  bc
@@ -5295,7 +5341,8 @@ label_C97E0::
     rra
     rla
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  c
     inc  bc
     inc  bc
@@ -5353,7 +5400,8 @@ label_C9845::
     rra
     rla
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  c
     inc  bc
     inc  bc
@@ -5405,8 +5453,10 @@ label_C9869::
     rra
     daa
     rra
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     inc  c
     inc  bc
     inc  bc
@@ -5459,7 +5509,8 @@ label_C98D0::
     rra
     inc  de
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  c
     inc  bc
     inc  bc
@@ -5700,7 +5751,8 @@ label_C997B::
     db   $FC ; Undefined instruction
     inc  de
     db   $EC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     ei
     rlca
     db   $FC ; Undefined instruction
@@ -6235,7 +6287,8 @@ label_C9B98::
     jr   label_C9C33
     jr   label_C9C71
     ret  nz
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld    hl, sp+$00
     ld   a, [$FF00]
     nop
@@ -6259,7 +6312,8 @@ label_C9B98::
 
 label_C9C55::
     jr   label_C9C96
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     rlca
     ld   [label_1F07], sp
     nop
@@ -6568,7 +6622,8 @@ label_C9DC5::
     add  hl, bc
     ld   b, $08
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   sp, label_C870E
     add  hl, sp
     adc  a, a
@@ -7093,7 +7148,8 @@ label_CA000::
     rrca
     nop
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     rra
     nop
@@ -7150,7 +7206,8 @@ label_CA03F::
     rrca
     nop
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     inc  c
     rra
     dec  bc
@@ -7405,7 +7462,8 @@ label_CA14F::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     nop
@@ -7541,7 +7599,8 @@ label_CA1FC::
     scf
     jr   c, label_CA227
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     ld   [label_277F], sp
     ld   [hl], a
     jr   z, label_CA24C
@@ -7682,9 +7741,12 @@ label_CA2A3::
     inc  bc
     add  hl, bc
     rlca
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     inc  c
     inc  bc
     inc  bc
@@ -7699,7 +7761,8 @@ label_CA2A3::
     nop
     ld   [hl], c
     jr   nz, label_CA306
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     inc  d
     rrca
@@ -7716,7 +7779,8 @@ label_CA2CE::
     rra
     nop
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6F
     jr   nc, label_CA2CE
     ld   b, c
     jp   label_101
@@ -8012,7 +8076,8 @@ label_CA41F::
     nop
     ld   a, a
     jr   nz, label_CA4A8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   d, b
     rst  $38
 
@@ -8330,7 +8395,8 @@ label_CA584::
     add  hl, hl
 
 label_CA587::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $26
     add  hl, de
     jr   nz, label_CA5AB
     ld   a, [hli]
@@ -8345,7 +8411,8 @@ label_CA587::
     ld   a, $43
     inc  a
     ld   a, $01
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     dec  de
     dec  c
     rra
@@ -8458,7 +8525,8 @@ label_CA60B::
     dec  hl
     rla
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     dec  c
     rra
     dec  c
@@ -8528,7 +8596,8 @@ label_CA60B::
     jr   nz, label_CA68B
     jr   nc, label_CA67D
     jr   nz, label_CA68F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_CA693
     jr   nz, label_CA695
     jr   nc, label_CA687
@@ -8551,7 +8620,8 @@ label_CA687::
     ld   l, $3F
 
 label_CA68B::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     dec  d
     ld   e, a
 
@@ -8596,7 +8666,8 @@ label_CA6AB::
     ld   sp, hl
     and  $F9
     add  a, $EE
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7C
     ret  c
     cp   h
     ret  c
@@ -8634,7 +8705,8 @@ label_CA6AB::
     nop
     ld   h, b
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     inc  e
     ld   [rDIV], a
     ld    hl, sp+$74
@@ -8651,7 +8723,8 @@ label_CA6AB::
     inc  e
     cp   h
     ld   b, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [$F8F0], sp
     nop
     nop
@@ -8701,7 +8774,8 @@ label_CA6AB::
     jr   label_CA733
     jr   label_CA771
     ret  nz
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld    hl, sp+$00
     ld   a, [$FF00]
     nop
@@ -8725,7 +8799,8 @@ label_CA6AB::
 
 label_CA755::
     jr   label_CA796
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     rlca
     ld   [label_1F07], sp
     nop
@@ -8802,7 +8877,8 @@ label_CA790::
     ret  nz
     ld   [rJOYP], a
     ld   a, [$FF00]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   a, [$FF00]
     ld   [$FFC0], a
     ld   a, [$FF00]
@@ -9187,7 +9263,8 @@ label_CA888::
 
 label_CA946::
     ld   a, [hli]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5D
     ldd  [hl], a
     ld   [hl], a
     db   $3A ; ldd  a, [hl]
@@ -10276,7 +10353,8 @@ label_CADA8::
     nop
     inc  c
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   de, label_230F
     rra
     daa
@@ -12261,7 +12339,8 @@ label_CB60D::
     add  hl, de
     rlca
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $4B
     scf
     ld   [hl], a
     inc  c
@@ -12353,7 +12432,8 @@ label_CB686::
     ccf
     inc  d
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $27
     jr   label_CB6AE
     dec  c
     rla
@@ -13153,7 +13233,8 @@ label_CB987::
     rrca
     inc  c
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     ld   h, $3F
     ld   l, $7F
     ld   c, h
@@ -13358,7 +13439,8 @@ label_CBAF0::
     rrca
     inc  c
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1C
     inc  de
     dec  sp
     daa
@@ -13851,7 +13933,8 @@ label_CBD3C::
     xor  $5C
     ld   l, h
     jr   z, label_CBD92
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     nop
@@ -13976,7 +14059,8 @@ label_CBDDF::
     ld   d, b
     ld   h, h
     jr   nz, label_CBE26
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     rrca
@@ -14258,8 +14342,10 @@ label_CBF06::
     inc  c
     rst  $20
     jr   label_CBEFC
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -14273,8 +14359,10 @@ label_CBF14::
     jr   label_CBF14
     ld   [label_8F7], sp
     rst  $28
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
+    db   $10
+    db   $E7
     jr   label_CBF1A
     inc  c
     ld    hl, sp+$07

--- a/src/disassembled-banks/Bank51.asm
+++ b/src/disassembled-banks/Bank51.asm
@@ -4080,7 +4080,7 @@ label_CD1C5::
     rst  $38
     jp   label_EDFF
     rst  $38
-    jp   [hl]
+    jp   hl
     rst  $30
     di
     rst  $38
@@ -4922,7 +4922,7 @@ label_CD601::
     cp   $00
     nop
     cp   $D5
-    jp   [hl]
+    jp   hl
     or   [hl]
     ld   e, a
     and  b
@@ -5826,7 +5826,7 @@ label_CDA63::
     ld   [de], a
 
 label_CDA6B::
-    jp   [hl]
+    jp   hl
     inc  d
     ld   [$FF35], a
     ret  nz
@@ -6167,6 +6167,8 @@ label_CDB83::
     add  hl, bc
     rst  $38
     db   $F4 ; Undefined instruction
+
+label_CDBF7::
     rst  $38
     ld   sp, hl
     rst  $38
@@ -7376,7 +7378,7 @@ label_CE13E::
     inc  b
     ld   a, [$F409]
     ld   [de], a
-    jp   [hl]
+    jp   hl
     scf
     add  a, c
     add  hl, sp
@@ -9440,7 +9442,7 @@ label_CEA71::
     rst  $38
     rst  $38
     rst  $38
-    jp   [hl]
+    jp   hl
     sbc  a, a
     ret
     cp   a
@@ -12759,7 +12761,7 @@ label_CF90E::
     ld   d, $EA
     ld   d, $EB
     inc  de
-    jp   [hl]
+    jp   hl
     inc  hl
     db   $21
     ld   hl, $FCDE
@@ -14270,4 +14272,4 @@ label_CFF8F::
     rst  $30
     adc  a, h
     rst  $30
-    ld   [$00F7], sp
+    ld   [$5CF7], sp

--- a/src/disassembled-banks/Bank51.asm
+++ b/src/disassembled-banks/Bank51.asm
@@ -280,7 +280,8 @@ label_CC0A5::
     inc  c
     rlca
     jr   label_CC14B
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     nop
     nop
     ccf
@@ -519,7 +520,8 @@ label_CC249::
     ld   a, a
     ld   e, b
     ld   e, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1C
     sub  a, b
     sbc  a, h
     ld   [bc], a
@@ -594,7 +596,8 @@ label_CC29D::
     inc  b
     nop
     ld   [label_1000], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     jr   nz, label_CC2DD
     jr   nz, label_CC2C3
     inc  b
@@ -629,11 +632,13 @@ label_CC2C3::
     nop
     ld   b, h
     ld   b, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
 
 label_CC2E6::
     jr   c, label_CC310
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     ld   b, h
     ld   b, h
     nop
@@ -740,8 +745,10 @@ label_CC310::
     ld   h, c
     ld   e, b
     ld   e, b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
+    db   $10
+    db   $1C
     ld   [bc], a
     ld   [bc], a
     add  a, [hl]
@@ -762,7 +769,8 @@ label_CC310::
     rrca
     add  a, b
     ret  nz
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $90
     dec  d
     sub  a, l
     nop
@@ -812,10 +820,12 @@ label_CC310::
     call z, label_C1CC
     inc  b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $04
     nop
     ld   [label_1000], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     jr   nz, label_CC3DD
     jr   nz, label_CC3C3
     inc  b
@@ -952,7 +962,8 @@ label_CC440::
     add  a, b
     inc  b
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     ld   [bc], a
@@ -986,7 +997,8 @@ label_CC440::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     dec  b
     dec  b
 
@@ -1038,7 +1050,8 @@ label_CC478::
     ld   b, c
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $04
     nop
     nop
     nop
@@ -2174,7 +2187,8 @@ label_CC9B3::
     sbc  a, $FF
     ld    hl, sp+$F0
     jr   nc, label_CC9B3
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $78
     sbc  a, b
     dec  sp
     ret  z
@@ -3560,7 +3574,8 @@ label_CCFF4::
     rrca
     ccf
     jr   nc, label_CD02A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     nop
     inc  bc
     nop
@@ -3598,7 +3613,8 @@ label_CD02A::
     rra
     nop
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $70
     rrca
     ld   [hl], b
     rrca
@@ -3798,7 +3814,8 @@ label_CD111::
     rra
     nop
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7C
     inc  de
     ld   a, [hl]
     ld   sp, label_CF0FF
@@ -3840,7 +3857,8 @@ label_CD141::
     ld   [hl], a
     sub  a, b
     ld   l, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     dec  h
     jp  c, label_956A
     rst  $10
@@ -3929,7 +3947,8 @@ label_CD141::
     nop
     rst  $38
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     push de
     ld   a, [hli]
     xor  d
@@ -4969,7 +4988,8 @@ label_CD601::
 
 label_CD688::
     sub  a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CF
     nop
     db   $FC ; Undefined instruction
     nop
@@ -5001,7 +5021,8 @@ label_CD696::
     inc  bc
     nop
     inc  a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     rst  $38
     rrca
 
@@ -5091,7 +5112,8 @@ label_CD6CC::
     adc  a, a
     rst  $38
     jr   nc, label_CD71A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     di
     inc  c
@@ -5326,7 +5348,8 @@ label_CD7FC::
     rst  $38
     ld   b, l
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   [$00FB], sp
     cp   h
     ld   [bc], a
@@ -5543,7 +5566,8 @@ label_CD8FE::
 
 label_CD92D::
     ld   [$0000], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5A
     nop
     dec  c
     nop
@@ -5775,7 +5799,8 @@ label_CDA13::
     rst  $18
     dec  c
     cp   a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     ld   c, e
     rst  $38
     sbc  a, a
@@ -5792,7 +5817,8 @@ label_CDA13::
     ld   e, $0F
     inc  e
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_CDA6B
     ld   b, b
     ccf
@@ -5987,7 +6013,8 @@ label_CDA6B::
     rst  $38
     inc  c
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -6536,7 +6563,8 @@ label_CDD6C::
     ret  nz
     nop
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $40
     add  a, b
     ld   h, b
     ld   [label_CE8F0], sp
@@ -6544,7 +6572,8 @@ label_CDD6C::
     ld   h, b
     add  hl, bc
     jr   nc, label_CDD6C
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     nop
     inc  c
     ld   h, $19
@@ -6916,7 +6945,8 @@ label_CDF05::
     rst  $38
     jr   label_CDF75
     jr   label_CDF77
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -6937,7 +6967,8 @@ label_CDF05::
     nop
     inc  h
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F4
     dec  bc
     ld   a, d
     dec  b
@@ -7121,7 +7152,8 @@ label_CE02D::
 
 label_CE061::
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_CE085
     jr   nz, label_CE087
     ld   e, a
@@ -7161,8 +7193,10 @@ label_CE087::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
     jr   nc, label_CE07F
     call c, label_FEF8
     ld   a, h
@@ -7261,14 +7295,16 @@ label_CE0F8::
     ld   e, h
     nop
     cp   a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   h, b
     ld   h, h
     jr   label_CE108
     inc  bc
     rlca
     ld   bc, label_708
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
 
 label_CE108::
     jr   nz, label_CE129
@@ -7478,7 +7514,8 @@ label_CE1D9::
     ret  nz
     nop
     jr   nz, label_CE1A6
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     rla
     ld   [$FF89], a
     ld   [hl], b
@@ -7858,7 +7895,8 @@ label_CE38D::
 label_CE394::
     sub  a, b
     rst  $20
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E7
     jr   z, label_CE36D
     ld   c, b
     or   e
@@ -7984,7 +8022,8 @@ label_CE410::
     add  a, b
     dec  b
     ld   a, [$F009]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     jr   nz, label_CE400
     rst  0
     nop
@@ -8003,7 +8042,8 @@ label_CE410::
     jr   label_CE463
     ld   l, b
     adc  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     rst  $38
     ld   [rIE], a
     ld   [rIE], a
@@ -8319,7 +8359,8 @@ label_CE58D::
 
 label_CE5A2::
     ld   l, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $92
     ld   l, h
     reti
     ld   l, $7F
@@ -8966,7 +9007,8 @@ label_CE84E::
     rlca
     ld   [label_807], sp
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     rra
     jr   nz, label_CE8FE
@@ -9015,7 +9057,8 @@ label_CE899::
     nop
     ret  nz
     jr   nz, label_CE88D
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     ld   [label_1000], sp
     nop
     jr   nz, label_CE8B5
@@ -9051,7 +9094,8 @@ label_CE8BB::
     ld   b, $DF
     nop
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D8
     jr   nz, label_CE90B
     nop
     nop
@@ -9071,13 +9115,15 @@ label_CE8EE::
     jr   nz, label_CE910
 
 label_CE8F0::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   [bc], a
     rrca
     nop
     sub  a, b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $41
     ld   b, c
     nop
     nop
@@ -9186,7 +9232,8 @@ label_CE910::
     rrca
     nop
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     jr   nz, label_CE9A8
     nop
     ccf
@@ -9458,10 +9505,12 @@ label_CEA71::
     ld   [bc], a
     rst  $38
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     sbc  a, $10
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -9581,7 +9630,8 @@ label_CEB1A::
     ccf
     ldi  [hl], a
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     jr   label_CEB3A
     inc  c
     inc  bc
@@ -10729,7 +10779,8 @@ label_CEF4C::
     rst  $38
     ld   b, l
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   [$00FB], sp
     cp   h
     ld   [bc], a
@@ -10939,7 +10990,8 @@ label_CF104::
 
 label_CF12D::
     ld   [$0000], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $5A
     nop
     dec  c
     nop
@@ -11165,7 +11217,8 @@ label_CF229::
     rst  $18
     dec  c
     cp   a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     ld   c, e
     rst  $38
     sbc  a, a
@@ -11270,7 +11323,8 @@ label_CF269::
     nop
     nop
     db   $E8 ; add  sp, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E4
     jr   label_CF269
     jr   c, label_CF229
     ld   a, h
@@ -11381,7 +11435,8 @@ label_CF269::
     rst  $38
     inc  c
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     nop
     nop
@@ -11393,7 +11448,8 @@ label_CF269::
     nop
     rrca
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_CF34D
     jr   nz, label_CF34F
     ld   b, b
@@ -11406,7 +11462,8 @@ label_CF269::
     inc  a
     inc  h
     jr   label_CF363
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $19
     nop
     dec  b
     nop
@@ -11467,7 +11524,8 @@ label_CF368::
     jr   z, label_CF3C3
     jr   nc, label_CF3C5
     jr   nc, label_CF3A9
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
     stop
     nop
     nop
@@ -11899,8 +11957,10 @@ label_CF50C::
     rlca
     ld   c, b
     rlca
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     rla
     ld   [$0000], sp
     nop
@@ -12327,7 +12387,8 @@ label_CF705::
     rst  $38
     jr   label_CF776
     jr   label_CF778
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -12459,7 +12520,8 @@ label_CF808::
     ld   bc, $0007
     ld   c, $01
     jr   label_CF819
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_CF835
     jr   nz, label_CF837
     ld   b, b
@@ -12633,9 +12695,12 @@ label_CF86B::
     ld   c, b
     and  c
     jr   label_CF86B
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $62
+    db   $10
+    db   $62
+    db   $10
+    db   $22
     nop
     ld   [de], a
     nop
@@ -12812,7 +12877,8 @@ label_CF979::
     jr   c, label_CF9D9
     jr   c, label_CF9BB
     jr   label_CF9BD
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     nop
     rst  $20
     rst  $18
@@ -12864,7 +12930,8 @@ label_CF9BD::
 
 label_CF9D5::
     rst  $30
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     jr   nz, label_CF9B9
     ret  nz
     ccf
@@ -13368,8 +13435,10 @@ label_CFBCC::
     add  a, b
     jr   nz, label_CFBCA
     jr   nz, label_CFBCC
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     ld   [label_8F0], sp
     ld   a, [$FF04]
     ld    hl, sp+$04
@@ -13508,7 +13577,8 @@ label_CFC99::
     ei
     adc  a, b
     rst  $30
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     jr   nz, label_CFC99
     ret  nz
     ccf
@@ -13743,7 +13813,8 @@ label_CFD99::
     ei
     adc  a, b
     rst  $30
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     jr   nz, label_CFD99
     ret  nz
     ccf

--- a/src/disassembled-banks/Bank52.asm
+++ b/src/disassembled-banks/Bank52.asm
@@ -48,7 +48,8 @@ section "bank52",romx,bank[$34]
     ld   b, b
     rst  $38
     jr   nz, label_D0032
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   [label_4FF], sp
     rst  $38
     ld   [bc], a
@@ -97,7 +98,8 @@ section "bank52",romx,bank[$34]
     ld   [$FF5F], a
     rst  $38
     jr   nz, label_D0072
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   [label_4FF], sp
     rst  $38
     ld   [bc], a
@@ -3895,7 +3897,8 @@ label_D0E27::
     jr   nc, label_D0E9A
     jr   c, label_D0E75
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   h, $19
     cpl
     ld   d, $3F
@@ -3941,9 +3944,11 @@ label_D0E92::
     rra
     dec  b
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
 
 label_D0E9A::
     ld   de, label_1B0E
@@ -4054,7 +4059,8 @@ label_D0EBF::
 
 label_D0F19::
     inc  e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  c
     inc  bc
     inc  bc
@@ -4172,7 +4178,8 @@ label_D0F74::
     rlca
     ld   [hl], a
     jr   label_D0FDC
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     dec  d
     nop
@@ -4189,7 +4196,8 @@ label_D0F74::
     scf
     jr   c, label_D0FC7
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     ld   [label_277F], sp
 
 label_D0FB6::
@@ -5866,7 +5874,8 @@ label_D1684::
     ld   b, h
     rst  $38
     jr   z, label_D16A8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D16AC
     ld   b, h
     rst  $38
@@ -5879,7 +5888,8 @@ label_D1684::
     ld   b, h
     rst  $38
     jr   z, label_D16B8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D16BC
     ld   b, h
     rst  $38
@@ -5892,7 +5902,8 @@ label_D1684::
     ld   b, h
     rst  $38
     jr   z, label_D16C8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D16CC
     ld   b, h
     rst  $38
@@ -5905,7 +5916,8 @@ label_D1684::
     ld   b, h
     rst  $38
     jr   z, label_D16D8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D16DC
     ld   b, h
     rst  $38
@@ -5918,7 +5930,8 @@ label_D1684::
     ld   b, h
     rst  $38
     jr   z, label_D16E8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D16EC
     ld   b, h
     rst  $38
@@ -5931,7 +5944,8 @@ label_D1684::
     ld   b, h
     rst  $38
     jr   z, label_D16F8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D16FC
     ld   b, h
     rst  $38
@@ -6007,14 +6021,20 @@ label_D173A::
     call nz, label_84F4
     nop
     ccf
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
+    db   $10
+    db   $29
+    db   $10
+    db   $28
 
 label_D1758::
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
+    db   $10
+    db   $29
+    db   $10
+    db   $29
     nop
     rst  $38
     nop
@@ -6226,7 +6246,8 @@ label_D182E::
     ld   b, h
     rst  $38
     jr   z, label_D1838
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D183C
     ld   b, h
     rst  $38
@@ -6239,7 +6260,8 @@ label_D182E::
     ld   b, h
     rst  $38
     jr   z, label_D1848
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D184C
     ld   b, h
     rst  $38
@@ -6252,7 +6274,8 @@ label_D182E::
     ld   b, h
     rst  $38
     jr   z, label_D1858
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D185C
     ld   b, h
     rst  $38
@@ -6265,7 +6288,8 @@ label_D182E::
     ld   b, h
     rst  $38
     jr   z, label_D1868
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D186C
     ld   b, h
     rst  $38
@@ -6278,7 +6302,8 @@ label_D182E::
     ld   b, h
     rst  $38
     jr   z, label_D1878
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D187C
     ld   b, h
     rst  $38
@@ -6291,7 +6316,8 @@ label_D182E::
     ld   b, h
     rst  $38
     jr   z, label_D1888
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D188C
     ld   b, h
     rst  $38
@@ -6304,7 +6330,8 @@ label_D182E::
     ld   b, h
     rst  $38
     jr   z, label_D1898
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D189C
     ld   b, h
     rst  $38
@@ -6317,7 +6344,8 @@ label_D182E::
     ld   b, h
     rst  $38
     jr   z, label_D18A8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D18AC
     ld   b, h
     rst  $38
@@ -6330,7 +6358,8 @@ label_D182E::
     ld   b, h
     rst  $38
     jr   z, label_D18B8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D18BC
     ld   b, h
     rst  $38
@@ -6343,7 +6372,8 @@ label_D182E::
     ld   b, h
     rst  $38
     jr   z, label_D18C8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D18CC
     ld   b, h
     rst  $38
@@ -6356,7 +6386,8 @@ label_D182E::
     ld   b, h
     rst  $38
     jr   z, label_D18D8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D18DC
     ld   b, h
     rst  $38
@@ -6369,7 +6400,8 @@ label_D182E::
     ld   b, h
     rst  $38
     jr   z, label_D18E8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D18EC
     ld   b, h
     rst  $38
@@ -6382,7 +6414,8 @@ label_D182E::
     ld   b, h
     rst  $38
     jr   z, label_D18F8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D18FC
     ld   b, h
     rst  $38

--- a/src/disassembled-banks/Bank53.asm
+++ b/src/disassembled-banks/Bank53.asm
@@ -48,7 +48,8 @@ section "bank53",romx,bank[$35]
     ld   b, b
     rst  $38
     jr   nz, label_D4032
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   [label_4FF], sp
     rst  $38
     ld   [bc], a
@@ -97,7 +98,8 @@ section "bank53",romx,bank[$35]
     ld   [$FF5F], a
     rst  $38
     jr   nz, label_D4072
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   [label_4FF], sp
     rst  $38
     ld   [bc], a
@@ -1187,7 +1189,8 @@ label_D44CB::
 label_D4519::
     inc  de
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     ld   [$000F], sp
     nop
     nop
@@ -1302,7 +1305,8 @@ label_D4574::
     rlca
     ld   [hl], a
     jr   label_D45DC
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     ld   [rJOYP], a
     ld    hl, sp+$E0
@@ -1746,7 +1750,8 @@ label_D4774::
     ccf
     dec  b
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
     jr   label_D47B6
     nop
     ld   bc, $0100
@@ -1943,7 +1948,8 @@ label_D4875::
 label_D487A::
     db   $F4 ; Undefined instruction
     jr   label_D4875
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $B0
     nop
     rst  $18
     cpl
@@ -2499,7 +2505,8 @@ label_D4AD2::
     ld   b, $07
     nop
     ld   [rJOYP], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     call c, label_F2E0
     db   $EC ; Undefined instruction
     ld   sp, hl
@@ -2523,7 +2530,8 @@ label_D4AD2::
     nop
     inc  c
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_D4B29
     ld   b, b
     ccf
@@ -2813,11 +2821,16 @@ label_D4BF7::
     inc  bc
     ld   [label_807], sp
     rlca
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     ld   [label_A07], sp
     rlca
     dec  b
@@ -3048,7 +3061,8 @@ label_D4D12::
     rrca
     inc  c
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3C
     nop
     ld   [hl], b
     nop
@@ -3276,7 +3290,8 @@ label_D4E27::
     jr   nc, label_D4E9A
     jr   c, label_D4E75
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   h, $19
     cpl
     ld   d, $3F
@@ -3322,9 +3337,11 @@ label_D4E92::
     rra
     dec  b
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     rla
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
 
 label_D4E9A::
     ld   de, label_1B0E
@@ -3435,7 +3452,8 @@ label_D4EBF::
 
 label_D4F19::
     inc  e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  c
     inc  bc
     inc  bc
@@ -3553,7 +3571,8 @@ label_D4F74::
     rlca
     ld   [hl], a
     jr   label_D4FDC
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     dec  d
     nop
@@ -3570,7 +3589,8 @@ label_D4F74::
     scf
     jr   c, label_D4FC7
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     ld   [label_277F], sp
 
 label_D4FB6::
@@ -3845,7 +3865,8 @@ label_D50D9::
     ld   l, h
     sub  a, b
     db   $E8 ; add  sp, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     ret  nz
     sbc  a, b
     ld   [$FF78], a
@@ -5137,7 +5158,8 @@ label_D5684::
     ld   b, h
     rst  $38
     jr   z, label_D56A8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D56AC
     ld   b, h
     rst  $38
@@ -5150,7 +5172,8 @@ label_D5684::
     ld   b, h
     rst  $38
     jr   z, label_D56B8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D56BC
     ld   b, h
     rst  $38
@@ -5163,7 +5186,8 @@ label_D5684::
     ld   b, h
     rst  $38
     jr   z, label_D56C8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D56CC
     ld   b, h
     rst  $38
@@ -5176,7 +5200,8 @@ label_D5684::
     ld   b, h
     rst  $38
     jr   z, label_D56D8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D56DC
     ld   b, h
     rst  $38
@@ -5189,7 +5214,8 @@ label_D5684::
     ld   b, h
     rst  $38
     jr   z, label_D56E8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D56EC
     ld   b, h
     rst  $38
@@ -5202,7 +5228,8 @@ label_D5684::
     ld   b, h
     rst  $38
     jr   z, label_D56F8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D56FC
     ld   b, h
     rst  $38
@@ -5278,14 +5305,20 @@ label_D573A::
     call nz, label_84F4
     nop
     ccf
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
+    db   $10
+    db   $29
+    db   $10
+    db   $28
 
 label_D5758::
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
+    db   $10
+    db   $29
+    db   $10
+    db   $29
     nop
     rst  $38
     nop
@@ -5497,7 +5530,8 @@ label_D582E::
     ld   b, h
     rst  $38
     jr   z, label_D5838
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D583C
     ld   b, h
     rst  $38
@@ -5510,7 +5544,8 @@ label_D582E::
     ld   b, h
     rst  $38
     jr   z, label_D5848
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D584C
     ld   b, h
     rst  $38
@@ -5523,7 +5558,8 @@ label_D582E::
     ld   b, h
     rst  $38
     jr   z, label_D5858
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D585C
     ld   b, h
     rst  $38
@@ -5536,7 +5572,8 @@ label_D582E::
     ld   b, h
     rst  $38
     jr   z, label_D5868
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D586C
     ld   b, h
     rst  $38
@@ -5549,7 +5586,8 @@ label_D582E::
     ld   b, h
     rst  $38
     jr   z, label_D5878
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D587C
     ld   b, h
     rst  $38
@@ -5562,7 +5600,8 @@ label_D582E::
     ld   b, h
     rst  $38
     jr   z, label_D5888
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D588C
     ld   b, h
     rst  $38
@@ -5575,7 +5614,8 @@ label_D582E::
     ld   b, h
     rst  $38
     jr   z, label_D5898
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D589C
     ld   b, h
     rst  $38
@@ -5588,7 +5628,8 @@ label_D582E::
     ld   b, h
     rst  $38
     jr   z, label_D58A8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D58AC
     ld   b, h
     rst  $38
@@ -5601,7 +5642,8 @@ label_D582E::
     ld   b, h
     rst  $38
     jr   z, label_D58B8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D58BC
     ld   b, h
     rst  $38
@@ -5614,7 +5656,8 @@ label_D582E::
     ld   b, h
     rst  $38
     jr   z, label_D58C8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D58CC
     ld   b, h
     rst  $38
@@ -5627,7 +5670,8 @@ label_D582E::
     ld   b, h
     rst  $38
     jr   z, label_D58D8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D58DC
     ld   b, h
     rst  $38
@@ -5640,7 +5684,8 @@ label_D582E::
     ld   b, h
     rst  $38
     jr   z, label_D58E8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D58EC
     ld   b, h
     rst  $38
@@ -5653,7 +5698,8 @@ label_D582E::
     ld   b, h
     rst  $38
     jr   z, label_D58F8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_D58FC
     ld   b, h
     rst  $38
@@ -7697,7 +7743,8 @@ label_D600A::
 label_D6012::
     ret  nz
     jr   nz, label_D6039
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $12
     ld   [label_2098], sp
     jr   c, label_D6060
     ld   b, h
@@ -7742,8 +7789,10 @@ label_D6039::
     db   $FC ; Undefined instruction
     ld   [label_10FB], sp
     rst  $30
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -7751,14 +7800,16 @@ label_D6039::
     nop
     rst  $38
     ld   [$FF3F], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     ld   [label_8EF], sp
     rst  $28
 
 label_D605F::
     ld   [label_10F7], sp
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F4
     jr   label_D605F
     rrca
     rst  $38
@@ -8399,9 +8450,12 @@ label_D62C0::
     nop
     ld   [$FF1F], a
     rst  $28
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
+    db   $10
+    db   $EF
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -8418,11 +8472,16 @@ label_D62C0::
     ei
     inc  b
     rst  $28
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
+    db   $10
+    db   $EF
+    db   $10
+    db   $EF
+    db   $10
+    db   $EF
+    db   $10
+    db   $E0
     rra
     rst  $38
     nop
@@ -8447,13 +8506,20 @@ label_D62C0::
     rst  $38
     rrca
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
+    db   $10
+    db   $FF
     ld    hl, sp+$FF
     inc  b
     rst  $38
@@ -8578,7 +8644,8 @@ label_D63F7::
     and  c
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   c, label_D644E
     ld   a, h
     ld   b, h
@@ -8592,7 +8659,8 @@ label_D63F7::
     cp   $44
     ld   a, h
     jr   z, label_D6474
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     ccf
@@ -8625,7 +8693,8 @@ label_D644E::
     sub  a, c
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   z, label_D648E
     ld   c, h
     ld   b, h
@@ -8646,7 +8715,8 @@ label_D6474::
     cp   $44
     ld   a, h
     jr   z, label_D64B4
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     ccf
@@ -8682,7 +8752,8 @@ label_D648E::
     and  c
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   c, label_D64CE
     ld   a, h
     ld   b, h
@@ -8698,7 +8769,8 @@ label_D64B4::
     sbc  a, $44
     ld   a, h
     jr   z, label_D64F4
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     ccf
@@ -8732,7 +8804,8 @@ label_D64CE::
     and  c
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   c, label_D650E
     ld   a, h
     ld   b, h
@@ -8748,7 +8821,8 @@ label_D64F4::
     cp   $4C
     ld   [hl], h
     jr   c, label_D6524
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     nop
     nop
@@ -9671,7 +9745,8 @@ label_D684A::
     ld   bc, label_701
     ld   b, $0F
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     cp   $FE
     rst  $28
     rra
@@ -11385,8 +11460,10 @@ label_D7017::
     xor  e
     rst  $10
     add  hl, hl
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2B
+    db   $10
+    db   $4C
     inc  sp
     ld   c, h
     inc  sp
@@ -11615,7 +11692,8 @@ label_D7100::
     rst  8
     jr   nc, label_D717F
     jr   nc, label_D715F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $39
     nop
     add  hl, hl
     nop
@@ -11831,7 +11909,8 @@ label_D71B0::
     rla
     db   $E8 ; add  sp, d
     inc  l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $4B
     jr   nc, label_D726D
     jr   nc, label_D71B0
     ld   [hl], b
@@ -11846,7 +11925,8 @@ label_D71B0::
     ld   c, a
     jr   nc, label_D727F
     jr   nc, label_D725F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $39
     nop
     ld   l, c
     nop
@@ -13253,7 +13333,8 @@ label_D7807::
     ld   bc, $0007
     ld   c, $01
     jr   label_D7819
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_D7835
     jr   nz, label_D7837
     ld   b, b
@@ -13531,7 +13612,8 @@ label_D7886::
     ld   a, h
     jr   c, label_D7991
     jr   c, label_D7973
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $BF
     ld   e, l
     ld   a, a
     cp   [hl]
@@ -13714,7 +13796,8 @@ label_D7991::
     cp   $00
     ld   de, label_100E
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [label_807], sp
     rlca
     inc  b
@@ -13901,7 +13984,8 @@ label_D7991::
     ld   bc, label_1FE
     cp   $01
     cp   $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $24
     jr   label_D7B29
     jr   label_D7B2B
     jr   label_D7B2D
@@ -13921,7 +14005,8 @@ label_D7B0F::
     ld   c, $11
     ld   c, $10
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     add  a, b
     rst  $38
     add  a, b
@@ -14146,8 +14231,10 @@ label_D7BCC::
     add  a, b
     jr   nz, label_D7BCA
     jr   nz, label_D7BCC
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     ld   [label_8F0], sp
     ld   a, [$FF04]
     ld    hl, sp+$04

--- a/src/disassembled-banks/Bank53.asm
+++ b/src/disassembled-banks/Bank53.asm
@@ -1058,7 +1058,7 @@ label_D419C::
     nop
     ccf
     rst  0
-    jp   [hl]
+    jp   hl
     rlca
     rrca
     nop
@@ -2766,6 +2766,8 @@ label_D4BCF::
     dec  bc
     rlca
     add  hl, bc
+
+label_D4BF7::
     rlca
     inc  c
     rlca
@@ -7951,7 +7953,7 @@ label_D6138::
     ld   [hl], e
     db   $EC ; Undefined instruction
     inc  [hl]
-    jp   [hl]
+    jp   hl
     ld   a, c
     xor  l
     cp   c
@@ -8356,7 +8358,7 @@ label_D62C0::
     dec  b
     dec  b
     ld   sp, hl
-    jp   [hl]
+    jp   hl
     inc  de
     ld   de, label_317
     rst  8
@@ -14987,4 +14989,4 @@ label_D7E59::
     rst  $30
     adc  a, h
     rst  $30
-    ld   [$00F7], sp
+    ld   [$4CF7], sp

--- a/src/disassembled-banks/Bank54.asm
+++ b/src/disassembled-banks/Bank54.asm
@@ -385,15 +385,18 @@ label_D8282::
     nop
     ld   [label_752], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $54
     rlca
     stop
     ld   d, [hl]
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   e, h
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   e, [hl]
     rlca
 
@@ -2368,16 +2371,19 @@ label_D8EE4::
     nop
     ld   [label_2766], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $64
     daa
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     ld   l, b
     ld   b, $10
     nop
     ld   l, d
     ld   b, $10
     ld   [label_66C], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   l, [hl]
     ld   b, $F0
     ld    hl, sp+$60
@@ -2401,16 +2407,19 @@ label_D8EE4::
     nop
     ld   [label_2766], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $64
     daa
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     ld   l, [hl]
     ld   h, $10
     nop
     ld   l, h
     ld   h, $10
     ld   [label_266A], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   l, b
     ld   h, $EA
     ld   c, [hl]
@@ -3453,7 +3462,8 @@ label_D95A5::
     nop
     db   $FC ; Undefined instruction
     ld   a, [label_1CFC]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FA
     sbc  a, a
     pop  bc
     and  a
@@ -3588,7 +3598,8 @@ label_D968C::
     ld    hl, sp+$00
     ld   [$FFF4], a
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
     db   $FC ; Undefined instruction
     nop
     ld   b, $F8
@@ -3604,11 +3615,14 @@ label_D968C::
     ld  [$FF00+C], a
     db   $F4 ; Undefined instruction
     nop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
+    db   $10
+    db   $0C
     inc  b
     ld   [$FFF4], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
     nop
     ld   [$FFF4], a
     ld  [$FF00+C], a
@@ -3873,7 +3887,8 @@ label_D982C::
     ld   a, [$FF00+C]
     ld   [label_1058], sp
     ld   e, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $58
     ld   d, $58
     inc  h
     ld   e, b
@@ -5810,7 +5825,8 @@ label_DA3DD::
 
 label_DA423::
     ret
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
     ld   c, $21
     inc  h
     ld   h, h
@@ -7989,7 +8005,8 @@ label_DB003::
     stop
     ld   [hl], d
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   [hl], d
     jr   nz, label_DB013
 
@@ -8002,7 +8019,8 @@ label_DB013::
     stop
     ld   [hl], d
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
 
 label_DB020::
     ld   [hl], d
@@ -8046,7 +8064,8 @@ label_DB044::
 label_DB052::
     ld   [label_818], sp
     jr   label_DB067
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     jr   nz, label_DB020
     ld   c, $03
     ld   b, $00
@@ -8134,7 +8153,8 @@ label_DB096::
     add  hl, bc
     ld   e, h
     ld   e, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0A
     ld   e, d
     ld   e, e
     ld   c, e

--- a/src/disassembled-banks/Bank54.asm
+++ b/src/disassembled-banks/Bank54.asm
@@ -6164,7 +6164,7 @@ label_DA5C6::
     ld   h, l
     reti
     ld   h, l
-    jp   [hl]
+    jp   hl
     ld   h, l
     pop  af
     ld   h, l
@@ -7478,7 +7478,7 @@ label_DAD3B::
     ld   l, h
     pop  hl
     ld   l, h
-    jp   [hl]
+    jp   hl
     ld   l, h
     pop  af
     ld   l, h

--- a/src/disassembled-banks/Bank55.asm
+++ b/src/disassembled-banks/Bank55.asm
@@ -932,7 +932,8 @@ label_DC4E3::
 
 label_DC4EB::
     jr   nz, label_DC505
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
 
 label_DC4EF::
     ld   bc, $0000
@@ -1588,13 +1589,15 @@ label_DC8E7::
     ld   b, $00
     ld   [label_66E], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $76
     ld   b, $10
     nop
     ld   a, b
     ld   b, $10
     ld   [label_67A], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   a, h
     ld   b, $F8
     nop
@@ -1628,13 +1631,15 @@ label_DC8E7::
     ld   b, $00
     ld   [label_642], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $44
     ld   b, $10
     nop
     ld   b, [hl]
     ld   b, $10
     ld   [label_648], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   c, d
     ld   b, $03
     ld   c, c
@@ -4014,7 +4019,8 @@ label_DD760::
     jr   nz, label_DD778
     ld   [label_2006], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     jr   nz, label_DD770
 
 label_DD770::
@@ -4025,7 +4031,8 @@ label_DD770::
     jr   nz, label_DD788
 
 label_DD778::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0E
     jr   nz, label_DD78C
     ld   [label_2010], sp
     stop
@@ -4033,7 +4040,8 @@ label_DD778::
     jr   nz, label_DD784
 
 label_DD784::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     jr   nz, label_DD788
 
 label_DD788::
@@ -4044,7 +4052,8 @@ label_DD78C::
     nop
     inc  c
     jr   nz, label_DD7A0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $64
     jr   nz, label_DD7A4
     ld   [label_2066], sp
     stop
@@ -4067,13 +4076,16 @@ label_DD7A4::
     jr   label_DD7A7
 
 label_DD7A7::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FC
     ld   a, [de]
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $04
     inc  e
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
     ld   e, $00
 
 label_DD7B3::
@@ -4089,15 +4101,18 @@ label_DD7B3::
     ld   d, a
 
 label_DD7BD::
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
+    db   $10
+    db   $18
     jr   label_DD7C3
 
 label_DD7C3::
     nop
     ld   a, [bc]
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     inc  c
     nop
     ld   [label_E10], sp
@@ -4108,7 +4123,8 @@ label_DD7C3::
     nop
     inc  e
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   e, $00
     ld   [label_2010], sp
     nop
@@ -4124,18 +4140,22 @@ label_DD7E2::
     nop
     ld   [$0020], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $22
     nop
     stop
     inc  h
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   h, $00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   z, label_DD7FE
 
 label_DD7FE::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   a, [hli]
     nop
     ld   [$0000], sp
@@ -4156,18 +4176,22 @@ label_DD810::
     nop
     ld   [$000E], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     ld   a, [bc]
     nop
     stop
     ld   [de], a
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     inc  d
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   d, $00
     nop
     nop
@@ -4176,16 +4200,19 @@ label_DD810::
     nop
     ld   [$000E], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     stop
     jr   label_DD842
 
 label_DD842::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   a, [de]
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     inc  e
     nop
     nop
@@ -4194,19 +4221,23 @@ label_DD842::
     nop
     ld   [$0020], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $22
     nop
     stop
     inc  l
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   h, b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   z, label_DD862
 
 label_DD862::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   a, [hli]
     nop
 
@@ -4234,7 +4265,8 @@ label_DD870::
     stop
     inc  b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   b, $00
     nop
     nop
@@ -4245,7 +4277,8 @@ label_DD870::
     nop
 
 label_DD891::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   c, $00
     nop
     nop
@@ -4255,7 +4288,8 @@ label_DD891::
     stop
     inc  d
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   d, $00
     nop
     nop
@@ -4265,15 +4299,18 @@ label_DD8A9::
     nop
     ld   [$0032], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $34
     nop
     stop
     ld   [hl], $00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     jr   c, label_DD8B9
 
 label_DD8B9::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     db   $3A ; ldd  a, [hl]
     nop
     ld   [hl], l
@@ -4296,7 +4333,8 @@ label_DD8CA::
     jr   nz, label_DD8E2
     ld   [label_2006], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     jr   nz, label_DD8DA
 
 label_DD8DA::
@@ -4307,7 +4345,8 @@ label_DD8DA::
     jr   nz, label_DD8F2
 
 label_DD8E2::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0E
     jr   nz, label_DD8F6
     ld   [label_2010], sp
     stop
@@ -4315,7 +4354,8 @@ label_DD8E2::
     jr   nz, label_DD8EE
 
 label_DD8EE::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     jr   nz, label_DD8F2
 
 label_DD8F2::
@@ -4326,7 +4366,8 @@ label_DD8F6::
     nop
     inc  c
     jr   nz, label_DD90A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7A
     jr   nz, label_DD90E
     ld   [label_207C], sp
     stop
@@ -4344,15 +4385,18 @@ label_DD90A::
     nop
 
 label_DD90E::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     nop
     stop
     ld   a, [de]
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     inc  e
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   e, $00
     nop
     nop
@@ -4362,14 +4406,17 @@ label_DD921::
     nop
     ld   [$0022], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $24
     nop
     stop
     ld   h, $00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   d, d
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   d, h
     nop
 
@@ -4388,8 +4435,10 @@ label_DD935::
     ld   e, c
 
 label_DD941::
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
+    db   $10
+    db   $18
     jr   label_DD95F
     nop
     cp   $54
@@ -4418,7 +4467,8 @@ label_DD95F::
     ei
     ld   [$005E], sp
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     nop
     dec  bc
     nop
@@ -4427,7 +4477,8 @@ label_DD95F::
     dec  bc
     ld   [$0064], sp
     dec  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
     nop
     db   $FC ; Undefined instruction
     nop
@@ -4436,7 +4487,8 @@ label_DD95F::
     db   $FC ; Undefined instruction
     ld   [$0042], sp
     db   $FC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $44
     nop
     inc  c
     nop
@@ -4445,7 +4497,8 @@ label_DD95F::
     inc  c
     ld   [$0048], sp
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $4A
     nop
     db   $FC ; Undefined instruction
     nop
@@ -4454,7 +4507,8 @@ label_DD95F::
     db   $FC ; Undefined instruction
     ld   [$006A], sp
     db   $FC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6C
     nop
     inc  c
     nop
@@ -4463,7 +4517,8 @@ label_DD95F::
     inc  c
     ld   [$0070], sp
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $72
     nop
     nop
     ld   [bc], a
@@ -4477,12 +4532,14 @@ label_DD95F::
     ld   [de], a
     ld   d, b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $04
     ld   d, d
     nop
 
 label_DD9B3::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
     ld   d, d
     jr   nz, label_DD9B3
     rst  $38
@@ -4533,13 +4590,15 @@ label_DD9DD::
     jr   label_DD9E5
 
 label_DD9E5::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $34
     ld   hl, label_800
     ld   [hl], $21
     nop
     nop
     jr   c, label_DDA11
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     db   $3A ; ldd  a, [hl]
     ld   hl, label_810
     inc  a
@@ -4548,14 +4607,16 @@ label_DD9E5::
 label_DD9FA::
     ld   a, $21
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
     ld   hl, label_800
     ld   a, [hli]
     ld   hl, $0000
     inc  l
     ld   hl, label_1010
     ld   l, $21
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     jr   nc, label_DDA31
     stop
     ldd  [hl], a
@@ -4587,9 +4648,11 @@ label_DDA31::
     inc  h
     ld   bc, label_810
     ld   h, $01
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   h, $21
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     inc  h
     ld   hl, label_DD9E4
     db   $FC ; Undefined instruction
@@ -4615,11 +4678,13 @@ label_DDA5D::
     ld   [bc], a
     inc  bc
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $04
     inc  bc
     stop
     ld   b, $01
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [label_1001], sp
 
 label_DDA70::
@@ -4631,11 +4696,13 @@ label_DDA70::
     inc  d
     inc  bc
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $16
     inc  bc
     stop
     jr   label_DDA84
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   a, [de]
     ld   bc, label_810
     ld   h, $01
@@ -4737,7 +4804,8 @@ label_DDAE9::
     ld   bc, label_800
     ld   [hl], $01
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     ld   bc, $0010
     db   $3A ; ldd  a, [hl]
     ld   bc, label_810
@@ -4750,7 +4818,8 @@ label_DDAE9::
     ld   bc, label_800
     ld   [hl], $01
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
     ld   bc, $0010
     ld   c, h
     ld   bc, label_810
@@ -4976,16 +5045,19 @@ label_DDC7F::
 label_DDC8C::
     ld   [$011A], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1C
     ld   bc, $0010
     ld   e, $01
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
 
 label_DDC99::
     jr   nz, label_DDC9C
 
 label_DDC9B::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ldi  [hl], a
     ld   bc, $00F8
     inc  h

--- a/src/disassembled-banks/Bank55.asm
+++ b/src/disassembled-banks/Bank55.asm
@@ -1410,7 +1410,7 @@ label_DC7C3::
 label_DC7D0::
     ld   a, [$C20E]
     rst  0
-    jp   [hl]
+    jp   hl
     ld   b, a
     add  hl, hl
     ld   c, b
@@ -4786,7 +4786,7 @@ label_DDAE9::
 
 label_DDB60::
     ld   e, d
-    jp   [hl]
+    jp   hl
     ld   e, d
     dec  d
     ld   e, e

--- a/src/disassembled-banks/Bank56.asm
+++ b/src/disassembled-banks/Bank56.asm
@@ -4009,7 +4009,8 @@ label_E100B::
     dec  hl
     rla
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     dec  c
     rra
     dec  c
@@ -4079,7 +4080,8 @@ label_E100B::
     jr   nz, label_E108B
     jr   nc, label_E107D
     jr   nz, label_E108F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_E1093
     jr   nz, label_E1095
     jr   nc, label_E1087
@@ -4283,7 +4285,8 @@ label_E112D::
     ld   a, [hl]
     jr   z, label_E11C9
     jr   label_E11CB
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1152
     ld   l, d
     rst  $38
@@ -5417,9 +5420,12 @@ label_E160D::
     ld   [de], a
     nop
     add  hl, sp
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
+    db   $10
+    db   $29
+    db   $10
+    db   $6F
     jr   nc, label_E1641
     nop
     jr   nz, label_E1624
@@ -5491,7 +5497,8 @@ label_E1645::
     inc  e
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     sub  a, $DF
     jr   nz, label_E166E
     xor  [hl]
@@ -6189,7 +6196,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1948
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E194C
     ld   b, h
     rst  $38
@@ -6202,7 +6210,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1958
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E195C
     ld   b, h
     rst  $38
@@ -6215,7 +6224,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1968
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E196C
     ld   b, h
     rst  $38
@@ -6228,7 +6238,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1978
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E197C
     ld   b, h
     rst  $38
@@ -6241,7 +6252,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1988
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E198C
     ld   b, h
     rst  $38
@@ -6254,7 +6266,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1998
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E199C
     ld   b, h
     rst  $38
@@ -6267,7 +6280,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E19A8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E19AC
     ld   b, h
     rst  $38
@@ -6280,7 +6294,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E19B8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E19BC
     ld   b, h
     rst  $38
@@ -6293,7 +6308,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E19C8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E19CC
     ld   b, h
     rst  $38
@@ -6306,7 +6322,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E19D8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E19DC
     ld   b, h
     rst  $38
@@ -6319,7 +6336,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E19E8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E19EC
     ld   b, h
     rst  $38
@@ -6332,7 +6350,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E19F8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E19FC
     ld   b, h
     rst  $38
@@ -6345,7 +6364,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1A08
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1A0C
     ld   b, h
     rst  $38
@@ -6358,7 +6378,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1A18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1A1C
     ld   b, h
     rst  $38
@@ -6371,7 +6392,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1A28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1A2C
     ld   b, h
     rst  $38
@@ -6384,7 +6406,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1A38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1A3C
     ld   b, h
     rst  $38
@@ -6397,7 +6420,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1A48
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1A4C
     ld   b, h
     rst  $38
@@ -6410,7 +6434,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1A58
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1A5C
     ld   b, h
     rst  $38
@@ -6423,7 +6448,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1A68
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1A6C
     ld   b, h
     rst  $38
@@ -6436,7 +6462,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1A78
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1A7C
     ld   b, h
     rst  $38
@@ -6449,7 +6476,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1A88
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1A8C
     ld   b, h
     rst  $38
@@ -6462,7 +6490,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1A98
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1A9C
     ld   b, h
     rst  $38
@@ -6475,7 +6504,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1AA8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1AAC
     ld   b, h
     rst  $38
@@ -6488,7 +6518,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1AB8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1ABC
     ld   b, h
     rst  $38
@@ -6501,7 +6532,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1AC8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1ACC
     ld   b, h
     rst  $38
@@ -6514,7 +6546,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1AD8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1ADC
     ld   b, h
     rst  $38
@@ -6527,7 +6560,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1AE8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1AEC
     ld   b, h
     rst  $38
@@ -6540,7 +6574,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1AF8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1AFC
     ld   b, h
     rst  $38
@@ -6553,7 +6588,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1B08
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1B0C
     ld   b, h
     rst  $38
@@ -6566,7 +6602,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1B18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1B1C
     ld   b, h
     rst  $38
@@ -6579,7 +6616,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1B28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1B2C
     ld   b, h
     rst  $38
@@ -6592,7 +6630,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1B38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1B3C
     ld   b, h
     rst  $38
@@ -6605,7 +6644,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1B48
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1B4C
     ld   b, h
     rst  $38
@@ -6618,7 +6658,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1B58
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1B5C
     ld   b, h
     rst  $38
@@ -6631,7 +6672,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1B68
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1B6C
     ld   b, h
     rst  $38
@@ -6644,7 +6686,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1B78
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1B7C
     ld   b, h
     rst  $38
@@ -6657,7 +6700,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1B88
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1B8C
     ld   b, h
     rst  $38
@@ -6670,7 +6714,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1B98
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1B9C
     ld   b, h
     rst  $38
@@ -6683,7 +6728,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1BA8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1BAC
     ld   b, h
     rst  $38
@@ -6696,7 +6742,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1BB8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1BBC
     ld   b, h
     rst  $38
@@ -6709,7 +6756,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1BC8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1BCC
     ld   b, h
     rst  $38
@@ -6722,7 +6770,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1BD8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1BDC
     ld   b, h
     rst  $38
@@ -6735,7 +6784,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1BE8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1BEC
     ld   b, h
     rst  $38
@@ -6748,7 +6798,8 @@ label_E192E::
     ld   b, h
     rst  $38
     jr   z, label_E1BF8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1BFC
     ld   b, h
     rst  $38
@@ -7073,7 +7124,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1D48
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1D4C
     ld   b, h
     rst  $38
@@ -7086,7 +7138,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1D58
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1D5C
     ld   b, h
     rst  $38
@@ -7099,7 +7152,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1D68
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1D6C
     ld   b, h
     rst  $38
@@ -7112,7 +7166,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1D78
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1D7C
     ld   b, h
     rst  $38
@@ -7125,7 +7180,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1D88
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1D8C
     ld   b, h
     rst  $38
@@ -7138,7 +7194,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1D98
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1D9C
     ld   b, h
     rst  $38
@@ -7151,7 +7208,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1DA8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1DAC
     ld   b, h
     rst  $38
@@ -7164,7 +7222,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1DB8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1DBC
     ld   b, h
     rst  $38
@@ -7177,7 +7236,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1DC8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1DCC
     ld   b, h
     rst  $38
@@ -7190,7 +7250,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1DD8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1DDC
     ld   b, h
     rst  $38
@@ -7203,7 +7264,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1DE8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1DEC
     ld   b, h
     rst  $38
@@ -7216,7 +7278,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1DF8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1DFC
     ld   b, h
     rst  $38
@@ -7229,7 +7292,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1E08
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1E0C
     ld   b, h
     rst  $38
@@ -7242,7 +7306,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1E18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1E1C
     ld   b, h
     rst  $38
@@ -7255,7 +7320,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1E28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1E2C
     ld   b, h
     rst  $38
@@ -7268,7 +7334,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1E38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1E3C
     ld   b, h
     rst  $38
@@ -7281,7 +7348,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1E48
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1E4C
     ld   b, h
     rst  $38
@@ -7294,7 +7362,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1E58
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1E5C
     ld   b, h
     rst  $38
@@ -7307,7 +7376,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1E68
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1E6C
     ld   b, h
     rst  $38
@@ -7320,7 +7390,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1E78
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1E7C
     ld   b, h
     rst  $38
@@ -7333,7 +7404,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1E88
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1E8C
     ld   b, h
     rst  $38
@@ -7346,7 +7418,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1E98
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1E9C
     ld   b, h
     rst  $38
@@ -7359,7 +7432,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1EA8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1EAC
     ld   b, h
     rst  $38
@@ -7372,7 +7446,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1EB8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1EBC
     ld   b, h
     rst  $38
@@ -7385,7 +7460,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1EC8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1ECC
     ld   b, h
     rst  $38
@@ -7398,7 +7474,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1ED8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1EDC
     ld   b, h
     rst  $38
@@ -7411,7 +7488,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1EE8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1EEC
     ld   b, h
     rst  $38
@@ -7424,7 +7502,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1EF8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1EFC
     ld   b, h
     rst  $38
@@ -7437,7 +7516,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1F08
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1F0C
     ld   b, h
     rst  $38
@@ -7450,7 +7530,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1F18
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1F1C
     ld   b, h
     rst  $38
@@ -7463,7 +7544,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1F28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1F2C
     ld   b, h
     rst  $38
@@ -7476,7 +7558,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1F38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1F3C
     ld   b, h
     rst  $38
@@ -7489,7 +7572,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1F48
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1F4C
     ld   b, h
     rst  $38
@@ -7502,7 +7586,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1F58
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1F5C
     ld   b, h
     rst  $38
@@ -7515,7 +7600,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1F68
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1F6C
     ld   b, h
     rst  $38
@@ -7528,7 +7614,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1F78
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1F7C
     ld   b, h
     rst  $38
@@ -7541,7 +7628,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1F88
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1F8C
     ld   b, h
     rst  $38
@@ -7554,7 +7642,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1F98
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1F9C
     ld   b, h
     rst  $38
@@ -7567,7 +7656,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1FA8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1FAC
     ld   b, h
     rst  $38
@@ -7580,7 +7670,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1FB8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1FBC
     ld   b, h
     rst  $38
@@ -7593,7 +7684,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1FC8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1FCC
     ld   b, h
     rst  $38
@@ -7606,7 +7698,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1FD8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1FDC
     ld   b, h
     rst  $38
@@ -7619,7 +7712,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1FE8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1FEC
     ld   b, h
     rst  $38
@@ -7632,7 +7726,8 @@ label_E1D2E::
     ld   b, h
     rst  $38
     jr   z, label_E1FF8
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_E1FFC
 
 label_E1FFD::
@@ -7649,7 +7744,8 @@ label_E2000::
     inc  sp
     inc  e
     dec  l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     ld   hl, label_364
     dec  c
     ld   b, $0B
@@ -7785,7 +7881,8 @@ label_E205D::
     ld   b, b
     add  a, b
     jr   nz, label_E2070
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     sub  a, h
     and  $B6
     ld   h, [hl]
@@ -8164,7 +8261,8 @@ label_E2269::
     ld   a, $01
     ret  z
     scf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     jr   nz, label_E2269
     ld   b, b
     cp   a
@@ -8308,7 +8406,8 @@ label_E22D3::
     db   $E8 ; add  sp, d
     jr   nc, label_E22D3
     ld   b, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [label_8F0], sp
     ld   a, [$FF08]
     ld   a, [$FF30]
@@ -11766,8 +11865,10 @@ label_E3106::
     call label_ED79
     jr   c, label_E3106
     jr   c, label_E3118
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FB
+    db   $10
+    db   $FF
     rst  $38
     ld   bc, label_3FF
     cp   $86
@@ -11775,7 +11876,8 @@ label_E3106::
     db   $ED ; Undefined instruction
     ld   a, b
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
     nop
     rst  $30
     nop
@@ -11998,10 +12100,12 @@ label_E31A3::
     inc  a
     db   $FD ; Undefined instruction
     jr   label_E3218
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FB
 
 label_E321F::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     rst  $38
     nop
     rst  $38
@@ -12011,7 +12115,8 @@ label_E321F::
     ld   a, [hl]
     xor  $38
     ld   sp, hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
     nop
     rst  $30
     nop
@@ -12232,10 +12337,12 @@ label_E324C::
     ld   e, $FC
     inc  e
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FB
 
 label_E331F::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     rst  $38
     nop
     rst  $38
@@ -12246,7 +12353,8 @@ label_E331F::
     ld   l, [hl]
     inc  a
     db   $FD ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F3
     nop
     rst  $30
     nop

--- a/src/disassembled-banks/Bank56.asm
+++ b/src/disassembled-banks/Bank56.asm
@@ -8609,7 +8609,7 @@ label_E242D::
     db   $FC ; Undefined instruction
     db   $FC ; Undefined instruction
     rst  $20
-    jp   [hl]
+    jp   hl
     rst  $38
     db   $E8 ; add  sp, d
     cp   $D0
@@ -11543,7 +11543,7 @@ label_E26CB::
     rst  $38
     call c, label_E34E7
     adc  a, a
-    jp   [hl]
+    jp   hl
     rra
     ld   [$ED1F], a
     ld   e, $F3
@@ -11644,7 +11644,7 @@ label_E26CB::
     sbc  a, a
     db   $E8 ; add  sp, d
     rra
-    jp   [hl]
+    jp   hl
     rra
     ld   [$ED1F], a
     ld   e, $F1
@@ -12465,7 +12465,7 @@ label_E33BD::
     rst  $38
     call c, label_E34E7
     adc  a, a
-    jp   [hl]
+    jp   hl
     rra
     ld   [$ED1F], a
     ld   e, $F3
@@ -12566,7 +12566,7 @@ label_E33BD::
     sbc  a, a
     db   $E8 ; add  sp, d
     rra
-    jp   [hl]
+    jp   hl
     rra
     ld   [$ED1F], a
     ld   e, $F1
@@ -12691,7 +12691,7 @@ label_E3513::
     ld   a, l
     ret
     inc  a
-    jp   [hl]
+    jp   hl
     jr   c, label_E3507
     jr   label_E3511
     jr   label_E3513
@@ -12701,7 +12701,7 @@ label_E3513::
     ld   bc, label_2FF
     cp   $84
     ld   a, h
-    jp   [hl]
+    jp   hl
 
 label_E352A::
     jr   label_E351F

--- a/src/disassembled-banks/Bank57.asm
+++ b/src/disassembled-banks/Bank57.asm
@@ -7,7 +7,8 @@ section "bank57",romx,bank[$39]
     nop
     ld   bc, label_600
     ld   bc, label_708
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   de, label_1F0E
     nop
     inc  bc
@@ -637,8 +638,10 @@ label_E42BF::
     add  a, b
     nop
     ld   a, [$FF00]
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     jr   nz, label_E4298
     and  b
     ld   b, b
@@ -708,7 +711,8 @@ label_E42BF::
     nop
 
 label_E4320::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [label_8F0], sp
     ld   a, [$FF10]
     ld   [$FF60], a
@@ -809,8 +813,10 @@ label_E436D::
     add  a, b
     nop
     ld   a, [$FF00]
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     jr   nz, label_E4356
     and  b
     ld   b, b
@@ -878,8 +884,10 @@ label_E43A2::
     nop
     nop
     jr   nz, label_E43A2
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     jr   nz, label_E43A8
     ret  nz
     nop
@@ -1215,7 +1223,8 @@ label_E447C::
     ld   [hl], $EA
     inc  d
     db   $EC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $78
     nop
     jr   nc, label_E4560
 
@@ -1311,20 +1320,30 @@ label_E4560::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     ld   a, [$FF00]
     stop
     stop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   a, [$FF00]
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     sub  a, b
     ld   h, b
     ld   [hl], b
@@ -1351,24 +1370,34 @@ label_E4560::
     nop
     sub  a, b
     ld   h, b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     sub  a, b
     ld   h, b
     ld   [hl], b
@@ -1534,7 +1563,8 @@ label_E4635::
     rla
     rrca
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     nop
     db   $FC ; Undefined instruction
     nop
@@ -1620,7 +1650,8 @@ label_E4635::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [label_8F0], sp
     ld   a, [$FF10]
     ld   [$FF60], a
@@ -2268,7 +2299,8 @@ label_E49DF::
     ld   h, b
     rra
     jr   nc, label_E4A27
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [label_807], sp
     rlca
     inc  b
@@ -3737,7 +3769,8 @@ label_E503D::
     ret  nz
     nop
     jr   nz, label_E5014
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     sub  a, b
     ld   h, b
     ld   [hl], b
@@ -3836,11 +3869,13 @@ label_E5099::
     ccf
     rrca
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $4F
     ldd  [hl], a
     ld   [hl], d
     dec  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_E50EF
     nop
     nop
@@ -3947,7 +3982,8 @@ label_E5138::
 label_E5139::
     ld   a, $38
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_E5157
     nop
     nop
@@ -4101,7 +4137,8 @@ label_E51B9::
     ld   [bc], a
     ld   [de], a
     dec  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_E520F
     nop
     nop
@@ -4656,9 +4693,12 @@ label_E542E::
     nop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $80
+    db   $10
+    db   $80
+    db   $10
+    db   $80
     ld   [$82C0], sp
     nop
     ld   a, h
@@ -5016,7 +5056,8 @@ label_E559E::
     ld   a, b
     rst  0
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld    hl, sp+$FF
     rst  $38
     rst  $38
@@ -5994,7 +6035,8 @@ label_E5984::
     ret  nz
     ccf
     jr   nz, label_E59F4
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [label_80F], sp
     rlca
     inc  b
@@ -6126,7 +6168,8 @@ label_E5A26::
     rst  $38
     add  a, b
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ldi  [hl], a
     rst  $38
     rra
@@ -6148,13 +6191,15 @@ label_E5A26::
     dec  bc
     inc  c
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     jr   nz, label_E5B0B
     ld   b, c
     xor  $91
     ld   a, a
     ld   a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     ld   a, [$FF0F]
     db   $FC ; Undefined instruction
     inc  bc
@@ -6358,7 +6403,8 @@ label_E5B63::
     dec  bc
     inc  c
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $09
     ldd  [hl], a
     ld   l, e
     ld   d, b
@@ -6536,8 +6582,10 @@ label_E5C17::
     db   $F4 ; Undefined instruction
     nop
     db   $EB ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $AF
+    db   $10
+    db   $F0
     rrca
     ld   a, b
     add  a, a
@@ -6562,7 +6610,8 @@ label_E5C17::
     rst  $38
     inc  d
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -6804,7 +6853,8 @@ label_E5D0E::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     rst  $38
     rst  $38
     rst  $38
@@ -6834,7 +6884,8 @@ label_E5D0E::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     rst  $38
     rst  $38
     rst  $38
@@ -6864,7 +6915,8 @@ label_E5D0E::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   h, b
     rst  $38
     or   b
@@ -7220,7 +7272,8 @@ label_E5F17::
     db   $FD ; Undefined instruction
     ld   [bc], a
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $AB
     ld   d, h
     rst  $20
     jr   label_E5F02
@@ -7431,7 +7484,8 @@ label_E5F17::
     nop
     ld   bc, label_600
     ld   bc, label_708
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   de, label_1F0E
     nop
     inc  bc
@@ -8647,7 +8701,8 @@ label_E6248::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     sub  a, b
     ld   h, b
     ld    hl, sp+$30
@@ -9538,7 +9593,8 @@ label_E6795::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     rst  $38
     nop
     add  a, c
@@ -9551,8 +9607,10 @@ label_E6795::
     rst  $38
     ld   b, b
     ld   b, b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $EF
     rst  $38
     nop
     add  a, c
@@ -9564,7 +9622,8 @@ label_E6795::
     rst  $38
     ld   [$FF50], a
     ld   e, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     nop
     nop
@@ -10127,7 +10186,8 @@ label_E6AF7::
     ld   bc, $BB45
     rst  $38
     ld   bc, $EF11
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     rst  $38
     nop
     add  a, c
@@ -10138,8 +10198,10 @@ label_E6AF7::
     ld   a, [hl]
     rst  $38
     nop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
+    db   $10
+    db   $EF
     ld   [$FFF7], sp
     nop
     add  a, c
@@ -11174,7 +11236,8 @@ label_E6C0C::
     nop
     ld   bc, label_600
     ld   bc, label_708
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   de, label_1F0E
     nop
     inc  bc
@@ -12466,7 +12529,8 @@ label_E7540::
     rst  8
     inc  sp
     ld   l, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $67
     jr   label_E75E4
     inc  c
     ld   sp, label_1C0E
@@ -13867,7 +13931,8 @@ label_E7AAB::
     rrca
     inc  c
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     jr   nz, label_E7BEC
     ld   b, b
     rst  $38
@@ -13914,7 +13979,8 @@ label_E7B86::
     ld   a, a
     ld   hl, label_303F
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     sbc  a, a
     ld   [$FF9F], a
     ld   [$FF9F], a
@@ -14184,16 +14250,20 @@ label_E7CB1::
     inc  e
     rst  $38
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   h, b
     rst  $38
     ret  nz
     rst  $18
     ld   h, b
     ld   l, a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     ld   [$FFE0], a
     jr   label_E7CE1
     ld   c, $FB
@@ -14495,7 +14565,8 @@ label_E7CE4::
     rst  $38
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -14625,7 +14696,8 @@ label_E7E8D::
     rst  $38
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     jr   nz, label_E7E66
     ld   h, b
     sub  a, c
@@ -14732,7 +14804,8 @@ label_E7E8D::
     db   $EB ; Undefined instruction
     inc  d
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -14766,7 +14839,8 @@ label_E7F4C::
     ld   b, $FF
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     rst  $38
@@ -14781,7 +14855,8 @@ label_E7F4C::
     rst  $38
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     rst  $38

--- a/src/disassembled-banks/Bank57.asm
+++ b/src/disassembled-banks/Bank57.asm
@@ -153,7 +153,7 @@ label_E40AF::
     sub  a, $EF
     sub  a, $EF
     call nc, label_D02F
-    jp   [hl]
+    jp   hl
     sub  a, $FF
     ret  nz
     nop
@@ -1816,7 +1816,7 @@ label_E47C0::
     rst  $38
     call c, label_E74E7
     adc  a, a
-    jp   [hl]
+    jp   hl
     rra
     ld   [$ED1F], a
     ld   e, $F3
@@ -2047,7 +2047,7 @@ label_E48F0::
     sbc  a, a
     db   $E8 ; add  sp, d
     rra
-    jp   [hl]
+    jp   hl
     rra
     ld   [$ED1F], a
     ld   e, $F1
@@ -2969,7 +2969,7 @@ label_E4D13::
     ld   a, l
     ret
     inc  a
-    jp   [hl]
+    jp   hl
     jr   c, label_E4D07
     jr   label_E4D11
     jr   label_E4D13
@@ -2979,7 +2979,7 @@ label_E4D13::
     ld   bc, label_2FF
     cp   $84
     ld   a, h
-    jp   [hl]
+    jp   hl
     jr   label_E4D1F
     nop
     rst  $30
@@ -6370,7 +6370,7 @@ label_E5B63::
     inc  b
     cp   l
     inc  bc
-    jp   [hl]
+    jp   hl
     rla
     rst  $20
     ld   e, $DF
@@ -7577,7 +7577,7 @@ label_E60AF::
     sub  a, $EF
     sub  a, $EF
     call nc, label_D02F
-    jp   [hl]
+    jp   hl
     sub  a, $FF
     ret  nz
     nop
@@ -9138,9 +9138,9 @@ label_E6730::
     nop
     and  $19
     and  $19
-    jp   [hl]
+    jp   hl
     rra
-    jp   [hl]
+    jp   hl
     rra
     ld   h, [hl]
     rra
@@ -11454,7 +11454,7 @@ label_E70FF::
     sub  a, $EF
     sub  a, $EF
     call nc, label_D02F
-    jp   [hl]
+    jp   hl
     sub  a, $FF
     ret  nz
     db   $EB ; Undefined instruction
@@ -11526,7 +11526,7 @@ label_E70FF::
     sub  a, $EF
     sub  a, $EF
     call nc, label_D02F
-    jp   [hl]
+    jp   hl
     sub  a, $FF
     ret  nz
     db   $EB ; Undefined instruction
@@ -13959,7 +13959,7 @@ label_E7B86::
     rrca
     ld   sp, hl
     rlca
-    jp   [hl]
+    jp   hl
     rla
     pop  af
     rrca

--- a/src/disassembled-banks/Bank58.asm
+++ b/src/disassembled-banks/Bank58.asm
@@ -1826,7 +1826,7 @@ label_E87BF::
     rst  $38
     call c, label_EB4E7
     adc  a, a
-    jp   [hl]
+    jp   hl
     rra
     ld   [$ED1F], a
     ld   e, $F3
@@ -2057,7 +2057,7 @@ label_E88F0::
     sbc  a, a
     db   $E8 ; add  sp, d
     rra
-    jp   [hl]
+    jp   hl
     rra
     ld   [$ED1F], a
     ld   e, $F1
@@ -6395,7 +6395,7 @@ label_E9B63::
     inc  b
     cp   l
     inc  bc
-    jp   [hl]
+    jp   hl
     rla
     rst  $20
     ld   e, $DF
@@ -13854,7 +13854,7 @@ label_EBB86::
     rrca
     ld   sp, hl
     rlca
-    jp   [hl]
+    jp   hl
     rla
     pop  af
     rrca

--- a/src/disassembled-banks/Bank58.asm
+++ b/src/disassembled-banks/Bank58.asm
@@ -637,8 +637,10 @@ label_E82BF::
     add  a, b
     nop
     ld   a, [$FF00]
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     jr   nz, label_E8298
     and  b
     ld   b, b
@@ -708,7 +710,8 @@ label_E82BF::
     nop
 
 label_E8320::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [label_8F0], sp
     ld   a, [$FF10]
     ld   [$FF60], a
@@ -809,8 +812,10 @@ label_E836D::
     add  a, b
     nop
     ld   a, [$FF00]
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     jr   nz, label_E8356
     and  b
     ld   b, b
@@ -878,8 +883,10 @@ label_E83A2::
     nop
     nop
     jr   nz, label_E83A2
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     jr   nz, label_E83A8
     ret  nz
     nop
@@ -1105,7 +1112,8 @@ label_E8461::
     nop
     ccf
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     add  hl, hl
     ld   d, $29
     ld   d, $00
@@ -1229,7 +1237,8 @@ label_E8530::
     ld   [hl], $FE
     inc  d
     db   $FC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $78
     nop
     jr   nc, label_E8560
 
@@ -1249,9 +1258,12 @@ label_E8560::
     ret  nz
     nop
     jr   nz, label_E8530
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     ld   [rJOYP], a
     nop
     nop
@@ -1323,20 +1335,30 @@ label_E858B::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     ld   a, [$FF00]
     stop
     stop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   a, [$FF00]
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     sub  a, b
     ld   h, b
     ld   [hl], b
@@ -1363,24 +1385,34 @@ label_E858B::
     nop
     sub  a, b
     ld   h, b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E0
     sub  a, b
     ld   h, b
     ld   [hl], b
@@ -1528,7 +1560,8 @@ label_E8635::
     nop
     ccf
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     add  hl, hl
     ld   d, $29
     ld   d, $29
@@ -1550,7 +1583,8 @@ label_E86D9::
     nop
     jr   label_E86ED
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     nop
     db   $FC ; Undefined instruction
     nop
@@ -1631,7 +1665,8 @@ label_E86D9::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     ld   [label_8F0], sp
     ld   a, [$FF10]
     ld   [$FF60], a
@@ -2278,7 +2313,8 @@ label_E89DF::
     ld   h, b
     rra
     jr   nc, label_E8A27
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [label_807], sp
     rlca
     inc  b
@@ -2980,8 +3016,10 @@ label_E8D06::
     call label_ED79
     jr   c, label_E8D06
     jr   c, label_E8D18
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FB
+    db   $10
+    db   $FF
     rst  $38
     ld   bc, label_3FF
     cp   $86
@@ -2989,7 +3027,8 @@ label_E8D06::
     db   $ED ; Undefined instruction
     ld   a, b
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
     nop
     rst  $30
     nop
@@ -3220,8 +3259,10 @@ label_E8D83::
     inc  a
     db   $FD ; Undefined instruction
     jr   label_E8E18
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FB
+    db   $10
+    db   $FF
     rst  $38
     nop
     rst  $38
@@ -3231,7 +3272,8 @@ label_E8D83::
     ld   a, [hl]
     xor  $38
     ld   sp, hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
     nop
     rst  $30
     nop
@@ -3458,8 +3500,10 @@ label_E8D83::
     ld   e, $FC
     inc  e
     ei
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FB
+    db   $10
+    db   $FF
     rst  $38
     nop
     rst  $38
@@ -3470,7 +3514,8 @@ label_E8D83::
     ld   l, [hl]
     inc  a
     db   $FD ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F3
     nop
     rst  $30
     nop
@@ -3754,7 +3799,8 @@ label_E903D::
     ret  nz
     nop
     jr   nz, label_E9014
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     sub  a, b
     ld   h, b
     ld   [hl], b
@@ -3859,11 +3905,13 @@ label_E9099::
     ccf
     rrca
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     ldd  [hl], a
     ld   [hl], d
     dec  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_E90EF
     nop
     nop
@@ -3971,7 +4019,8 @@ label_E9138::
 label_E9139::
     ld   a, $38
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_E9157
     nop
     nop
@@ -4132,7 +4181,8 @@ label_E91B9::
     ld   [bc], a
     ld   [de], a
     dec  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_E920F
     nop
     nop
@@ -4684,9 +4734,12 @@ label_E942E::
     nop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $80
+    db   $10
+    db   $80
+    db   $10
+    db   $80
     ld   [$82C0], sp
     nop
     ld   a, h
@@ -5044,7 +5097,8 @@ label_E959E::
     ld   a, b
     rst  0
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld    hl, sp+$FF
     rst  $38
     rst  $38
@@ -6022,7 +6076,8 @@ label_E9984::
     ret  nz
     ccf
     jr   nz, label_E99F4
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [label_80F], sp
     rlca
     inc  b
@@ -6153,7 +6208,8 @@ label_E99F4::
     ld   a, a
     add  a, b
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DD
     ldi  [hl], a
     or   $1F
     pop  af
@@ -6177,13 +6233,15 @@ label_E99F4::
     dec  bc
     inc  c
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     jr   nz, label_E9B0B
     ld   b, c
     xor  $91
     ld   a, a
     ld   a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     ld   a, [$FF0F]
     db   $FC ; Undefined instruction
     inc  bc
@@ -6383,7 +6441,8 @@ label_E9B63::
     dec  bc
     inc  c
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $09
     ldd  [hl], a
     ld   l, e
     ld   d, b
@@ -6561,8 +6620,10 @@ label_E9C27::
     db   $F4 ; Undefined instruction
     nop
     db   $EB ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $AF
+    db   $10
+    db   $F0
     rrca
     ld   a, b
     add  a, a
@@ -6588,7 +6649,8 @@ label_E9C27::
     db   $EB ; Undefined instruction
     inc  d
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -6889,7 +6951,8 @@ label_E9D8E::
     rst  $38
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   h, b
     xor  a
     or   b
@@ -7051,7 +7114,8 @@ label_E9E3A::
     nop
     call label_B132
     ld   c, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     rst  $38
     rst  $38
     inc  bc
@@ -7080,7 +7144,8 @@ label_E9E3A::
     nop
     call label_B132
     ld   c, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     rst  $38
     rst  $38
     inc  bc
@@ -7109,7 +7174,8 @@ label_E9E3A::
     nop
     call label_B132
     ld   c, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     rst  $38
     rst  $38
     inc  bc
@@ -7239,7 +7305,8 @@ label_E9F17::
     db   $FD ; Undefined instruction
     ld   [bc], a
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $AB
     ld   d, h
     rst  $20
     jr   label_E9F02
@@ -7530,7 +7597,8 @@ label_EA048::
     cp   $03
     cp   $03
     cp   $EF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E7
     jr   label_EA048
     inc  e
     pop  af
@@ -8139,8 +8207,10 @@ label_EA2E2::
     ld    hl, sp+$5F
     or   b
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $F7
     jr   c, label_EA2E2
     inc  a
     rst  $38
@@ -9441,7 +9511,8 @@ label_EA605::
     rst  $38
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
     ld   [label_12CA], sp
     ld   h, e
     add  hl, bc
@@ -9466,7 +9537,8 @@ label_EA8B7::
     call z, label_FD38
     ld    hl, sp+$F9
     jr   nc, label_EA8B7
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     rst  $38
     rst  $38
     rst  $38
@@ -9686,7 +9758,8 @@ label_EA997::
     ld   de, $93FD
     ld    hl, sp+$10
     db   $FC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     jr   label_EAA36
     ld   [label_C7F], sp
     ld   a, a
@@ -9774,7 +9847,8 @@ label_EA997::
     sbc  a, [hl]
     nop
     cp   h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E8
     nop
     nop
     nop
@@ -10099,9 +10173,11 @@ label_EAB39::
     dec  de
     jr   label_EAB8E
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     jr   label_EAB9C
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     rrca
 
 label_EAB80::
@@ -10158,7 +10234,8 @@ label_EAB9C::
 
 label_EABB5::
     ret  nc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $70
     ld    hl, sp+$08
     db   $E8 ; add  sp, d
     jr   label_EABB5
@@ -10475,7 +10552,8 @@ label_EACD3::
     ld   b, b
     add  a, b
     ld   l, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     rra
     ld   c, b
     scf
@@ -10937,8 +11015,10 @@ label_EAEC5::
     nop
     ld   bc, label_600
     ld   bc, label_708
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
+    db   $10
+    db   $0F
     jr   nz, label_EAF77
     ld   hl, label_2F1E
     ld   de, label_61F
@@ -12373,7 +12453,8 @@ label_EB540::
     rst  8
     inc  sp
     ld   l, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $67
     jr   label_EB5E4
     inc  c
     ld   sp, label_1C0E
@@ -13763,7 +13844,8 @@ label_EBAAB::
     rrca
     inc  c
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     jr   nz, label_EBBEC
     ld   b, b
     rst  $38
@@ -13810,7 +13892,8 @@ label_EBB86::
     ld   a, a
     ld   hl, label_303F
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     sbc  a, a
     ld   [$FF9F], a
     ld   [$FF9F], a
@@ -14077,16 +14160,20 @@ label_EBCB1::
     inc  e
     rst  $38
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   h, b
     rst  $38
     ret  nz
     rst  $18
     ld   h, b
     ld   l, a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     ld   [$FFE0], a
     nop
     nop
@@ -14394,7 +14481,8 @@ label_EBCE4::
     rst  $38
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -14522,7 +14610,8 @@ label_EBE66::
     rst  $38
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DF
     jr   nz, label_EBE66
     ld   h, b
     sub  a, c
@@ -14631,7 +14720,8 @@ label_EBEF3::
     db   $EB ; Undefined instruction
     inc  d
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -14665,7 +14755,8 @@ label_EBF4C::
     ld   b, $FF
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     rst  $38
@@ -14680,7 +14771,8 @@ label_EBF4C::
     rst  $38
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     rst  $38

--- a/src/disassembled-banks/Bank59.asm
+++ b/src/disassembled-banks/Bank59.asm
@@ -86,7 +86,8 @@ label_EC048::
     cp   $03
     cp   $03
     cp   $EF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E7
     jr   label_EC048
     inc  e
     pop  af
@@ -695,8 +696,10 @@ label_EC2E2::
     ld    hl, sp+$5F
     or   b
     rst  $38
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
+    db   $10
+    db   $F7
     jr   c, label_EC2E2
     inc  a
 
@@ -2001,7 +2004,8 @@ label_EC605::
     rst  $38
     nop
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F7
     ld   [label_12CA], sp
     ld   h, e
     add  hl, bc
@@ -2026,7 +2030,8 @@ label_EC8B7::
     call z, label_FD38
     ld    hl, sp+$F9
     jr   nc, label_EC8B7
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     rst  $38
     rst  $38
     rst  $38
@@ -2248,7 +2253,8 @@ label_EC997::
     ld   de, $93FD
     ld    hl, sp+$10
     db   $FC ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     jr   label_ECA36
     ld   [label_C7F], sp
     ld   a, a
@@ -2336,7 +2342,8 @@ label_EC997::
     sbc  a, [hl]
     nop
     cp   h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E8
     nop
     nop
     nop
@@ -2653,14 +2660,17 @@ label_ECB39::
     ret  nz
     ld   a, [bc]
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     inc  d
     dec  de
     jr   label_ECB8E
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $17
     jr   label_ECB9C
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     rrca
 
 label_ECB80::
@@ -2717,7 +2727,8 @@ label_ECB9C::
 
 label_ECBB5::
     ret  nc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $70
     ld    hl, sp+$08
     db   $E8 ; add  sp, d
     jr   label_ECBB5
@@ -3031,7 +3042,8 @@ label_ECC5E::
     ret  nz
     add  a, b
     ld   l, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     rra
     ld   c, b
     scf
@@ -4873,7 +4885,8 @@ label_ED248::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     sub  a, b
     ld   h, b
     ld    hl, sp+$30
@@ -5764,7 +5777,8 @@ label_ED795::
     nop
     nop
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     rst  $38
     nop
     add  a, c
@@ -5777,8 +5791,10 @@ label_ED795::
     rst  $38
     ld   b, b
     ld   b, b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $EF
     rst  $38
     nop
     add  a, c
@@ -5790,7 +5806,8 @@ label_ED795::
     rst  $38
     ld   [$FF50], a
     ld   e, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     nop
     nop
     nop
@@ -6351,7 +6368,8 @@ label_ED9E6::
     ld   bc, $BB45
     rst  $38
     ld   bc, $EF11
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     rst  $38
     nop
     add  a, c
@@ -6362,8 +6380,10 @@ label_ED9E6::
     ld   a, [hl]
     rst  $38
     nop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
+    db   $10
+    db   $EF
     ld   [$FFF7], sp
     nop
     add  a, c
@@ -7450,7 +7470,8 @@ label_EE03D::
     ret  nz
     nop
     jr   nz, label_EE014
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
     sub  a, b
     ld   h, b
     ld   [hl], b
@@ -7551,11 +7572,13 @@ label_EE09F::
     ccf
     rrca
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $4F
     ldd  [hl], a
     ld   [hl], d
     dec  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_EE0EF
     nop
     nop
@@ -7664,7 +7687,8 @@ label_EE138::
 label_EE139::
     ld   a, $38
     rlca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_EE157
     nop
     nop
@@ -7820,7 +7844,8 @@ label_EE1E2::
     ld   [bc], a
     ld   [de], a
     dec  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     jr   nz, label_EE20F
     nop
     nop
@@ -8373,9 +8398,12 @@ label_EE42E::
     nop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $80
+    db   $10
+    db   $80
+    db   $10
+    db   $80
     ld   [$82C0], sp
     nop
     ld   a, h
@@ -8733,7 +8761,8 @@ label_EE59E::
     ld   a, b
     rst  0
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld    hl, sp+$FF
     rst  $38
     rst  $38
@@ -9711,7 +9740,8 @@ label_EE984::
     ret  nz
     ccf
     jr   nz, label_EE9F4
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   [label_80F], sp
     rlca
     inc  b
@@ -9843,7 +9873,8 @@ label_EEA26::
     rst  $38
     add  a, b
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ldi  [hl], a
     rst  $38
     rra
@@ -9865,13 +9896,15 @@ label_EEA26::
     dec  bc
     inc  c
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3F
     jr   nz, label_EEB0B
     ld   b, c
     xor  $91
     ld   a, a
     ld   a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EF
     ld   a, [$FF0F]
     db   $FC ; Undefined instruction
     inc  bc
@@ -10077,7 +10110,8 @@ label_EEB63::
     dec  bc
     inc  c
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $09
     ldd  [hl], a
     ld   l, e
     ld   d, b
@@ -10255,8 +10289,10 @@ label_EEC17::
     db   $F4 ; Undefined instruction
     nop
     db   $EB ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $AF
+    db   $10
+    db   $F0
     rrca
     ld   a, b
     add  a, a
@@ -10281,7 +10317,8 @@ label_EEC17::
     rst  $38
     inc  d
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -10523,7 +10560,8 @@ label_EED0E::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     rst  $38
     rst  $38
     rst  $38
@@ -10553,7 +10591,8 @@ label_EED0E::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     rst  $38
     rst  $38
     rst  $38
@@ -10583,7 +10622,8 @@ label_EED0E::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   h, b
     rst  $38
     or   b
@@ -10939,7 +10979,8 @@ label_EEF17::
     db   $FD ; Undefined instruction
     ld   [bc], a
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $AB
     ld   d, h
     rst  $20
     jr   label_EEF02
@@ -11170,7 +11211,8 @@ label_EF00A::
     ld   h, b
     ccf
     jr   nc, label_EF03C
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
 
 label_EF01F::
     jr   label_EF01F
@@ -11214,7 +11256,8 @@ label_EF03C::
     cp   $20
     rst  $38
     jr   nz, label_EF056
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   label_EF05A
     ld   [label_8FF], sp
     rst  $38
@@ -11870,7 +11913,8 @@ label_EF30B::
     ld   b, b
     rst  $38
     jr   nz, label_EF38A
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
 
 label_EF38D::
     ld    hl, sp+$07
@@ -12001,9 +12045,12 @@ label_EF3D1::
     dec  a
     jr   nz, label_EF45F
     jr   nz, label_EF443
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1E
+    db   $10
+    db   $1E
+    db   $10
+    db   $0F
     ld   [label_80F], sp
     rrca
     ld   [$00FF], sp
@@ -12132,7 +12179,8 @@ label_EF49F::
     jr   nc, label_EF4E1
     jr   nz, label_EF503
     jr   nz, label_EF505
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
     ld   [label_40F], sp
     rlca
     ld  [$FF00+C], a
@@ -12452,7 +12500,8 @@ label_EF61C::
     ld   b, b
     rst  $38
     jr   nz, label_EF646
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   [label_9FF], sp
     rst  $38
     dec  b
@@ -12583,9 +12632,12 @@ label_EF6D3::
     and  b
     ccf
     jr   nz, label_EF6FA
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $1F
+    db   $10
+    db   $FC
     inc  b
     db   $FC ; Undefined instruction
     inc  b
@@ -12685,7 +12737,8 @@ label_EF6FA::
     ld   b, b
     ld   h, b
     jr   nz, label_EF7CB
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $79
     add  hl, bc
     dec  a
     dec  b
@@ -12787,16 +12840,24 @@ label_EF7BE::
     adc  a, a
     adc  a, b
     cp   a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $17
+    db   $10
+    db   $17
+    db   $10
+    db   $13
+    db   $10
+    db   $93
     sub  a, b
     sub  a, c
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $90
+    db   $10
+    db   $98
+    db   $10
+    db   $FE
     ld   [bc], a
     rst  $38
     ld   bc, label_1FF
@@ -12888,7 +12949,8 @@ label_EF82B::
     rst  $38
     ld   [label_10FF], sp
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   nz, label_EF84C
     jr   nz, label_EF84E
     ld   b, b
@@ -12937,7 +12999,8 @@ label_EF82B::
     add  a, b
     add  a, b
     ld   [$FFE0], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   [$C408], sp
     call nz, label_2424
     ldi  [hl], a
@@ -12946,7 +13009,8 @@ label_EF82B::
     inc  bc
     inc  c
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   hl, label_2221
     ldi  [hl], a
     inc  h
@@ -12971,8 +13035,10 @@ label_EF8AE::
     jr   label_EF8AE
     ld   [label_1079], sp
     ld   [hl], c
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $71
+    db   $10
+    db   $70
     jr   nz, label_EF91D
     jr   nz, label_EF91F
 
@@ -12990,15 +13056,20 @@ label_EF8C1::
     ld   [rNR41], a
     ld   [rLCDC], a
     inc  e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1E
 
 label_EF8D3::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1E
 
 label_EF8D5::
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1F
+    db   $10
+    db   $3F
+    db   $10
+    db   $3F
     jr   nz, label_EF95C
     jr   nc, label_EF8DE
     ld   d, b
@@ -13022,8 +13093,10 @@ label_EF8E7::
     jr   nz, label_EF8D3
     jr   nz, label_EF8D5
     jr   nz, label_EF8E7
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
+    db   $10
+    db   $F8
     ld   [label_8F8], sp
     db   $FC ; Undefined instruction
     inc  b
@@ -13137,7 +13210,8 @@ label_EF95C::
     jp   nc, label_D112
     ld   de, label_1090
     sub  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $8E
     ld   c, $81
     ld   bc, label_2222
     call nz, label_4C4
@@ -13153,7 +13227,8 @@ label_EF95C::
     ldi  [hl], a
     ldi  [hl], a
     ld   de, label_1011
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
     inc  c
     inc  bc
     inc  bc
@@ -13383,7 +13458,8 @@ label_EFA21::
     nop
     rrca
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   label_EFAA4
     rrca
     rrca
@@ -14065,8 +14141,10 @@ label_EFD89::
     rst  $38
     ld   a, [$FF10]
     or   b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $A0
     jr   nc, label_EFD89
     and  b
     rst  0
@@ -14187,7 +14265,8 @@ label_EFE01::
     rst  $38
     db   $FC ; Undefined instruction
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     and  b
     rst  $38
     ld   b, b
@@ -14378,7 +14457,8 @@ label_EFE44::
     ld   a, a
     ld   a, a
     rst  $28
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3C
     jp   label_EE09F
     adc  a, $31
     db   $E3 ; Undefined instruction
@@ -14442,7 +14522,8 @@ label_EFE44::
     sbc  a, $29
     rst  $38
     stop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     rst  $38
     rst  $38
     rst  $38

--- a/src/disassembled-banks/Bank59.asm
+++ b/src/disassembled-banks/Bank59.asm
@@ -5364,9 +5364,9 @@ label_ED730::
     nop
     and  $19
     and  $19
-    jp   [hl]
+    jp   hl
     rra
-    jp   [hl]
+    jp   hl
     rra
     ld   h, [hl]
     rra
@@ -10089,7 +10089,7 @@ label_EEB63::
     inc  b
     cp   l
     inc  bc
-    jp   [hl]
+    jp   hl
     rla
     rst  $20
     ld   e, $DF
@@ -13103,7 +13103,7 @@ label_EF944::
     rst  $38
     jr   nz, label_EF944
     ld   d, b
-    jp   [hl]
+    jp   hl
     sbc  a, b
     db   $F4 ; Undefined instruction
     inc  c
@@ -13430,7 +13430,7 @@ label_EFAA4::
     ld   [hl], b
     and  b
     ld   a, [$FFF0]
-    jp   [hl]
+    jp   hl
     jr   label_EFB01
     ld   a, a
     ld   b, b

--- a/src/disassembled-banks/Bank6.asm
+++ b/src/disassembled-banks/Bank6.asm
@@ -1897,7 +1897,8 @@ label_18BF0::
     inc  bc
 
 label_18BF8::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     db   $F4 ; Undefined instruction
     inc  c
     ld   a, [$FFF0]
@@ -1907,7 +1908,8 @@ label_18BF8::
 label_18C00::
     db   $F4 ; Undefined instruction
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     db   $F4 ; Undefined instruction
     inc  c
     ld   a, [$FFF0]
@@ -2770,7 +2772,8 @@ label_1912F::
     inc  d
     inc  d
     inc  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     inc  b
     nop
     call label_C05
@@ -2932,7 +2935,8 @@ label_191FA::
     db   $F4 ; Undefined instruction
     ld   [label_264], sp
     db   $F4 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
     ld   [bc], a
     inc  b
     ld    hl, sp+$68
@@ -2944,7 +2948,8 @@ label_191FA::
     inc  b
     ld   [label_26C], sp
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6E
     ld   [bc], a
     db   $F4 ; Undefined instruction
     ld    hl, sp+$66
@@ -2956,7 +2961,8 @@ label_191FA::
     db   $F4 ; Undefined instruction
     ld   [label_2262], sp
     db   $F4 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     ldi  [hl], a
     inc  b
     ld    hl, sp+$6E
@@ -2968,7 +2974,8 @@ label_191FA::
     inc  b
     ld   [label_226A], sp
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     ldi  [hl], a
 
 label_1927A::
@@ -2982,7 +2989,8 @@ label_1927A::
     db   $F4 ; Undefined instruction
     ld   [label_364], sp
     db   $F4 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
     inc  bc
     inc  b
     ld    hl, sp+$68
@@ -2994,7 +3002,8 @@ label_1927A::
     inc  b
     ld   [label_36C], sp
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6E
     inc  bc
     db   $F4 ; Undefined instruction
     ld    hl, sp+$66
@@ -3006,7 +3015,8 @@ label_1927A::
     db   $F4 ; Undefined instruction
     ld   [label_2362], sp
     db   $F4 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     inc  hl
     inc  b
     ld    hl, sp+$6E
@@ -3018,7 +3028,8 @@ label_1927A::
     inc  b
     ld   [label_236A], sp
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     inc  hl
 
 label_192BA::
@@ -3397,7 +3408,8 @@ label_19523::
     db   $F4 ; Undefined instruction
     ld   [label_2372], sp
     db   $F4 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $70
     inc  hl
     inc  b
     ld    hl, sp+$74
@@ -3409,7 +3421,8 @@ label_19523::
     inc  b
     ld   [label_37A], sp
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7A
     inc  hl
     db   $F4 ; Undefined instruction
     ld    hl, sp+$70
@@ -3421,7 +3434,8 @@ label_19523::
     db   $F4 ; Undefined instruction
     ld   [label_2278], sp
     db   $F4 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $70
     ldi  [hl], a
     inc  b
     ld    hl, sp+$74
@@ -3433,7 +3447,8 @@ label_19523::
     inc  b
     ld   [label_27A], sp
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7A
     ldi  [hl], a
     db   $F4 ; Undefined instruction
     ld    hl, sp+$70
@@ -3445,7 +3460,8 @@ label_19523::
     db   $F4 ; Undefined instruction
     ld   [label_2272], sp
     db   $F4 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $70
     ldi  [hl], a
     inc  b
     ld    hl, sp+$74
@@ -3457,7 +3473,8 @@ label_19523::
     inc  b
     ld   [label_2276], sp
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $74
     ldi  [hl], a
     db   $F4 ; Undefined instruction
     ld    hl, sp+$7C
@@ -3469,7 +3486,8 @@ label_19523::
     db   $F4 ; Undefined instruction
     ld   [label_227E], sp
     db   $F4 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7C
     ldi  [hl], a
     inc  b
     ld    hl, sp+$74
@@ -3481,7 +3499,8 @@ label_19523::
     inc  b
     ld   [label_2276], sp
     inc  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $74
     ldi  [hl], a
 
 label_195A3::
@@ -4211,7 +4230,8 @@ label_199C8::
     ldi  [hl], a
     ld   a, h
     ldi  [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $02
     ld   [de], a
     ld   [bc], a
     inc  d
@@ -4219,7 +4239,8 @@ label_199C8::
     ld   d, $02
     ld   [de], a
     ldi  [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $22
     ld   d, $22
     inc  d
     ldi  [hl], a
@@ -4953,7 +4974,8 @@ label_19E63::
     stop
     ld   l, b
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   l, d
     ld   [bc], a
     nop
@@ -4965,7 +4987,8 @@ label_19E63::
     stop
     ld   l, b
     ld   [bc], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   l, d
     ld   [bc], a
     nop
@@ -4977,7 +5000,8 @@ label_19E63::
     stop
     ld   l, d
     ldi  [hl], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   l, b
     ldi  [hl], a
 
@@ -6254,7 +6278,8 @@ label_1A61D::
     stop
     ld   a, [$FF00]
     ld   a, [$FF00]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     nop
     ld   a, [$FF00]
     stop
@@ -7519,7 +7544,8 @@ label_1AE1E::
     ld   h, $00
     ld   [label_2662], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     ld   h, $F0
     ld   [label_66E], sp
     nop
@@ -7528,7 +7554,8 @@ label_1AE1E::
     ld   h, $00
     ld   [label_2668], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
     ld   h, $F0
     ld   [label_266E], sp
     nop
@@ -7537,7 +7564,8 @@ label_1AE1E::
     ld   h, $00
     ld   [label_2668], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
     ld   h, $F0
     ld   [bc], a
     ld   l, [hl]
@@ -8998,14 +9026,17 @@ label_1B762::
     jr   nz, label_1B77D
     ld   a, [$FF6A]
     ld   b, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
     ld   l, d
     jr   nz, label_1B785
 
 label_1B775::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6A
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     ld   l, d
     ld   h, b
     nop
@@ -9058,18 +9089,22 @@ label_1B7A7::
 
 label_1B7AB::
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     rst  $38
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F8
 
 label_1B7B2::
     rst  $38
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     rst  $38
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     rst  $38
     nop
     ld   [$FFE0], a
@@ -9116,7 +9151,8 @@ label_1B7EB::
     jr   nz, label_1B7ED
 
 label_1B7ED::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $64
     nop
     nop
     jr   label_1B857
@@ -9126,7 +9162,8 @@ label_1B7F5::
     nop
     ld   h, [hl]
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
 
 label_1B7FA::
     ld   h, [hl]
@@ -9171,7 +9208,8 @@ label_1B815::
     jr   nz, label_1B82D
 
 label_1B82D::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     nop
     jr   label_1B832
@@ -9181,7 +9219,8 @@ label_1B82D::
 
 label_1B837::
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
 
 label_1B83A::
     rst  $38
@@ -9278,11 +9317,14 @@ label_1B8B7::
     ldi  [hl], a
 
 label_1B8BF::
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
+    db   $10
+    db   $F0
 
 label_1B8C3::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   a, [$FFF0]
     ld   de, label_1B8B7
     call label_3BC0
@@ -9660,7 +9702,8 @@ label_1BAF4::
 label_1BAFB::
     rrca
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   de, label_1011
     rrca
 

--- a/src/disassembled-banks/Bank6.asm
+++ b/src/disassembled-banks/Bank6.asm
@@ -66,7 +66,7 @@ label_18049::
     ld   b, b
     ret  c
     ld   b, b
-    jp   [hl]
+    jp   hl
     ld   b, b
     call label_3B12
     ld   a, [$DB15]

--- a/src/disassembled-banks/Bank60.asm
+++ b/src/disassembled-banks/Bank60.asm
@@ -4596,7 +4596,7 @@ label_F1435::
     nop
     db   $EB ; Undefined instruction
     inc  d
-    jp   [hl]
+    jp   hl
     add  a, b
     ld   de, label_F08
     nop
@@ -5780,7 +5780,7 @@ label_F18E4::
     rst  $38
     sbc  a, b
     ld   a, a
-    jp   [hl]
+    jp   hl
     db   $E8 ; add  sp, d
     rst  $30
     or   $1F
@@ -6846,7 +6846,7 @@ label_F1CA4::
     rst  $18
     ld   [$FFF9], a
     ret  nz
-    jp   [hl]
+    jp   hl
     ld  [$FF00+C], a
     ld    hl, sp+$F8
     rst  $38

--- a/src/disassembled-banks/Bank60.asm
+++ b/src/disassembled-banks/Bank60.asm
@@ -533,7 +533,8 @@ label_F00F7::
     ld   a, a
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   nz, label_F0255
     ld   b, b
     rst  $38
@@ -1058,7 +1059,8 @@ label_F041F::
     rst  $38
     nop
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     nop
     rst  $38
     nop
@@ -2010,7 +2012,8 @@ label_F0891::
     ei
     inc  d
     ei
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_F0891
     ld   b, b
     rst  $38
@@ -2753,7 +2756,8 @@ label_F0BF5::
     ei
     ld   [label_8FF], sp
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   z, label_F0BF5
     ld   [rIE], a
 
@@ -2858,7 +2862,8 @@ label_F0C31::
     ld   a, a
     ld   b, c
     rst  $38
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     jr   nz, label_F0C73
     add  a, b
     ld   a, a
@@ -3127,7 +3132,8 @@ label_F0D90::
     rrca
     ld   [label_F1057], sp
     sub  a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     or   $FF
     ld   a, h
     db   $FD ; Undefined instruction
@@ -3136,7 +3142,8 @@ label_F0D90::
     cp   a
     ld   [label_F10F7], sp
     xor  [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EE
     or   $08
     ld   a, l
     add  a, c
@@ -3207,7 +3214,8 @@ label_F0E00::
     dec  b
     xor  d
     daa
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $33
     ld   c, b
     jr   nc, label_F0E00
     jr   nc, label_F0E02
@@ -4018,7 +4026,8 @@ label_F1057::
     call nc, label_F036
     dec  h
     dec  h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $55
     inc  e
     ld   e, l
     inc  de
@@ -4122,8 +4131,10 @@ label_F11F6::
     ld   h, b
     jr   nz, label_F1285
     jr   nz, label_F1249
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
+    db   $10
+    db   $B8
     jr   label_F11D7
     inc  e
     sub  a, [hl]
@@ -4298,7 +4309,8 @@ label_F12E0::
     inc  bc
     jr   z, label_F130E
     ld   [de], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $80
     ld   c, [hl]
     inc  d
     ld   [$007F], sp
@@ -4310,7 +4322,8 @@ label_F12E0::
     rst  $10
     ld   [label_2ED], sp
     inc  d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $91
     add  a, c
 
 label_F1304::
@@ -4330,7 +4343,8 @@ label_F130E::
     xor  d
     ld   b, l
     ld   l, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $09
     jr   nz, label_F133D
     jr   label_F131D
     jr   nz, label_F1399
@@ -4415,7 +4429,8 @@ label_F133D::
     ld   a, [$FF00+C]
     ld   l, a
     jr   nz, label_F1364
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $BF
     nop
     ld   a, a
     nop
@@ -4511,7 +4526,8 @@ label_F133D::
     cpl
     call nc, label_F142
     ld   l, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     or   d
     scf
     ld   [$FFEF], a
@@ -4624,7 +4640,8 @@ label_F144F::
 label_F146B::
     nop
     sub  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $B2
     nop
     ld   a, [$FFF1]
     rlc  h
@@ -4853,13 +4870,16 @@ label_F14E9::
     ld   h, e
     inc  c
     ccf
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CF
     ret  nz
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7F
     ld   b, b
     rra
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     inc  b
     adc  a, a
     ld   [bc], a
@@ -4978,7 +4998,8 @@ label_F15D4::
     ret  nz
     ret  z
     jr   nz, label_F159F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     and  b
     adc  a, d
     nop
@@ -5230,7 +5251,8 @@ label_F1706::
     ld   h, b
     ld   h, $20
     add  hl, de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9C
     sub  a, b
     adc  a, h
     inc  c
@@ -5279,7 +5301,8 @@ label_F1706::
     add  a, c
     rst  $38
     ld   [rNR22], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     rst  $28
     rst  $18
     rst  $18
@@ -5298,7 +5321,8 @@ label_F1706::
     nop
 
 label_F1797::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $20
     nop
     ld   [rJOYP], a
     ld   [hl], b
@@ -5624,7 +5648,8 @@ label_F18E4::
     pop  bc
     ld   c, d
     ld   b, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9F
     sbc  a, [hl]
     ld   [hl], $00
     ld   a, [hli]
@@ -5727,7 +5752,8 @@ label_F18E4::
     ret  nc
     sub  a, b
     sub  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $B8
     nop
     dec  b
     db   $FC ; Undefined instruction
@@ -6346,7 +6372,8 @@ label_F1B11::
     ld   h, b
     nop
     jr   label_F1C57
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     rlca
     rst  $38
     sbc  a, [hl]
@@ -6360,14 +6387,16 @@ label_F1B11::
     rra
     rst  $38
     ld    hl, sp+$FF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   bc, $83FE
     ld   a, h
     ld   a, a
     add  a, b
     adc  a, a
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ld   h, b
     sbc  a, a
     rrca
@@ -7163,24 +7192,38 @@ label_F1F42::
 
 label_F2000::
     ld   bc, $0110
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $02
+    db   $10
+    db   $01
     inc  d
     ld   bc, $0114
     inc  d
     ld   bc, label_314
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $04
+    db   $10
+    db   $01
     inc  d
     ld   bc, $0114
     inc  d
@@ -7189,32 +7232,56 @@ label_F2000::
     ld   bc, $0114
     inc  d
     dec  b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $06
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $07
+    db   $10
+    db   $01
     inc  d
     ld   bc, label_814
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $09
+    db   $10
+    db   $0A
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $0B
+    db   $10
+    db   $0C
+    db   $10
+    db   $01
     inc  d
     ld   bc, $0114
     inc  d
@@ -7223,93 +7290,156 @@ label_F2000::
     ld   bc, $0114
     inc  d
     dec  c
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $0E
+    db   $10
+    db   $0F
+    db   $10
+    db   $01
     inc  d
     ld   bc, label_1014
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
+    db   $10
+    db   $12
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $13
+    db   $10
+    db   $14
     inc  d
     dec  d
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
+    db   $10
+    db   $16
+    db   $10
+    db   $17
+    db   $10
+    db   $18
+    db   $10
+    db   $19
+    db   $10
+    db   $01
     inc  d
     ld   bc, $0114
     inc  d
     ld   bc, label_1A14
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $1B
+    db   $10
+    db   $01
     inc  d
     ld   bc, $0114
     inc  d
     inc  e
     inc  d
     dec  e
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1E
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $1F
+    db   $10
+    db   $20
+    db   $10
+    db   $21
+    db   $10
+    db   $22
+    db   $10
+    db   $23
+    db   $10
+    db   $01
+    db   $10
+    db   $01
+    db   $10
+    db   $24
+    db   $10
+    db   $25
+    db   $10
+    db   $11
+    db   $10
+    db   $26
+    db   $10
+    db   $01
     inc  d
     ld   bc, $0114
     inc  d
     daa
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
+    db   $10
+    db   $29
+    db   $10
+    db   $2A
+    db   $10
+    db   $01
+    db   $10
+    db   $2B
+    db   $10
+    db   $2C
+    db   $10
+    db   $2D
     inc  d
     ld   l, $14
     cpl
     inc  d
     jr   nc, label_F2120
     ld   sp, label_3210
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $33
+    db   $10
+    db   $34
+    db   $10
+    db   $34
+    db   $10
+    db   $34
+    db   $10
+    db   $34
+    db   $10
+    db   $35
     inc  d
     inc  [hl]
     inc  d
@@ -7317,23 +7447,40 @@ label_F2000::
 
 label_F2120::
     scf
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $38
+    db   $10
+    db   $34
+    db   $10
+    db   $39
+    db   $10
+    db   $3A
+    db   $10
+    db   $3B
+    db   $10
+    db   $3C
+    db   $10
+    db   $3D
+    db   $10
+    db   $3E
+    db   $10
+    db   $3F
+    db   $10
+    db   $40
+    db   $10
+    db   $41
+    db   $10
+    db   $42
+    db   $10
+    db   $43
+    db   $10
+    db   $44
+    db   $10
+    db   $01
+    db   $10
+    db   $45
+    db   $10
+    db   $46
     inc  d
     ld   b, a
     inc  d
@@ -7360,13 +7507,20 @@ label_F2120::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $4A
+    db   $10
+    db   $4B
+    db   $10
+    db   $4C
+    db   $10
+    db   $4D
+    db   $10
+    db   $4E
+    db   $10
+    db   $4F
+    db   $10
+    db   $50
     inc  d
     ld   d, c
     inc  d
@@ -7396,13 +7550,20 @@ label_F2120::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $55
+    db   $10
+    db   $56
+    db   $10
+    db   $11
+    db   $10
+    db   $11
+    db   $10
+    db   $57
+    db   $10
+    db   $01
+    db   $10
+    db   $01
     inc  d
     ld   e, b
     inc  d
@@ -7434,20 +7595,30 @@ label_F2120::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C9
+    db   $10
+    db   $5D
+    db   $10
+    db   $5E
+    db   $10
+    db   $11
+    db   $10
+    db   $5F
+    db   $10
+    db   $01
+    db   $10
+    db   $60
+    db   $10
+    db   $61
+    db   $10
+    db   $62
     inc  d
     ld   h, e
     inc  d
     ld   h, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $65
     stop
     stop
     stop
@@ -7468,20 +7639,30 @@ label_F2120::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
+    db   $10
+    db   $67
+    db   $10
+    db   $68
+    db   $10
+    db   $69
+    db   $10
+    db   $6A
+    db   $10
+    db   $01
+    db   $10
+    db   $6B
+    db   $10
+    db   $6C
     inc  d
     ld   l, l
     inc  d
     ld   l, [hl]
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6F
+    db   $10
+    db   $70
     stop
     stop
     stop
@@ -7502,22 +7683,30 @@ label_F2120::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $71
     inc  d
     ld   [hl], d
     inc  d
     ld   [hl], e
     inc  d
     ld   [hl], h
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $75
+    db   $10
+    db   $76
+    db   $10
+    db   $77
     inc  d
     ld   a, b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $79
+    db   $10
+    db   $7A
+    db   $10
+    db   $7B
+    db   $10
+    db   $7C
     stop
     stop
     stop
@@ -7538,7 +7727,8 @@ label_F2120::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7D
     inc  d
     ld   a, [hl]
     inc  d
@@ -7551,11 +7741,16 @@ label_F2120::
     add  a, d
     inc  d
     add  a, e
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $84
+    db   $10
+    db   $85
+    db   $10
+    db   $86
+    db   $10
+    db   $87
+    db   $10
+    db   $88
     stop
     stop
     stop
@@ -7576,18 +7771,30 @@ label_F2120::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $89
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8B
+    db   $10
+    db   $8C
+    db   $10
+    db   $8D
+    db   $10
+    db   $8E
+    db   $10
+    db   $8F
+    db   $10
+    db   $90
     stop
     stop
     stop
@@ -7608,20 +7815,30 @@ label_F2120::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $89
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $91
     inc  d
     sub  a, d
     inc  d
     sub  a, e
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $94
+    db   $10
+    db   $95
+    db   $10
+    db   $96
     stop
     stop
     stop
@@ -7642,13 +7859,20 @@ label_F2120::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $89
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $97
     inc  d
     sbc  a, b
     inc  d
@@ -7657,7 +7881,8 @@ label_F2120::
     sbc  a, d
     inc  d
     sbc  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9C
     stop
     stop
     stop
@@ -7678,13 +7903,20 @@ label_F2120::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $89
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $9D
     inc  d
     sbc  a, [hl]
     inc  d
@@ -7693,7 +7925,8 @@ label_F2120::
     and  b
     inc  d
     and  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A2
     stop
     stop
     stop
@@ -7714,21 +7947,30 @@ label_F2120::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $89
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $A3
     inc  d
     and  h
     inc  d
     and  l
     inc  d
     and  [hl]
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A7
+    db   $10
+    db   $A8
     inc  d
     nop
     stop
@@ -7750,20 +7992,30 @@ label_F2120::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $89
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $A9
+    db   $10
+    db   $AA
+    db   $10
+    db   $AB
     inc  d
     xor  h
     inc  d
     xor  l
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $AE
+    db   $10
+    db   $AF
+    db   $10
+    db   $B0
     inc  d
     nop
     stop
@@ -7785,12 +8037,18 @@ label_F2120::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $89
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $B1
+    db   $10
+    db   $01
     inc  d
     or   d
     inc  d
@@ -7799,8 +8057,10 @@ label_F2120::
     or   h
     inc  d
     or   l
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $B6
+    db   $10
+    db   $B7
     inc  d
     nop
     stop
@@ -7822,11 +8082,16 @@ label_F2120::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $89
+    db   $10
+    db   $8A
+    db   $10
+    db   $B8
+    db   $10
+    db   $B9
+    db   $10
+    db   $01
     inc  d
     ld   bc, $BA14
     inc  d
@@ -7860,10 +8125,14 @@ label_F2120::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C0
+    db   $10
+    db   $C1
+    db   $10
+    db   $C2
+    db   $10
+    db   $01
     inc  d
     ld   bc, $0114
     inc  d
@@ -7896,8 +8165,10 @@ label_F2120::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C9
+    db   $10
+    db   $01
     inc  d
     ld   bc, $0114
     inc  d
@@ -7930,8 +8201,10 @@ label_F2120::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C9
+    db   $10
+    db   $01
     inc  d
     ld   bc, $0114
     inc  d
@@ -7969,8 +8242,10 @@ label_F2120::
     stop
     stop
     stop
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C9
+    db   $10
+    db   $01
     inc  d
     ld   bc, $0114
     inc  d
@@ -8005,7 +8280,8 @@ label_F2120::
     ret  c
     inc  d
     jp   nc, label_D310
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D4
     inc  d
     push de
     inc  d
@@ -8017,9 +8293,12 @@ label_F2120::
     rst  $10
     inc  d
     ret  c
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $D8
+    db   $10
+    db   $D9
+    db   $10
+    db   $01
     inc  d
     ld   bc, $0114
     inc  d
@@ -8028,12 +8307,16 @@ label_F2120::
     ld   bc, $0114
     inc  d
     ld   bc, $DA14
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CF
     inc  d
     db   $DB
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $DC
+    db   $10
+    db   $DD
+    db   $10
+    db   $8A
     inc  d
     adc  a, d
     inc  d
@@ -8045,8 +8328,10 @@ label_F2120::
     inc  d
     sbc  a, $10
     rst  $18
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E0
+    db   $10
+    db   $E1
     inc  d
     ld  [$FF00+C], a
     inc  d
@@ -8062,9 +8347,12 @@ label_F2120::
     inc  d
     and  $14
     adc  a, d
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $8A
+    db   $10
+    db   $B1
+    db   $10
+    db   $01
     inc  d
     ld   bc, $0114
     inc  d
@@ -8077,11 +8365,14 @@ label_F2642::
     ld   bc, $0114
     inc  d
     ld   bc, $E714
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E8
+    db   $10
+    db   $E9
     inc  d
     ld   [$E814], a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $E9
     inc  d
     ld   [$EB14], a
     inc  d
@@ -8103,8 +8394,10 @@ label_F2642::
     db   $F4 ; Undefined instruction
     inc  d
     cp   b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $B9
+    db   $10
+    db   $01
     inc  d
     ld   bc, $0114
     inc  d
@@ -8117,7 +8410,8 @@ label_F2642::
     ld   bc, $0114
     inc  d
     ld   bc, $F514
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F6
     inc  d
     rst  $30
     inc  d
@@ -8142,9 +8436,12 @@ label_F2642::
     db   $F4 ; Undefined instruction
     inc  d
     cp   b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C1
+    db   $10
+    db   $C2
+    db   $10
+    db   $01
     inc  d
     ld   bc, $0114
     inc  d
@@ -8175,14 +8472,22 @@ label_F2642::
     db   $FC ; Undefined instruction
     inc  d
     adc  a, d
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $A9
+    db   $10
+    db   $C2
+    db   $10
+    db   $01
     inc  d
     ld   bc, $0114
     inc  d
@@ -8205,17 +8510,28 @@ label_F2642::
     xor  c
     ld   d, b
     adc  a, d
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $B1
+    db   $10
+    db   $01
     inc  d
     ld   bc, $0114
     inc  d
@@ -8238,16 +8554,26 @@ label_F2642::
     ld   bc, $B114
     ld   d, b
     adc  a, d
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $B8
+    db   $10
+    db   $B9
+    db   $10
+    db   $01
     inc  d
     ld   bc, $0114
     inc  d
@@ -8274,13 +8600,20 @@ label_F2642::
     cp   b
     ld   d, b
     adc  a, d
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $8A
+    db   $10
+    db   $A9
+    db   $10
+    db   $AA
+    db   $10
+    db   $C2
+    db   $10
+    db   $01
     inc  d
     ld   bc, $0114
     inc  d
@@ -8311,8 +8644,10 @@ label_F2642::
     xor  c
     ld   d, b
     xor  c
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
+    db   $10
+    db   $01
     inc  d
     ld   bc, $0114
     inc  d
@@ -8495,7 +8830,8 @@ label_F2890::
     set  1, c
     dec  b
     ret  nc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A2
     jr   z, label_F292A
     inc  a
     ld   [label_B00], sp
@@ -8545,7 +8881,8 @@ label_F28E0::
 
 label_F28F0::
     ld   a, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     nop
     dec  bc
     ld   c, h
@@ -8560,7 +8897,8 @@ label_F28F0::
     dec  l
     ldi  [hl], a
     db   $EB ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     ccf
     dec  l
     ldi  [hl], a
@@ -8753,49 +9091,56 @@ label_F2960::
     dec  l
     ldi  [hl], a
     db   $EB ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   e, e
     rrca
     ccf
     dec  l
     ldi  [hl], a
     db   $EB ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   e, e
     rrca
     ccf
     dec  l
     ldi  [hl], a
     db   $EB ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   e, e
     rrca
     ccf
     dec  l
     ldi  [hl], a
     db   $EB ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   e, e
     rrca
     ccf
     dec  l
     ldi  [hl], a
     db   $EB ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   e, e
     rrca
     ccf
     dec  l
     ldi  [hl], a
     db   $EB ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FF
     ld   e, e
     rrca
     ccf
     dec  l
     ldi  [hl], a
     db   $EB ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $89
     nop
     nop
     nop

--- a/src/disassembled-banks/Bank7.asm
+++ b/src/disassembled-banks/Bank7.asm
@@ -140,7 +140,8 @@ label_1C0C1::
     ld   b, c
 
 label_1C0CE::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     nop
     nop
 
@@ -309,7 +310,8 @@ label_1C1E6::
 label_1C1E8::
     nop
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
     nop
     db   $F4 ; Undefined instruction
     ld   a, [$FFF4]
@@ -1002,7 +1004,8 @@ label_1C667::
     nop
     ld   [label_26A], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6A
     ld   [bc], a
     nop
     jr   label_1C6E6
@@ -1028,7 +1031,8 @@ label_1C693::
     nop
     ld   [hl], h
     jr   nz, label_1C70C
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $74
     jr   nc, label_1C69C
 
 label_1C69C::
@@ -1754,7 +1758,8 @@ label_1CB6B::
     ld   a, [bc]
     ld   [label_378], sp
     ld   a, [bc]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $78
     inc  hl
     ld   a, [bc]
     jr   label_1CC00
@@ -1776,7 +1781,8 @@ label_1CB8B::
     ld   a, [bc]
     ld   [label_378], sp
     ld   a, [bc]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $78
     inc  hl
     ld   a, [bc]
     jr   label_1CC20
@@ -2142,7 +2148,8 @@ label_1CDF5::
     db   $E8 ; add  sp, d
     ld   [$FFE0], a
     ret  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     jr   label_1CE1F
     jr   nz, label_1CE29
     nop
@@ -2161,7 +2168,8 @@ label_1CE0D::
     nop
     ld   [label_8F8], sp
     ld    hl, sp+$00
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $18
     jr   label_1CE3D
     jr   nz, label_1CE47
 
@@ -2710,7 +2718,8 @@ label_1D173::
     ret
 
 label_1D174::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F0
     nop
     nop
 
@@ -4107,7 +4116,8 @@ label_1D98D::
     nop
 
 label_1D994::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $30
     jr   nz, label_1D9D6
     ld   [bc], a
     ld   [$FFA1], a
@@ -5709,7 +5719,8 @@ label_1E348::
     nop
     ld   [label_752], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     daa
     nop
     jr   label_1E3A7
@@ -5841,7 +5852,8 @@ label_1E422::
     nop
     ld   [label_752], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $52
     daa
     nop
     jr   label_1E481
@@ -7624,7 +7636,8 @@ label_1EF19::
     nop
     ld   [$0064], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $66
     nop
     nop
     ld    hl, sp+$66
@@ -7638,7 +7651,8 @@ label_1EF2E::
 label_1EF32::
     ld   [label_2062], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $60
     jr   nz, label_1EF3A
 
 label_1EF3A::
@@ -7651,7 +7665,8 @@ label_1EF3A::
     nop
     ld   [$006C], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6E
     nop
     nop
     ld    hl, sp+$6E
@@ -7665,7 +7680,8 @@ label_1EF4E::
 label_1EF52::
     ld   [label_206A], sp
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     jr   nz, label_1EF5A
 
 label_1EF5A::
@@ -7695,10 +7711,12 @@ label_1EF79::
     stop
     db   $76 ; Halt
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     ld   a, b
     nop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     ld   a, d
     nop
     ld   [label_1FC18], sp
@@ -7708,7 +7726,8 @@ label_1EF79::
     nop
 
 label_1EF8D::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $08
     db   $76 ; Halt
     jr   nz, label_1EFA2
     nop
@@ -8410,7 +8429,8 @@ label_1F400::
     call label_1FD96
     ld   a, [$FFF0]
     rst  0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $74
     xor  b
     ld   [hl], h
 
@@ -8817,7 +8837,8 @@ label_1F633::
 label_1F643::
     nop
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
     nop
     db   $F4 ; Undefined instruction
     ld   a, [$FFF4]
@@ -8826,7 +8847,8 @@ label_1F64B::
     ld   a, [$FFF4]
     nop
     inc  c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0C
     nop
     db   $F4 ; Undefined instruction
 
@@ -9699,24 +9721,32 @@ label_1FB57::
     add  a, [hl]
     dec  d
     adc  a, b
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $8A
+    db   $10
+    db   $8C
     inc  d
     sbc  a, b
     ld   d, $90
     rla
     sub  a, d
     ld   d, $96
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $8E
+    db   $10
+    db   $80
     dec  d
     add  a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $94
     dec  d
     sbc  a, d
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $AE
+    db   $10
+    db   $9C
+    db   $10
+    db   $A0
     inc  d
     ret  nz
     inc  d
@@ -9776,16 +9806,24 @@ label_1FB99::
     xor  [hl]
     rst  $28
     ld   b, $10
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     ld   bc, label_1001
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $10
     ld   bc, label_1010
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $01
     ld   bc, $0101
     ld   bc, $0101
     ld   bc, $0101

--- a/src/disassembled-banks/Bank8.asm
+++ b/src/disassembled-banks/Bank8.asm
@@ -3991,7 +3991,7 @@ label_2121C::
     ld   [hl], h
     ld   [hl], h
     ld   [hl], h
-    jp   [hl]
+    jp   hl
     ld   a, h
     ld   a, h
     ld   a, h
@@ -4014,7 +4014,7 @@ label_2121C::
     ld   a, a
     ld   [hl], h
     ld   [hl], h
-    jp   [hl]
+    jp   hl
     ld   a, h
     ld   a, h
     ld   a, h
@@ -9170,7 +9170,7 @@ label_227B3::
     call z, label_2289C
     adc  a, $8D
     sbc  a, h
-    jp   [hl]
+    jp   hl
     ld   c, c
     ld   a, a
     sbc  a, l
@@ -10917,7 +10917,7 @@ label_22E9F::
     ld   a, a
     ld   a, a
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     ld   [$DAEB], a
     ld   a, a
     db   $EC ; Undefined instruction
@@ -11655,7 +11655,7 @@ label_23170::
     push hl
     and  $E7
     db   $E8 ; add  sp, d
-    jp   [hl]
+    jp   hl
     ld   [$ECEB], a
     db   $ED ; Undefined instruction
     xor  $EF

--- a/src/disassembled-banks/Bank8.asm
+++ b/src/disassembled-banks/Bank8.asm
@@ -31,24 +31,28 @@ section "bank8",romx,bank[$08]
     ld   a, l
     ld   a, l
     ld   a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     ld   [de], a
     add  hl, sp
     ld   a, [hli]
     dec  hl
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   a, [hli]
     dec  hl
     db   $3A ; ldd  a, [hl]
     dec  sp
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     db   $3A ; ldd  a, [hl]
     dec  sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
     ld   l, l
@@ -58,7 +62,8 @@ section "bank8",romx,bank[$08]
     jr   label_20057
     ld   a, [de]
     dec  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     ld   [de], a
     ld   l, b
     ld   l, b
@@ -67,10 +72,12 @@ section "bank8",romx,bank[$08]
     ld   l, b
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   l, b
     ld   l, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     ld   l, b
     ld   l, b
     ld   l, b
@@ -86,7 +93,8 @@ section "bank8",romx,bank[$08]
     inc  e
     dec  e
     ld   e, $1F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     ld   l, b
     inc  de
     ld   l, b
@@ -249,7 +257,8 @@ label_20108::
 label_2010C::
     jr   z, label_2011F
     jr   c, label_20123
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
     ld   [de], a
     jr   c, label_2013E
     ld   h, [hl]
@@ -308,7 +317,8 @@ label_20146::
     dec  d
     inc  b
     dec  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     nop
     ld   bc, label_1110
     nop
@@ -317,10 +327,12 @@ label_20146::
 label_20158::
     inc  b
     dec  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     nop
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     nop
     inc  bc
     inc  d
@@ -330,11 +342,13 @@ label_20158::
     ld   de, $0102
     ld   d, $17
     ld   b, $07
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     nop
     ld   bc, label_1716
     ld   b, $07
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     nop
     inc  bc
     ld   d, $17
@@ -531,13 +545,16 @@ label_20247::
     ld   l, b
     ld   l, b
     ld   de, label_1312
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   l, b
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     ld   l, b
     ld   a, b
@@ -639,7 +656,8 @@ label_202C6::
     ld   b, $06
     dec  bc
     ld   de, label_130B
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0B
     ld   [de], a
     nop
     ld   b, $07
@@ -849,24 +867,28 @@ label_203B9::
     ld   a, l
     ld   a, l
     ld   a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     ld   [de], a
     add  hl, sp
     ld   a, [hli]
     dec  hl
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   a, [hli]
     dec  hl
     db   $3A ; ldd  a, [hl]
     dec  sp
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     db   $3A ; ldd  a, [hl]
     dec  sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
     ld   l, l
@@ -876,7 +898,8 @@ label_203B9::
     jr   label_20407
     ld   a, [de]
     dec  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     ld   [de], a
     ld   l, b
     ld   l, b
@@ -885,10 +908,12 @@ label_203B9::
     ld   l, b
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   l, b
     ld   l, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     ld   l, b
     ld   l, b
     ld   l, b
@@ -904,7 +929,8 @@ label_203B9::
     inc  e
     dec  e
     ld   e, $1F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     ld   l, b
     inc  de
     ld   l, b
@@ -1067,7 +1093,8 @@ label_204B8::
 label_204BC::
     jr   z, label_204CF
     jr   c, label_204D3
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
     ld   [de], a
     jr   c, label_204EE
     ld   h, [hl]
@@ -1126,7 +1153,8 @@ label_204F6::
     dec  d
     inc  b
     dec  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     nop
     ld   bc, label_1110
     nop
@@ -1135,10 +1163,12 @@ label_204F6::
 label_20508::
     inc  b
     dec  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     nop
     inc  bc
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     nop
     inc  bc
     inc  d
@@ -1148,11 +1178,13 @@ label_20508::
     ld   de, $0102
     ld   d, $17
     ld   b, $07
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     nop
     ld   bc, label_1716
     ld   b, $07
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     nop
     inc  bc
     ld   d, $17
@@ -1349,13 +1381,16 @@ label_205F7::
     ld   l, b
     ld   l, b
     ld   de, label_1312
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   l, b
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     ld   l, b
     ld   a, b
@@ -1457,7 +1492,8 @@ label_20676::
     ld   b, $06
     dec  bc
     ld   de, label_130B
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0B
     ld   [de], a
     nop
     ld   b, $07
@@ -1667,24 +1703,28 @@ label_20769::
     ld   a, l
     ld   a, l
     ld   a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $29
     ld   [de], a
     add  hl, sp
     ld   a, [hli]
     dec  hl
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   a, [hli]
     dec  hl
     db   $3A ; ldd  a, [hl]
     dec  sp
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     db   $3A ; ldd  a, [hl]
     dec  sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
     ld   l, l
@@ -1694,7 +1734,8 @@ label_20769::
     jr   label_207B7
     ld   a, [de]
     dec  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     ld   [de], a
     ld   l, b
     ld   l, b
@@ -1703,10 +1744,12 @@ label_20769::
     ld   l, b
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   l, b
     ld   l, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     ld   l, b
     ld   l, b
     ld   l, b
@@ -1722,7 +1765,8 @@ label_20769::
     inc  e
     dec  e
     ld   e, $1F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     ld   l, b
     inc  de
     ld   l, b
@@ -1885,7 +1929,8 @@ label_20868::
 label_2086C::
     jr   z, label_2087F
     jr   c, label_20883
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $28
     ld   [de], a
     jr   c, label_2089E
     ld   h, [hl]
@@ -1956,13 +2001,16 @@ label_208A6::
 label_208B8::
     ld   l, [hl]
     ld   de, label_136F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $6E
     ld   [de], a
     ld   l, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     inc  b
     dec  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $06
     ld   [de], a
     rlca
     inc  c
@@ -1974,10 +2022,12 @@ label_208B8::
     dec  bc
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     inc  b
     dec  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $06
     ld   [de], a
     rlca
     inc  c
@@ -1989,10 +2039,12 @@ label_208B8::
     dec  bc
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     inc  b
     dec  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $06
     ld   [de], a
     rlca
     inc  c
@@ -2165,13 +2217,16 @@ label_209A7::
     ld   l, b
     ld   l, b
     ld   de, label_1312
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $68
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   l, b
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     ld   l, b
     ld   a, b
@@ -2272,7 +2327,8 @@ label_20A26::
     dec  bc
     dec  bc
     ld   de, label_130B
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0B
     ld   [de], a
     nop
     ld   b, $07
@@ -5789,8 +5845,10 @@ label_2199C::
     and  b
     and  b
     ld   [bc], a
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
+    db   $10
+    db   $30
     inc  b
     inc  bc
     inc  b
@@ -5823,7 +5881,8 @@ label_219C4::
     and  b
     ld   [bc], a
     ld   e, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $30
     jr   nc, label_219FC
     jr   nc, label_219DE
     inc  b
@@ -5847,7 +5906,8 @@ label_219DE::
 
 label_219E5::
     ld   hl, label_21A12
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   bc, $0100
 
 label_219ED::
@@ -5902,7 +5962,8 @@ label_21A12::
     sbc  a, c
     ld   h, b
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0F
     and  b
     and  b
     and  b
@@ -6000,7 +6061,8 @@ label_21A7F::
     and  b
     nop
     jr   nz, label_21A93
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
     jr   nc, label_21A8B
     and  b
     and  b
@@ -6018,14 +6080,17 @@ label_21A8B::
     nop
 
 label_21A93::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $04
     inc  bc
     inc  b
     inc  bc
     ld   [hl], c
     ld   l, e
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $10
+    db   $10
+    db   $0F
 
 label_21A9E::
     and  b
@@ -6040,7 +6105,8 @@ label_21A9E::
     and  b
     ld   [bc], a
     ld   e, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $30
     ld   de, label_3010
     ld   de, label_1111
     ld   bc, $A0A0
@@ -7312,7 +7378,8 @@ label_21FF5::
     nop
     ld   bc, label_22564
     sbc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $01
 
 label_22001::
     ld   h, h
@@ -7597,7 +7664,8 @@ label_220CA::
     sbc  a, e
     ld   [rTIMA], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     xor  [hl]
     jr   nc, label_22165
     sbc  a, e
@@ -7784,7 +7852,8 @@ label_221D9::
     jr   nz, label_221F5
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     sub  a, b
 
 label_221F5::
@@ -8610,7 +8679,8 @@ label_22506::
     ld   b, d
     ld   b, $0E
     rrca
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
     inc  d
@@ -11013,7 +11083,8 @@ label_22E9F::
     inc  c
     dec  c
     ld   c, $0F
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
     ld   a, a
@@ -11882,19 +11953,24 @@ label_23281::
     ld   bc, label_302
     sbc  a, b
     jr   nz, label_232B0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
 
 label_232B0::
@@ -11934,7 +12010,8 @@ label_232B0::
     dec  bc
     inc  d
     ld   d, $17
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     sbc  a, b
     add  a, b
     inc  de
@@ -11957,7 +12034,8 @@ label_232B0::
     sbc  a, b
     and  b
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     ld   h, $27
     jr   z, label_23328
 
@@ -11971,7 +12049,8 @@ label_232FF::
     rra
     jr   nz, label_2334C
     dec  l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     sbc  a, b
     ret  nz
 
@@ -12008,7 +12087,8 @@ label_23328::
     jr   c, label_23370
     ld   b, d
     dec  l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     sbc  a, c
     nop
 
@@ -12039,7 +12119,8 @@ label_2334C::
 label_23352::
     sbc  a, c
     jr   nz, label_23368
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     jr   label_2339A
 
 label_23359::
@@ -12100,7 +12181,8 @@ label_23370::
     ld   e, h
     ld   e, l
     dec  l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     sbc  a, c
     add  a, b
     inc  de
@@ -12127,7 +12209,8 @@ label_2339A::
     sbc  a, c
     and  b
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     jr   label_23420
     ld   l, h
     ld   l, l
@@ -12145,7 +12228,8 @@ label_233B7::
     ld   [hl], e
     ld   d, b
     dec  l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $13
     sbc  a, c
     ret  nz
     inc  de
@@ -12171,7 +12255,8 @@ label_233B7::
     ld   [de], a
     inc  de
     ld   a, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7B
     ld   a, d
     ld   a, e
     ld   a, d
@@ -12185,7 +12270,8 @@ label_233B7::
     ld   a, d
     ld   a, a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     sbc  a, d
     nop
     inc  de
@@ -12201,19 +12287,24 @@ label_233B7::
     ld   bc, label_302
     sbc  a, d
     jr   nz, label_23420
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
 
 label_23420::
@@ -12349,7 +12440,8 @@ label_2349C::
     dec  b
     dec  b
     ld   a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
     inc  d
@@ -12901,15 +12993,22 @@ label_236CE::
     ret  nz
     inc  de
     ld   a, $3F
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
+    db   $10
+    db   $11
+    db   $10
+    db   $11
+    db   $10
+    db   $11
+    db   $10
+    db   $11
+    db   $10
+    db   $11
     inc  b
     dec  b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     dec  a
     ld   a, $99
     ld   [rNR13], a
@@ -13106,7 +13205,8 @@ label_237AE::
     ld   a, a
     ld   a, a
     ld   a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $11
     ld   [de], a
     inc  de
     inc  d
@@ -13148,7 +13248,8 @@ label_237F1::
     ld   a, a
     ld   a, a
     ld   a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $31
     ldd  [hl], a
     inc  sp
     inc  [hl]

--- a/src/disassembled-banks/Bank9.asm
+++ b/src/disassembled-banks/Bank9.asm
@@ -359,7 +359,8 @@ label_2414E::
     ld   c, [hl]
     db   $E8 ; add  sp, d
     ld   c, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $4F
     ld   c, h
     ld   c, a
     and  c
@@ -482,7 +483,8 @@ label_241FF::
     stop
     adc  a, d
     jr   nz, label_241FA
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7C
     ld   de, label_197D
     ld   a, h
     inc  de
@@ -521,7 +523,8 @@ label_2421B::
     rlca
     db   $3A ; ldd  a, [hl]
     ld   e, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $82
     ld   b, l
     db   $3A ; ldd  a, [hl]
     jp   nz, label_E035
@@ -570,9 +573,11 @@ label_2425E::
     ld   a, h
     inc  b
     ld   a, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1C
     add  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1C
     ld   [de], a
     ld   a, [hl]
     add  a, d
@@ -685,7 +690,8 @@ label_242CB::
     rlca
     dec  a
     ld   e, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $44
     dec  sp
     jp   label_3845
     ld   c, c
@@ -836,7 +842,8 @@ label_24385::
     ld   b, $7C
     rlca
     ld   a, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7C
     ld   de, label_137D
     ld   a, h
     inc  d
@@ -991,7 +998,8 @@ label_24438::
     dec  [hl]
     xor  d
     ld   [hl], $BF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7C
     ld   de, label_187D
     ld   a, h
     add  hl, de
@@ -1083,7 +1091,8 @@ label_24482::
     inc  [hl]
     xor  c
     ld   [hl], $BF
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7C
 
 label_244B7::
     ld   de, label_187D
@@ -1156,7 +1165,8 @@ label_244B7::
     stop
     add  a, l
     jr   nz, label_24505
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7C
     ld   de, label_137D
     add  a, b
     add  a, l
@@ -1442,7 +1452,8 @@ label_2463E::
     inc  bc
     db   $FD ; Undefined instruction
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9F
     ld   d, b
     ld   a, h
     ld   [de], a
@@ -1455,7 +1466,8 @@ label_2463E::
     ld   h, d
     sbc  a, $00
     add  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $4B
 
 label_2465C::
     cp   $0B
@@ -1656,7 +1668,8 @@ label_24725::
     ld   a, h
     ld   [$8A7D], sp
     jr   nz, label_24725
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $80
     add  a, e
     ld   de, label_144D
     add  a, c
@@ -1736,7 +1749,8 @@ label_24791::
     nop
     adc  a, d
     stop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7C
     ld   de, label_127E
     ld   a, l
     jr   label_24819
@@ -1817,7 +1831,8 @@ label_247F0::
 
 label_247F2::
     stop
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7C
     ld   de, label_127E
     ld   a, l
     jr   label_24878
@@ -1908,7 +1923,8 @@ label_24820::
 
 label_2485B::
     ld   a, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $7C
     ld   de, label_157D
     ld   a, [hl]
     add  a, d
@@ -2059,7 +2075,8 @@ label_248E6::
     jp   nz, label_923
     ld   h, $E1
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $99
     ld   d, b
     ld   a, h
     add  a, d
@@ -2167,7 +2184,8 @@ label_2495C::
     adc  a, d
     ld   [hl], b
     cpl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C8
     jp   nz, label_C812
     jp   label_C816
     jr   label_24944
@@ -2254,7 +2272,8 @@ label_249DA::
     ccf
     jp   nz, label_3809
     add  a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     rla
     dec  sp
 
@@ -2577,7 +2596,8 @@ label_24B65::
     nop
     inc  bc
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     jp   nz, label_3702
     inc  d
     dec  a
@@ -2644,7 +2664,8 @@ label_24BB6::
     nop
     inc  bc
     add  a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     jr   nz, label_24BEC
     ld   hl, label_114E
     dec  a
@@ -2729,7 +2750,8 @@ label_24BEC::
     nop
     inc  bc
     add  a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     jr   nz, label_24C52
     ld   hl, label_114E
     dec  a
@@ -2860,7 +2882,8 @@ label_24C52::
     jp   nz, label_E509
 
 label_24CD2::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2E
     ld   de, label_122F
     inc  a
     dec  d
@@ -3025,7 +3048,8 @@ label_24D65::
     ld   h, b
     ld   a, h
     ld   [$843F], sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     ld   de, label_1409
     jr   c, label_24D65
     dec  d
@@ -3148,7 +3172,8 @@ label_24DF5::
     add  hl, bc
     scf
     add  a, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $2F
     ld   [de], a
     ld   c, b
     inc  d
@@ -3187,7 +3212,8 @@ label_24E39::
     nop
     db   $3A ; ldd  a, [hl]
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     add  a, $21
     inc  b
 
@@ -3232,7 +3258,8 @@ label_24E91::
     nop
     db   $3A ; ldd  a, [hl]
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     jr   nz, label_24EEE
     add  a, d
     ld   hl, label_2730
@@ -3264,7 +3291,8 @@ label_24E91::
     nop
     db   $3A ; ldd  a, [hl]
     add  a, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     ld   b, $3F
     ld   d, $3B
     inc  de
@@ -3413,7 +3441,8 @@ label_24F4E::
     nop
     db   $3A ; ldd  a, [hl]
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     jp   nz, label_E005
     cp   $0B
     inc  b
@@ -3456,7 +3485,8 @@ label_24F98::
     ld   [rSC], a
     ccf
     add  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     ld   [de], a
     dec  sp
     ld   [hl], $3C
@@ -3573,7 +3603,8 @@ label_2501A::
     nop
     db   $3A ; ldd  a, [hl]
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     add  a, [hl]
     inc  h
     db   $3A ; ldd  a, [hl]
@@ -3628,7 +3659,8 @@ label_25036::
     nop
     db   $3A ; ldd  a, [hl]
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     adc  a, d
     jr   nz, label_250A1
     jp   nz, label_3F01
@@ -3681,7 +3713,8 @@ label_25070::
     nop
     db   $3A ; ldd  a, [hl]
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     adc  a, d
     jr   nz, label_250DF
     jp   nz, label_3F01
@@ -3772,7 +3805,8 @@ label_250DF::
     nop
     db   $3A ; ldd  a, [hl]
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     jp   nz, label_3F01
 
 label_25104::
@@ -3822,7 +3856,8 @@ label_25125::
     nop
     db   $3A ; ldd  a, [hl]
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     adc  a, d
     jr   nz, label_2514E
     adc  a, d
@@ -3876,7 +3911,8 @@ label_25174::
     nop
     db   $3A ; ldd  a, [hl]
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     adc  a, d
     jr   nz, label_2518B
     adc  a, d
@@ -3923,7 +3959,8 @@ label_251AC::
     ld   [label_93F], sp
     dec  l
     adc  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     rst  0
     jr   label_251C5
     rst  0
@@ -3958,7 +3995,8 @@ label_251CB::
     rra
     rst  $20
     ld   c, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FE
     inc  bc
     inc  b
     jp   nz, label_E00
@@ -4003,7 +4041,8 @@ label_25213::
     ld   [hl], $0A
     ld   d, $FD
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $A8
     ld   d, b
     ld   a, h
 
@@ -4050,7 +4089,8 @@ label_25231::
     ld   b, [hl]
     pop  hl
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $9B
     ld   d, b
     ld   a, h
     cp   $03
@@ -4059,7 +4099,8 @@ label_25231::
     ldd  [hl], a
     dec  d
     inc  sp
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $34
     add  hl, de
 
 label_25264::
@@ -4088,7 +4129,8 @@ label_25264::
     ld   d, h
     dec  d
     ld   d, l
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $56
     add  hl, de
     ld   h, a
     dec  de
@@ -4173,7 +4215,8 @@ label_252E1::
     nop
     dec  de
     add  a, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $1B
     add  a, h
     jr   nz, label_25309
     add  a, e
@@ -4201,7 +4244,8 @@ label_252FF::
     add  a, d
     rst  $30
     push af
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $51
     jp   nz, label_25112
     dec  d
     jr   nc, label_25329
@@ -4209,7 +4253,8 @@ label_252FF::
     inc  h
     ld   a, [de]
     dec  h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $26
     ld   d, $27
     push af
     ld   sp, label_3351
@@ -4399,7 +4444,8 @@ label_253E8::
     inc  c
     jp   nz, label_26222
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $B5
     ld   d, b
     ld   a, h
     cp   $0B
@@ -4485,7 +4531,8 @@ label_25442::
     nop
     db   $3A ; ldd  a, [hl]
     add  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
 
 label_25456::
     jp   nz, label_E001
@@ -4554,7 +4601,8 @@ label_25456::
     ld   sp, $008A
     ld   a, [bc]
     add  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0A
     add  a, e
     inc  d
     ld   a, [bc]
@@ -4635,7 +4683,8 @@ label_254FF::
     ld   [label_937], sp
     db   $E8 ; add  sp, d
     adc  a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $0A
     jr   label_25541
     add  hl, de
     cpl
@@ -4850,7 +4899,8 @@ label_255CA::
     ld   a, c
     ccf
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $B0
     ld   d, b
     ld   a, h
     ld   bc, label_2B6
@@ -4923,7 +4973,8 @@ label_25639::
     rst  $38
     push af
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $84
     ld   d, $89
     rla
     adc  a, b
@@ -4994,7 +5045,8 @@ label_256BC::
     adc  a, d
 
 label_256C7::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $84
     ld   de, label_2189
     add  a, [hl]
     ld   sp, label_328D
@@ -5092,7 +5144,8 @@ label_25720::
     rst  $38
     push af
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $84
     jr   z, label_256C7
     ld   b, b
     add  a, l
@@ -5331,7 +5384,8 @@ label_2583B::
     rst  $38
     push af
     call nz, label_F508
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $FB
     dec  h
     ei
     ccf
@@ -5384,7 +5438,8 @@ label_25863::
     inc  b
     rst  $38
     push af
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3D
     ld   de, label_122F
     ld   c, [hl]
     ld   [bc], a
@@ -5444,7 +5499,8 @@ label_2588C::
     nop
     sbc  a, c
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $96
     adc  a, d
     jr   nz, label_25863
     add  a, d
@@ -5478,7 +5534,8 @@ label_258D4::
     rlca
     push af
     add  a, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $96
     jp   label_9A16
     add  a, [hl]
     jr   nz, label_2588C
@@ -5551,7 +5608,8 @@ label_25922::
 
 label_25941::
     pop  hl
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CC
     ld   d, b
     ld   a, h
     ret  z
@@ -5689,7 +5747,8 @@ label_259E7::
 
 label_259EE::
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     jr   nz, label_259EE
     call nz, label_ED24
     ld   b, l
@@ -5721,7 +5780,8 @@ label_25A0D::
     nop
     db   $3A ; ldd  a, [hl]
     adc  a, c
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $3A
     jp   nz, label_3F09
     add  a, $29
     jr   c, label_259A4
@@ -5840,7 +5900,8 @@ label_25A96::
     push bc
     ld   sp, hl
     push af
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $88
     ld   de, label_178C
     adc  a, l
     jr   label_25A35
@@ -6170,7 +6231,8 @@ label_25C36::
 
 label_25C41::
     add  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $09
 
 label_25C44::
     inc  de
@@ -6277,7 +6339,8 @@ label_25C8A::
     inc  c
     rlca
     sbc  a, e
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $F9
     pop  hl
     inc  d
     push de
@@ -6332,7 +6395,8 @@ label_25C8A::
 
 label_25CF0::
     sbc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $98
     jr   nz, label_25C8A
     call nz, label_D30
     ld   [hl], b
@@ -6574,7 +6638,8 @@ label_25DBD::
     db   $ED ; Undefined instruction
     nop
     adc  a, $C6
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EB
     add  a, d
     ld   sp, $82EB
     ld   b, $EB
@@ -6897,7 +6962,8 @@ label_25FA9::
     nop
     inc  b
     rst  0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $04
     add  a, [hl]
     rst  $38
     push af
@@ -6962,7 +7028,8 @@ label_25FEA::
     adc  a, b
 
 label_2601F::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $51
     add  a, d
 
 label_26022::
@@ -7053,7 +7120,8 @@ label_26032::
     adc  a, d
 
 label_2608D::
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $93
     inc  hl
     or   a
     daa
@@ -7105,7 +7173,8 @@ label_2608D::
     inc  b
     nop
     sub  a, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $93
     ld   bc, label_11B7
     and  d
     ld   hl, $C2B6
@@ -7230,7 +7299,8 @@ label_26137::
     dec  b
     or   b
     ld   a, b
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $48
     ei
     cp   $09
     xor  $25
@@ -7660,7 +7730,8 @@ label_26380::
     db   $3A ; ldd  a, [hl]
     jp   label_3706
     add  a, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $03
     add  a, [hl]
     jr   nz, label_263A7
     add  a, [hl]
@@ -7865,7 +7936,8 @@ label_26485::
     push af
     nop
     or   a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $CE
     cp   $03
     ld   c, $8A
     ld   h, b
@@ -7918,7 +7990,8 @@ label_26485::
     nop
     sub  a, [hl]
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $93
     adc  a, d
     jr   nz, label_264E0
     adc  a, d
@@ -7994,7 +8067,8 @@ label_2650E::
     nop
     sub  a, [hl]
     adc  a, d
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $93
     adc  a, d
     jr   nz, label_2652C
     adc  a, d
@@ -8068,7 +8142,8 @@ label_26556::
     nop
     sub  a, [hl]
     add  a, a
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $93
     add  a, [hl]
     ld   a, a
     push af
@@ -8178,7 +8253,8 @@ label_265D0::
     adc  a, d
     ld   [hl], b
     db   $3A ; ldd  a, [hl]
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $C8
     add  a, e
     ld   hl, $C3C8
     dec  b
@@ -8249,7 +8325,8 @@ label_26640::
     ret  z
     add  hl, bc
     jr   c, label_265D0
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $ED
     jr   nz, label_26618
     add  a, e
     jr   nc, label_26640
@@ -8301,7 +8378,8 @@ label_26675::
     ld   [hl], d
     jp   hl
     add  a, h
-    db   $10 ; Undefined instruction
+    db   $10
+    db   $EB
     add  a, d
     jr   nc, label_26675
     add  a, d

--- a/src/disassembled-banks/Bank9.asm
+++ b/src/disassembled-banks/Bank9.asm
@@ -147,7 +147,7 @@ label_2403C::
     ld   e, c
     sbc  a, b
     ld   e, c
-    jp   [hl]
+    jp   hl
     ld   e, c
     ld   c, $5A
     ccf
@@ -2608,7 +2608,7 @@ label_24B65::
     ccf
     add  a, e
     dec  [hl]
-    jp   [hl]
+    jp   hl
     jr   c, label_24BD7
     jp   nz, label_3A39
 
@@ -2619,7 +2619,7 @@ label_24B9C::
     dec  sp
     add  a, e
     ld   b, l
-    jp   [hl]
+    jp   hl
     ld   c, b
     add  hl, sp
     add  a, e
@@ -2667,7 +2667,7 @@ label_24BB6::
 label_24BD7::
     ld   sp, $C23F
     ldd  [hl], a
-    jp   [hl]
+    jp   hl
     inc  sp
     ld   a, $83
     inc  [hl]
@@ -2685,7 +2685,7 @@ label_24BD7::
 
 label_24BEC::
     ld   b, [hl]
-    jp   [hl]
+    jp   hl
     ld   b, a
     dec  sp
     add  a, a
@@ -2700,7 +2700,7 @@ label_24BEC::
     ld   c, b
     add  a, e
     ld   h, e
-    jp   [hl]
+    jp   hl
     ld   h, [hl]
     ld   c, c
     ld   h, a
@@ -2711,7 +2711,7 @@ label_24BEC::
     db   $3A ; ldd  a, [hl]
     add  a, e
     ld   [hl], e
-    jp   [hl]
+    jp   hl
     db   $76 ; Halt
     db   $3A ; ldd  a, [hl]
     ld   [hl], a
@@ -3650,10 +3650,10 @@ label_25070::
     ld   d, h
     add  a, e
     inc  bc
-    jp   [hl]
+    jp   hl
     add  a, e
     inc  de
-    jp   [hl]
+    jp   hl
     add  a, l
     ldi  [hl], a
     ld   c, $70
@@ -3764,7 +3764,7 @@ label_250DF::
     ld   h, $C6
     pop  hl
     rra
-    jp   [hl]
+    jp   hl
     jr   z, label_25118
     cp   $0B
     inc  b
@@ -4698,10 +4698,10 @@ label_25545::
     ld   h, a
     ld   c, $83
     ld   h, d
-    jp   [hl]
+    jp   hl
     add  a, e
     ld   [hl], d
-    jp   [hl]
+    jp   hl
     ld   h, l
     ld   c, c
     ld   h, [hl]
@@ -4760,10 +4760,10 @@ label_25575::
     db   $3A ; ldd  a, [hl]
     add  a, d
     ld   h, e
-    jp   [hl]
+    jp   hl
     add  a, d
     ld   [hl], e
-    jp   [hl]
+    jp   hl
     ld   h, l
     ld   c, c
     add  a, h
@@ -5566,10 +5566,10 @@ label_25941::
 label_25951::
     ld   de, $833B
     ld   [bc], a
-    jp   [hl]
+    jp   hl
     add  a, e
     ld   [de], a
-    jp   [hl]
+    jp   hl
     jp   nz, label_3A05
     jp   nz, label_3E06
     ld   h, $39
@@ -5594,16 +5594,16 @@ label_25951::
     ret  z
     add  a, d
     ld   h, c
-    jp   [hl]
+    jp   hl
     add  a, d
     ld   [hl], c
-    jp   [hl]
+    jp   hl
     add  a, d
     ld   h, a
-    jp   [hl]
+    jp   hl
     add  a, d
     ld   [hl], a
-    jp   [hl]
+    jp   hl
     ld   h, e
     dec  hl
     ld   l, c
@@ -5636,10 +5636,10 @@ label_25951::
     db   $3A ; ldd  a, [hl]
     add  a, d
     inc  bc
-    jp   [hl]
+    jp   hl
     add  a, d
     inc  de
-    jp   [hl]
+    jp   hl
     ld   sp, label_32ED
     ret  z
     jp   nz, label_ED25
@@ -6423,7 +6423,7 @@ label_25D4E::
     add  a, d
     ld   bc, $82E9
     rlca
-    jp   [hl]
+    jp   hl
     add  hl, bc
     add  hl, sp
     push bc
@@ -8296,10 +8296,10 @@ label_26675::
     ccf
     add  a, e
     ld   h, d
-    jp   [hl]
+    jp   hl
     add  a, e
     ld   [hl], d
-    jp   [hl]
+    jp   hl
     add  a, h
     db   $10 ; Undefined instruction
     add  a, d

--- a/tools/Z80Dis.c
+++ b/tools/Z80Dis.c
@@ -1050,7 +1050,7 @@ DisassembleBank(u16 BankNum) {
                     fprintf(Output, "stop\n");
                 }
                 else {
-                    fprintf(Output, "db   $10 ; Undefined instruction\n");
+                    fprintf(Output, "db   $10\n    db   $%02X\n", N);
                 }
                 break;
             }


### PR DESCRIPTION
Slighly improve the built-in disassembler:

- Add a Makefile target to compile the disassembler
- Fix an issue with invalid stop instructions

It is still not able to produce valid code for bank2, for instance.

I'd prefer to attempt fixing enough of the poketools disassembler to make it work on this codebase (with the added bonus of being able to read symbol files)