### PR TITLE
Document wLinkMotionState

### DIFF
--- a/src/code/bank1.asm
+++ b/src/code/bank1.asm
@@ -337,7 +337,8 @@ label_41BB::
     ld   [rBGP], a
     ret
 
-
+LinkPassOut::
+    ; Actually code, not data
     db $f0, $9c, $c7, $03, $42, $91, $42, $9b
     db $42, $ca, $42, $d9, $42
 
@@ -717,7 +718,7 @@ label_4425::
 label_442B::
     call ClearLowerWRAM
     xor  a
-    ld   [$C11C], a
+    ld   [wLinkMotionState], a
     call IncrementGameplaySubtype
     ld   a, [$DB9D]
     ldh  [$FF98], a
@@ -854,10 +855,10 @@ label_4507::
     ld   [wLCDControl], a
     ld   [rLCDC], a
     call IncrementGameplaySubtype
-    ld   a, [$C11C]
+    ld   a, [wLinkMotionState]
     ld   [$D463], a
     ld   a, $04
-    ld   [$C11C], a
+    ld   [wLinkMotionState], a
     xor  a
     ld   [$C16B], a
     ld   [$C16C], a
@@ -3014,7 +3015,7 @@ label_531D::
     xor  a
     ld   [wGameplaySubtype], a
     xor  a
-    ld   [$C11C], a
+    ld   [wLinkMotionState], a
     ldh  [$FF9C], a
     ld   [wSubstractRupeeBufferLow], a
     ld   [$DB94], a
@@ -5234,7 +5235,7 @@ label_61E9::
     inc  a
     ld   [$990A], a
     ret
-    ld   a, [$C11C]
+    ld   a, [wLinkMotionState]
     cp   $00
     jr   nz, label_6202
     ld   a, [wFreeMovementMode]

--- a/src/code/bank3.asm
+++ b/src/code/bank3.asm
@@ -5356,7 +5356,7 @@ data_EBDA::
     db 2, $A, $E, 6
 
 label_EBDE::
-    ld   a, [$C11C]
+    ld   a, [wLinkMotionState]
     cp   $02
     jr   nc, label_EC5A
     ldh  a, [$FFA2]
@@ -5454,7 +5454,7 @@ label_EC72::
     jr   nz, label_EC5A
 
 label_EC77::
-    ld   a, [$C11C]
+    ld   a, [wLinkMotionState]
     cp   $02
     jr   nc, label_EC5A
     push bc
@@ -6926,7 +6926,7 @@ label_F571::
     cp   $22
     jr   c, label_F570
     ld   a, $0A
-    ld   [$C11C], a
+    ld   [wLinkMotionState], a
     ld   hl, $C380
     add  hl, bc
     ld   a, [hl]
@@ -7590,7 +7590,7 @@ label_F9AC::
     jr   z, label_FA18
     cp   $C1
     jr   nz, label_F9CB
-    ld   a, [$C11C]
+    ld   a, [wLinkMotionState]
     cp   $06
     jr   nz, label_FA18
     ldh  a, [$FFAF]
@@ -8057,7 +8057,7 @@ label_FCAB::
     ldh  a, [$FFFE]
     and  a
     jr   z, label_FCFD
-    ld   a, [$C11C]
+    ld   a, [wLinkMotionState]
     cp   $05
     ret  z
     ld   a, [$DDD6]

--- a/src/constants/gameplay.asm
+++ b/src/constants/gameplay.asm
@@ -118,6 +118,19 @@ DIALOG_CLOSING_2           equ $0F
 DIALOG_BG_TILE_DARK        equ $7E
 DIALOG_BG_TILE_LIGHT       equ $7F
 
+; Values for wLinkMotionState
+LINK_MOTION_INTERACTIVE    equ $00
+LINK_MOTION_FALLING_UP     equ $01
+LINK_MOTION_JUMPING        equ $02
+LINK_MOTION_MAP_FADE_OUT   equ $03
+LINK_MOTION_MAP_FADE_IN    equ $04
+LINK_MOTION_REVOLVING_DOOR equ $05
+LINK_MOTION_FALLING_DOWN   equ $06
+LINK_MOTION_PASS_OUT       equ $07
+LINK_MOTION_RECOVER        equ $08
+LINK_MOTION_TELEPORT       equ $09
+LINK_MOTION_UNKNOWN        equ $0F
+
 ; Values for wTransitionSfx
 TRANSITION_SFX_NONE         equ $00 ; no transition
 TRANSITION_SFX_DREAM_SHRINE equ $01 ; wavy transition when sleeping in the Dream Shrine

--- a/src/constants/wram.asm
+++ b/src/constants/wram.asm
@@ -49,7 +49,11 @@ wC118: ds 1
 wC119: ds 1
 wC11A: ds 1
 wC11B: ds 1
-wC11C: ds 1
+
+; See LINK_MOTION_* constants for possible values.
+wLinkMotionState: ; C11C
+  ds 1
+
 wC11D: ds 1
 wC11E: ds 1
 wC11F: ds 1


### PR DESCRIPTION
Document the `wLinkMotionState` variable.

This variable holds the state of Link when it is moving, but not necessarily interactively. The associated state machine has also been documented.

```
LINK_MOTION_INTERACTIVE    equ $00
LINK_MOTION_FALLING_UP     equ $01
LINK_MOTION_JUMPING        equ $02
LINK_MOTION_MAP_FADE_OUT   equ $03
LINK_MOTION_MAP_FADE_IN    equ $04
LINK_MOTION_REVOLVING_DOOR equ $05
LINK_MOTION_FALLING_DOWN   equ $06
LINK_MOTION_PASS_OUT       equ $07
LINK_MOTION_RECOVER        equ $08
LINK_MOTION_TELEPORT       equ $09
LINK_MOTION_UNKNOWN        equ $0F
```